### PR TITLE
release: drop latest tag, mark RCs as prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,11 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           echo "version=${REF_NAME}" >> "$GITHUB_OUTPUT"
+          if [[ "${REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build templates with version baked in
         env:
@@ -55,22 +60,21 @@ jobs:
           aws s3 sync generated-templates/ \
             "s3://${CARDINAL_BUCKET_NAME}/lakerunner/${VERSION}/" --delete
 
-      - name: Publish latest
-        env:
-          VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          aws s3 sync generated-templates/ \
-            "s3://${CARDINAL_BUCKET_NAME}/lakerunner/latest/" --delete
-
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
+          PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
           ROOT_URL="https://${CARDINAL_BUCKET_NAME}.s3.${CARDINAL_BUCKET_REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-lakerunner.yaml"
           VPC_URL="https://${CARDINAL_BUCKET_NAME}.s3.${CARDINAL_BUCKET_REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-vpc.yaml"
+          PRERELEASE_FLAG=()
+          if [[ "${PRERELEASE}" == "true" ]]; then
+            PRERELEASE_FLAG=(--prerelease)
+          fi
           gh release create "$VERSION" \
             --title "$VERSION" \
+            "${PRERELEASE_FLAG[@]}" \
             --notes "**Lakerunner root template:** $ROOT_URL
 
           **Optional VPC template:** $VPC_URL


### PR DESCRIPTION
## Summary

- Drop the `lakerunner/latest/` S3 publish; only explicit versioned paths are written.
- Detect prerelease tags (anything not matching `^v[0-9]+\.[0-9]+\.[0-9]+$`) and pass `--prerelease` to `gh release create`.

## Behavior

- `v1.2.3` → `s3://cardinal-cfn/lakerunner/v1.2.3/...`, stable GitHub release.
- `v1.2.3-rc4` → `s3://cardinal-cfn/lakerunner/v1.2.3-rc4/...`, GitHub release marked prerelease.

## Test plan

- [ ] Tag `vX.Y.Z-rc1` and confirm: only `lakerunner/vX.Y.Z-rc1/` written, GitHub release shows prerelease badge, no `latest/` objects updated.
- [ ] Tag `vX.Y.Z` and confirm: only `lakerunner/vX.Y.Z/` written, GitHub release is stable.