### PR TITLE
Use VPC lookup for subnet configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ Fargate.
 When launching the stacks you will be prompted for a small set of parameters:
 
 * **VpcId** – the existing VPC ID to deploy into.
-* **PrivateSubnetIds** – comma separated list of private subnet IDs.
-* **PublicSubnetIds** – comma separated list of public subnet IDs.
-* **PrivateSubnetRouteTableIds** – comma separated route table IDs for the private subnets.
-* **PublicSubnetRouteTableIds** – comma separated route table IDs for the public subnets.
 * **DbSecretName** – optional name for the database secret (defaults to `lakerunner-pg-password`).
 
 The account and region are automatically detected when the CloudFormation stack is created. No CDK bootstrap or credentials are required just to synthesize the templates.


### PR DESCRIPTION
## Summary
- look up VPC details instead of passing subnet/route table parameters
- wire ALB and RDS to VPC public/private subnets and export subnet IDs
- document simplified stack parameters

## Testing
- `npm run build`
- `npm test`
- `npx cdk synth` *(fails: All arguments to Vpc.fromLookup() must be concrete (no Tokens))*

------
https://chatgpt.com/codex/tasks/task_e_689cf35123a083218820fa3aa67c1075