### PR TITLE
Add Lakerunner root stack template with conditional nested stacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,11 @@ help:	## Show this help
 install:	## Install dependencies in virtual environment
 	source $(VENV_DIR)/bin/activate && pip install -r requirements.txt
 
-build:		## Generate CloudFormation templates and validate
+build:		## Generate CloudFormation templates and validate (includes root stack)
 	source $(VENV_DIR)/bin/activate && ./build.sh
+
+build-root:	## Generate only the Lakerunner root template
+	source $(VENV_DIR)/bin/activate && python src/lakerunner_root.py > generated-templates/lakerunner-root.yaml && cfn-lint generated-templates/lakerunner-root.yaml
 
 test:		## Run unit tests (working tests only)
 	source $(VENV_DIR)/bin/activate && $(PYTEST) tests/test_common_infra.py tests/test_*_simple.py tests/test_demo_otel_collector.py tests/test_parameter_validation.py tests/test_condition_validation.py -v

--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,10 @@ echo "6. Generating Demo OTEL Collector..."
 python3 src/demo_otel_collector.py > generated-templates/lakerunner-demo-otel-collector.yaml
 cfn-lint generated-templates/lakerunner-demo-otel-collector.yaml
 
+echo "7. Generating Lakerunner Root Stack..."
+python3 src/lakerunner_root.py > generated-templates/lakerunner-root.yaml
+cfn-lint generated-templates/lakerunner-root.yaml
+
 echo -e "\nGenerated CloudFormation templates:"
 ls -la generated-templates/
 

--- a/generated-templates/lakerunner-root.yaml
+++ b/generated-templates/lakerunner-root.yaml
@@ -1,0 +1,169 @@
+{
+ "Conditions": {
+  "DeployCommon": {
+   "Fn::Equals": [
+    {
+     "Ref": "DeployCommon"
+    },
+    "Yes"
+   ]
+  },
+  "DeployGrafanaService": {
+   "Fn::Equals": [
+    {
+     "Ref": "DeployGrafanaService"
+    },
+    "Yes"
+   ]
+  },
+  "DeployMigration": {
+   "Fn::Equals": [
+    {
+     "Ref": "DeployMigration"
+    },
+    "Yes"
+   ]
+  },
+  "DeployOtelCollector": {
+   "Fn::Equals": [
+    {
+     "Ref": "DeployOtelCollector"
+    },
+    "Yes"
+   ]
+  },
+  "DeployServices": {
+   "Fn::Equals": [
+    {
+     "Ref": "DeployServices"
+    },
+    "Yes"
+   ]
+  },
+  "DeployVpc": {
+   "Fn::Equals": [
+    {
+     "Ref": "DeployVpc"
+    },
+    "Yes"
+   ]
+  }
+ },
+ "Description": "Root stack that links all Lakerunner nested stacks. Set Deploy* parameters to control which components are launched.",
+ "Parameters": {
+  "DeployCommon": {
+   "AllowedValues": [
+    "Yes",
+    "No"
+   ],
+   "Default": "Yes",
+   "Description": "Deploy the Common Infrastructure stack",
+   "Type": "String"
+  },
+  "DeployGrafanaService": {
+   "AllowedValues": [
+    "Yes",
+    "No"
+   ],
+   "Default": "No",
+   "Description": "Deploy the Grafana Service stack",
+   "Type": "String"
+  },
+  "DeployMigration": {
+   "AllowedValues": [
+    "Yes",
+    "No"
+   ],
+   "Default": "No",
+   "Description": "Deploy the Migration stack",
+   "Type": "String"
+  },
+  "DeployOtelCollector": {
+   "AllowedValues": [
+    "Yes",
+    "No"
+   ],
+   "Default": "No",
+   "Description": "Deploy the demo OTEL Collector stack",
+   "Type": "String"
+  },
+  "DeployServices": {
+   "AllowedValues": [
+    "Yes",
+    "No"
+   ],
+   "Default": "Yes",
+   "Description": "Deploy the Services stack",
+   "Type": "String"
+  },
+  "DeployVpc": {
+   "AllowedValues": [
+    "Yes",
+    "No"
+   ],
+   "Default": "Yes",
+   "Description": "Deploy the VPC stack",
+   "Type": "String"
+  },
+  "TemplateBaseUrl": {
+   "Description": "Base URL where nested templates are stored",
+   "Type": "String"
+  }
+ },
+ "Resources": {
+  "CommonInfraStack": {
+   "Condition": "DeployCommon",
+   "Properties": {
+    "TemplateURL": {
+     "Fn::Sub": "${TemplateBaseUrl}/lakerunner-common.yaml"
+    }
+   },
+   "Type": "AWS::CloudFormation::Stack"
+  },
+  "GrafanaServiceStack": {
+   "Condition": "DeployGrafanaService",
+   "Properties": {
+    "TemplateURL": {
+     "Fn::Sub": "${TemplateBaseUrl}/lakerunner-grafana-service.yaml"
+    }
+   },
+   "Type": "AWS::CloudFormation::Stack"
+  },
+  "MigrationStack": {
+   "Condition": "DeployMigration",
+   "Properties": {
+    "TemplateURL": {
+     "Fn::Sub": "${TemplateBaseUrl}/lakerunner-migration.yaml"
+    }
+   },
+   "Type": "AWS::CloudFormation::Stack"
+  },
+  "OtelCollectorStack": {
+   "Condition": "DeployOtelCollector",
+   "Properties": {
+    "TemplateURL": {
+     "Fn::Sub": "${TemplateBaseUrl}/lakerunner-demo-otel-collector.yaml"
+    }
+   },
+   "Type": "AWS::CloudFormation::Stack"
+  },
+  "ServicesStack": {
+   "Condition": "DeployServices",
+   "Properties": {
+    "TemplateURL": {
+     "Fn::Sub": "${TemplateBaseUrl}/lakerunner-services.yaml"
+    }
+   },
+   "Type": "AWS::CloudFormation::Stack"
+  },
+  "VpcStack": {
+   "Condition": "DeployVpc",
+   "Properties": {
+    "TemplateURL": {
+     "Fn::Sub": "${TemplateBaseUrl}/lakerunner-vpc.yaml"
+    }
+   },
+   "Type": "AWS::CloudFormation::Stack"
+  }
+ }
+}

--- a/src/lakerunner_root.py
+++ b/src/lakerunner_root.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Lakerunner root CloudFormation template.
+
+This template orchestrates the deployment of Lakerunner by creating nested
+stacks for each major component. Individual stacks are only deployed when the
+corresponding Deploy* parameter is set to "Yes".
+"""
+
+from troposphere import Template, Parameter, Ref, Equals, Sub
+from troposphere.cloudformation import Stack
+
+
+# Initialize template
+TEMPLATE_DESCRIPTION = (
+    "Root stack that links all Lakerunner nested stacks. Set Deploy* parameters "
+    "to control which components are launched."
+)
+
+t = Template()
+t.set_description(TEMPLATE_DESCRIPTION)
+
+
+# Base URL for nested templates
+base_url = t.add_parameter(
+    Parameter(
+        "TemplateBaseUrl",
+        Type="String",
+        Description="Base URL where nested templates are stored",
+    )
+)
+
+
+# Deploy parameters and conditions
+
+def deploy_param(name, description, default="Yes"):
+    param = t.add_parameter(
+        Parameter(
+            name,
+            Type="String",
+            Default=default,
+            AllowedValues=["Yes", "No"],
+            Description=description,
+        )
+    )
+    t.add_condition(name, Equals(Ref(param), "Yes"))
+    return name
+
+
+deploy_vpc = deploy_param("DeployVpc", "Deploy the VPC stack")
+deploy_common = deploy_param("DeployCommon", "Deploy the Common Infrastructure stack")
+deploy_migration = deploy_param("DeployMigration", "Deploy the Migration stack", default="No")
+deploy_services = deploy_param("DeployServices", "Deploy the Services stack")
+deploy_grafana = deploy_param("DeployGrafanaService", "Deploy the Grafana Service stack", default="No")
+deploy_otel = deploy_param("DeployOtelCollector", "Deploy the demo OTEL Collector stack", default="No")
+
+
+# Nested stacks
+stack_urls = {
+    "VpcStack": (deploy_vpc, "lakerunner-vpc.yaml"),
+    "CommonInfraStack": (deploy_common, "lakerunner-common.yaml"),
+    "MigrationStack": (deploy_migration, "lakerunner-migration.yaml"),
+    "ServicesStack": (deploy_services, "lakerunner-services.yaml"),
+    "GrafanaServiceStack": (deploy_grafana, "lakerunner-grafana-service.yaml"),
+    "OtelCollectorStack": (deploy_otel, "lakerunner-demo-otel-collector.yaml"),
+}
+
+for stack_name, (condition, filename) in stack_urls.items():
+    t.add_resource(
+        Stack(
+            stack_name,
+            Condition=condition,
+            TemplateURL=Sub(f"${{TemplateBaseUrl}}/{filename}"),
+        )
+    )
+
+
+if __name__ == "__main__":
+    print(t.to_json())
+


### PR DESCRIPTION
## Summary
- add `lakerunner_root.py` to generate a root CloudFormation template with conditional nested stacks
- support new template in build scripts and makefile, including standalone `build-root` target
- output generated `lakerunner-root.yaml` alongside existing templates

## Testing
- `cfn-lint generated-templates/lakerunner-root.yaml`
- `pytest tests/test_common_infra.py tests/test_*_simple.py tests/test_demo_otel_collector.py tests/test_parameter_validation.py tests/test_condition_validation.py -v`


------
https://chatgpt.com/codex/tasks/task_e_68c1d16331e8832193eefdc93d95ecab