### PR TITLE
bump default images: lakerunner v1.19.0, maestro v1.8.4, otel v1.7.0

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,13 +33,13 @@ storage_profiles:
 # root-template concern, not a default here.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.18.1"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.7.16"
   otel:       "ghcr.io/cardinalhq/cardinalhq-otel-collector:v1.4.2"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
-  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.18.1"
+  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
 
 # ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,8 +34,8 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.7.16"
-  otel:       "ghcr.io/cardinalhq/cardinalhq-otel-collector:v1.4.2"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.8.4"
+  otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"


### PR DESCRIPTION
Bump default images to current latest stable versions, and migrate the otel collector default from ghcr.io to ECR Public (where releases now publish).

| Image | From | To |
|---|---|---|
| lakerunner | v1.18.1 | v1.19.0 |
| maestro | v1.7.16 | v1.8.4 |
| otel collector | ghcr.io/.../v1.4.2 | public.ecr.aws/.../v1.7.0 |

migration image stays pinned to lakerunner (now v1.19.0).

## Test plan
- [x] tests pass locally (256 passed)
- [ ] CI passes
- [ ] post-merge: tag v0.0.2 → release publish to s3://cardinal-cfn/lakerunner/v0.0.2/