### PR TITLE
Fix ALB security group export and pass ALB object between stacks

### DIFF
--- a/bin/lakerunner-cloudformation.ts
+++ b/bin/lakerunner-cloudformation.ts
@@ -68,5 +68,6 @@ for (const svc of services) {
     apiKeysParam: common.apiKeysParam,
     queue: common.queue,
     vpcId: common.vpc.vpcId,
+    alb: common.alb,
   });
 }

--- a/lib/common-infra-stack.ts
+++ b/lib/common-infra-stack.ts
@@ -78,16 +78,32 @@ export class CommonInfraStack extends cdk.Stack {
       allowAllOutbound: true,
     });
 
-    albSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(3000), 'Allow HTTP from internet');
-    albSecurityGroup.addIngressRule(ec2.Peer.anyIpv4(), ec2.Port.tcp(7101), 'Allow HTTPS from internet');
+    albSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(3000),
+      'Allow HTTP from internet',
+    );
+    albSecurityGroup.addIngressRule(
+      ec2.Peer.anyIpv4(),
+      ec2.Port.tcp(7101),
+      'Allow HTTPS from internet',
+    );
 
-    this.taskSecurityGroup.addIngressRule(albSecurityGroup, ec2.Port.tcp(3000), 'Allow only ALB to grafana on port 3000');
-    this.taskSecurityGroup.addIngressRule(albSecurityGroup, ec2.Port.tcp(7101), 'Allow only ALB to query-api on port 7101');
+    this.taskSecurityGroup.addIngressRule(
+      albSecurityGroup,
+      ec2.Port.tcp(3000),
+      'Allow only ALB to grafana on port 3000',
+    );
+    this.taskSecurityGroup.addIngressRule(
+      albSecurityGroup,
+      ec2.Port.tcp(7101),
+      'Allow only ALB to query-api on port 7101',
+    );
 
     this.alb = new elbv2.ApplicationLoadBalancer(this, 'query-api-requests', {
       vpc: this.vpc,
       internetFacing: true,
-      securityGroup: this.taskSecurityGroup,
+      securityGroup: albSecurityGroup,
       vpcSubnets: { subnetType: ec2.SubnetType.PUBLIC },
     });
 
@@ -277,7 +293,7 @@ export class CommonInfraStack extends cdk.Stack {
 
     new cdk.CfnOutput(this, 'AlbSecurityGroupId', {
       exportName: 'CommonInfraAlbSG',
-      value: this.alb.connections.securityGroups![0].securityGroupId,
+      value: albSecurityGroup.securityGroupId,
     });
 
     new cdk.CfnOutput(this, 'TaskRoleArn', {

--- a/lib/fargate-service-stack.ts
+++ b/lib/fargate-service-stack.ts
@@ -10,7 +10,6 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as elbv2 from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 import * as efs from 'aws-cdk-lib/aws-efs';
 import { Fn } from 'aws-cdk-lib';
-import { ApplicationLoadBalancer } from 'aws-cdk-lib/aws-elasticloadbalancingv2';
 
 export interface FargateServiceStackProps extends cdk.StackProps {
   readonly cluster: ecs.Cluster;
@@ -22,6 +21,7 @@ export interface FargateServiceStackProps extends cdk.StackProps {
   readonly queue: sqs.IQueue;
   readonly taskSecurityGroup: ec2.ISecurityGroup;
   readonly vpcId: string;
+  readonly alb: elbv2.IApplicationLoadBalancer;
 }
 export class FargateServiceStack extends cdk.Stack {
   private readonly vpc: ec2.IVpc;
@@ -178,11 +178,7 @@ export class FargateServiceStack extends cdk.Stack {
       enableExecuteCommand: true,
     });
 
-    const alb = ApplicationLoadBalancer.fromApplicationLoadBalancerAttributes(this, 'ImportedAlb', {
-      loadBalancerArn: Fn.importValue('CommonInfraAlbArn'),
-      securityGroupId: Fn.importValue('CommonInfraAlbSG'),
-      vpc: this.vpc,
-    });
+    const alb = props.alb;
 
     if (props.service.ingress) {
       const { port, desc } = props.service.ingress;


### PR DESCRIPTION
## Summary
- use dedicated ALB security group and export its ID
- pass ALB construct to service stacks instead of importing its attributes

## Testing
- `npm test`
- `npx cdk synth CommonInfra`
- `npx cdk synth lakerunner-query-api`


------
https://chatgpt.com/codex/tasks/task_e_689c4646b5348321a71932588fa22751