### PR TITLE
add cert import: PEM in stack params, custom resource imports to ACM

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -24,7 +24,7 @@ python3 -m cardinal_cfn.cardinal_vpc > generated-templates/cardinal-vpc.yaml
 echo "Generating cardinal-lakerunner.yaml (root)..."
 python3 -m cardinal_cfn.root > generated-templates/cardinal-lakerunner.yaml
 
-for child in cluster database storage alb config migration \
+for child in cluster database storage alb config cert migration \
              services_query services_process services_control otel maestro; do
   out_name=$(echo "$child" | tr '_' '-')
   echo "Generating cardinal-lakerunner/${out_name}.yaml..."

--- a/src/cardinal_cfn/children/cert.py
+++ b/src/cardinal_cfn/children/cert.py
@@ -1,0 +1,172 @@
+"""cert.yaml nested stack: optional ACM cert importer custom resource.
+
+Lets the customer pass cert/private-key/chain PEMs directly into the stack
+parameters. A Lambda-backed custom resource imports them into ACM and the
+output ``EffectiveCertificateArn`` is wired into the ALB child. If the
+customer instead supplies an existing ``CertificateArn`` the Lambda is not
+deployed and the existing ARN is forwarded as-is.
+"""
+
+from troposphere import (
+    And,
+    Equals,
+    GetAtt,
+    If,
+    Not,
+    Output,
+    Parameter,
+    Ref,
+    Sub,
+    Template,
+)
+from troposphere.awslambda import Code, Function
+from troposphere.cloudformation import CustomResource
+from troposphere.iam import Policy, Role
+from troposphere.logs import LogGroup
+
+from cardinal_cfn.children import cert_lambda
+from cardinal_cfn.naming import cardinal_tags
+from cardinal_cfn.parameters import add_install_id_parameters
+from cardinal_cfn.policies import apply_policy
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal cert: optional ACM certificate import (custom-resource Lambda)."
+    )
+
+    add_install_id_parameters(t)
+
+    t.add_parameter(Parameter(
+        "CertificateArn",
+        Type="String",
+        Default="",
+        Description=(
+            "Existing ACM certificate ARN. If empty, the cert is imported "
+            "from CertificateBody + CertificatePrivateKey."
+        ),
+    ))
+    t.add_parameter(Parameter(
+        "CertificateBody",
+        Type="String",
+        Default="",
+        NoEcho=True,
+        Description="PEM-encoded certificate. Required when CertificateArn is empty.",
+    ))
+    t.add_parameter(Parameter(
+        "CertificatePrivateKey",
+        Type="String",
+        Default="",
+        NoEcho=True,
+        Description="PEM-encoded private key. Required when CertificateArn is empty.",
+    ))
+    t.add_parameter(Parameter(
+        "CertificateChain",
+        Type="String",
+        Default="",
+        NoEcho=True,
+        Description="Optional PEM-encoded chain of intermediate certificates.",
+    ))
+
+    t.add_condition(
+        "ImportCert",
+        And(Equals(Ref("CertificateArn"), ""),
+            Not(Equals(Ref("CertificateBody"), ""))),
+    )
+
+    log_group = t.add_resource(LogGroup(
+        "CertLambdaLogGroup",
+        Condition="ImportCert",
+        LogGroupName=Sub("/aws/lambda/cardinal-cert-${InstallIdLong}"),
+        RetentionInDays=14,
+    ))
+    apply_policy(log_group, "log-group")
+
+    lambda_role = t.add_resource(Role(
+        "CertLambdaRole",
+        Condition="ImportCert",
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "lambda.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }],
+        },
+        Policies=[Policy(
+            PolicyName="cert-lambda-policy",
+            PolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "logs:CreateLogGroup",
+                            "logs:CreateLogStream",
+                            "logs:PutLogEvents",
+                        ],
+                        "Resource": "*",
+                    },
+                    {
+                        # Create has no ARN to scope to; ACM requires ImportCertificate
+                        # on "*" for the initial import call.
+                        "Effect": "Allow",
+                        "Action": ["acm:ImportCertificate"],
+                        "Resource": "*",
+                    },
+                    {
+                        "Effect": "Allow",
+                        "Action": [
+                            "acm:DeleteCertificate",
+                            "acm:AddTagsToCertificate",
+                            "acm:RemoveTagsFromCertificate",
+                        ],
+                        "Resource": Sub(
+                            "arn:${AWS::Partition}:acm:${AWS::Region}:"
+                            "${AWS::AccountId}:certificate/*"
+                        ),
+                    },
+                ],
+            },
+        )],
+        Tags=cardinal_tags(component="cert", role="lambda-role"),
+    ))
+
+    cert_fn = t.add_resource(Function(
+        "CertLambda",
+        Condition="ImportCert",
+        FunctionName=Sub("cardinal-cert-${InstallIdLong}"),
+        Code=Code(ZipFile=cert_lambda.SOURCE),
+        Runtime="python3.11",
+        Handler="index.lambda_handler",
+        Role=GetAtt(lambda_role, "Arn"),
+        Timeout=900,
+        Tags=cardinal_tags(component="cert", role="lambda"),
+    ))
+
+    custom = t.add_resource(CustomResource(
+        "ImportedCertificate",
+        Condition="ImportCert",
+        ServiceToken=GetAtt(cert_fn, "Arn"),
+        InstallIdLong=Ref("InstallIdLong"),
+        CertificateBody=Ref("CertificateBody"),
+        CertificatePrivateKey=Ref("CertificatePrivateKey"),
+        CertificateChain=Ref("CertificateChain"),
+    ))
+
+    t.add_output(Output(
+        "EffectiveCertificateArn",
+        Description="ACM certificate ARN to use on the ALB HTTPS listener.",
+        Value=If(
+            "ImportCert",
+            GetAtt(custom, "CertificateArn"),
+            Ref("CertificateArn"),
+        ),
+    ))
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml())

--- a/src/cardinal_cfn/children/cert_lambda.py
+++ b/src/cardinal_cfn/children/cert_lambda.py
@@ -1,0 +1,153 @@
+"""Source code for the cert custom-resource Lambda.
+
+Embedded in cert.yaml as Code.ZipFile. Behavior contract:
+
+- Create: imports CertificateBody/PrivateKey/Chain into ACM, returns the new
+  cert ARN as PhysicalResourceId and as Data.CertificateArn.
+- Update: re-imports into the existing ARN if any of body/key/chain changed
+  (keeps the ARN stable so the ALB listener attachment does not flap).
+- Delete: deletes the ACM cert. Retries on ResourceInUseException — when the
+  root stack is being torn down, the ALB listener releases the cert
+  asynchronously; the retry loop covers that window.
+- The Lambda is only deployed when the parent template's ImportCert condition
+  is true; consumers that pass an existing CertificateArn never see this code.
+"""
+
+SOURCE = '''\
+import json
+import time
+import traceback
+import urllib.request
+
+import boto3
+from botocore.exceptions import ClientError
+
+
+acm = boto3.client("acm")
+
+MAX_REASON_LEN = 1000
+
+
+def _send(event, context, status, reason="", physical_id=None, data=None):
+    body = json.dumps({
+        "Status": status,
+        "Reason": (reason or f"see CloudWatch log {context.log_stream_name}")[:MAX_REASON_LEN],
+        "PhysicalResourceId": physical_id or event.get("PhysicalResourceId") or "cardinal-cert-unknown",
+        "StackId": event["StackId"],
+        "RequestId": event["RequestId"],
+        "LogicalResourceId": event["LogicalResourceId"],
+        "Data": data or {},
+    }).encode("utf-8")
+    req = urllib.request.Request(
+        url=event["ResponseURL"],
+        data=body,
+        method="PUT",
+        headers={"content-type": "", "content-length": str(len(body))},
+    )
+    urllib.request.urlopen(req).read()
+
+
+def _import_kwargs(props, existing_arn=None):
+    body = props.get("CertificateBody") or ""
+    key = props.get("CertificatePrivateKey") or ""
+    if not body or not key:
+        raise ValueError("CertificateBody and CertificatePrivateKey are required")
+    kwargs = {
+        "Certificate": body.encode("utf-8"),
+        "PrivateKey": key.encode("utf-8"),
+    }
+    chain = props.get("CertificateChain") or ""
+    if chain:
+        kwargs["CertificateChain"] = chain.encode("utf-8")
+    if existing_arn:
+        kwargs["CertificateArn"] = existing_arn
+    return kwargs
+
+
+def _do_import(props, existing_arn=None):
+    response = acm.import_certificate(**_import_kwargs(props, existing_arn))
+    arn = response["CertificateArn"]
+    install_id_long = props.get("InstallIdLong") or ""
+    tags = [
+        {"Key": "Name", "Value": f"cardinal-cert-{install_id_long}" if install_id_long else "cardinal-cert"},
+        {"Key": "cardinal:component", "Value": "cert"},
+    ]
+    if install_id_long:
+        tags.append({"Key": "cardinal:install-id-long", "Value": install_id_long})
+    try:
+        acm.add_tags_to_certificate(CertificateArn=arn, Tags=tags)
+    except ClientError as exc:
+        # Tagging is best-effort; the cert is still usable without tags.
+        print(f"add_tags_to_certificate failed: {exc!r}", flush=True)
+    return arn
+
+
+def _delete_with_retry(arn, deadline):
+    last_exc = None
+    while time.time() < deadline:
+        try:
+            acm.delete_certificate(CertificateArn=arn)
+            return
+        except ClientError as exc:
+            code = exc.response.get("Error", {}).get("Code", "")
+            if code == "ResourceNotFoundException":
+                return
+            if code == "ResourceInUseException":
+                last_exc = exc
+                time.sleep(15)
+                continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+
+
+def _is_acm_arn(value):
+    return isinstance(value, str) and value.startswith("arn:") and ":acm:" in value
+
+
+def lambda_handler(event, context):
+    request_type = event["RequestType"]
+    props = event.get("ResourceProperties") or {}
+    old_props = event.get("OldResourceProperties") or {}
+    physical_id = event.get("PhysicalResourceId")
+    existing_arn = physical_id if _is_acm_arn(physical_id) else None
+
+    try:
+        if request_type == "Delete":
+            if existing_arn:
+                _delete_with_retry(existing_arn, time.time() + 14 * 60)
+            _send(event, context, "SUCCESS",
+                  physical_id=physical_id or "cardinal-cert-noop")
+            return
+
+        if request_type == "Create":
+            arn = _do_import(props)
+            _send(event, context, "SUCCESS", physical_id=arn,
+                  data={"CertificateArn": arn})
+            return
+
+        # Update
+        cert_changed = (
+            (props.get("CertificateBody") or "") != (old_props.get("CertificateBody") or "")
+            or (props.get("CertificatePrivateKey") or "") != (old_props.get("CertificatePrivateKey") or "")
+            or (props.get("CertificateChain") or "") != (old_props.get("CertificateChain") or "")
+        )
+        if existing_arn and cert_changed:
+            arn = _do_import(props, existing_arn=existing_arn)
+        elif existing_arn:
+            arn = existing_arn
+        else:
+            arn = _do_import(props)
+        _send(event, context, "SUCCESS", physical_id=arn,
+              data={"CertificateArn": arn})
+
+    except Exception as exc:
+        print(f"CERT IMPORT FAILED: {exc!r}", flush=True)
+        traceback.print_exc()
+        try:
+            _send(event, context, "FAILED", reason=str(exc),
+                  physical_id=physical_id or "cardinal-cert-failed")
+        except Exception as send_exc:
+            print(f"FAILED to notify CFN: {send_exc!r}", flush=True)
+            raise
+'''

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -167,7 +167,12 @@ def build() -> Template:
     t.add_parameter(Parameter(
         "CertificateArn",
         Type="String",
-        Description="ACM certificate ARN for the ALB HTTPS listener (required).",
+        Default="",
+        Description=(
+            "ACM certificate ARN for the ALB HTTPS listener. Leave empty to "
+            "import a cert from the CertificateBody / CertificatePrivateKey "
+            "parameters instead."
+        ),
     ))
 
     # ---------------------------------------------------------------------
@@ -178,6 +183,27 @@ def build() -> Template:
                           description="Optional YAML override for API keys.")
     add_no_echo_parameter(t, "StorageProfilesOverride",
                           description="Optional YAML override for storage profiles.")
+    add_no_echo_parameter(
+        t, "CertificateBody",
+        description=(
+            "PEM-encoded certificate. Required when CertificateArn is empty; "
+            "ignored otherwise."
+        ),
+    )
+    add_no_echo_parameter(
+        t, "CertificatePrivateKey",
+        description=(
+            "PEM-encoded private key. Required when CertificateArn is empty; "
+            "ignored otherwise."
+        ),
+    )
+    add_no_echo_parameter(
+        t, "CertificateChain",
+        description=(
+            "Optional PEM-encoded chain of intermediate certificates. Used "
+            "when CertificateArn is empty."
+        ),
+    )
     t.add_parameter(Parameter(
         "TemplateBaseUrl",
         Type="String",
@@ -254,7 +280,9 @@ def build() -> Template:
         groups=[
             {"label": "Networking",
              "parameters": ["VpcId", "PrivateSubnets", "PublicSubnets",
-                            "AlbScheme", "CertificateArn"]},
+                            "AlbScheme", "CertificateArn",
+                            "CertificateBody", "CertificatePrivateKey",
+                            "CertificateChain"]},
             {"label": "Sizing", "parameters": sizing_param_names},
             {"label": "Images", "parameters": image_param_names},
             {"label": "Advanced",
@@ -304,6 +332,15 @@ def build() -> Template:
         "StorageProfilesOverride": Ref("StorageProfilesOverride"),
     })
 
+    cert_stack = _add_child(t, "CertStack", "cert.yaml", {
+        "InstallIdShort": install_short,
+        "InstallIdLong": install_long,
+        "CertificateArn": Ref("CertificateArn"),
+        "CertificateBody": Ref("CertificateBody"),
+        "CertificatePrivateKey": Ref("CertificatePrivateKey"),
+        "CertificateChain": Ref("CertificateChain"),
+    })
+
     alb_stack = _add_child(t, "AlbStack", "alb.yaml", {
         "InstallIdShort": install_short,
         "InstallIdLong": install_long,
@@ -312,8 +349,8 @@ def build() -> Template:
         "PrivateSubnetsCsv": private_subnets_csv,
         "AlbScheme": Ref("AlbScheme"),
         "TaskSecurityGroupId": GetAtt(cluster_stack, "Outputs.TaskSecurityGroupId"),
-        "CertificateArn": Ref("CertificateArn"),
-    }, depends_on=["ClusterStack"])
+        "CertificateArn": GetAtt(cert_stack, "Outputs.EffectiveCertificateArn"),
+    }, depends_on=["ClusterStack", "CertStack"])
 
     migration_stack = _add_child(t, "MigrationStack", "migration.yaml", {
         "InstallIdShort": install_short,

--- a/tests/templates/test_cert.py
+++ b/tests/templates/test_cert.py
@@ -1,0 +1,91 @@
+"""Tests for the cert nested-stack template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn.children import cert
+
+
+@pytest.fixture
+def template_dict():
+    return json.loads(cert.build().to_json())
+
+
+def test_required_parameters(template_dict):
+    for n in ("InstallIdShort", "InstallIdLong",
+              "CertificateArn", "CertificateBody",
+              "CertificatePrivateKey", "CertificateChain"):
+        assert n in template_dict["Parameters"], f"missing parameter: {n}"
+
+
+def test_pem_parameters_are_no_echo(template_dict):
+    for n in ("CertificateBody", "CertificatePrivateKey", "CertificateChain"):
+        assert template_dict["Parameters"][n].get("NoEcho") is True, (
+            f"{n} must be NoEcho=true"
+        )
+
+
+def test_cert_arn_default_empty(template_dict):
+    assert template_dict["Parameters"]["CertificateArn"].get("Default") == ""
+
+
+def test_import_cert_condition(template_dict):
+    cond = template_dict["Conditions"]["ImportCert"]
+    # And(Equals(CertificateArn, ""), Not(Equals(CertificateBody, "")))
+    assert "Fn::And" in cond
+
+
+def test_lambda_resources_gated_on_import_cert(template_dict):
+    for logical in ("CertLambdaLogGroup", "CertLambdaRole",
+                    "CertLambda", "ImportedCertificate"):
+        res = template_dict["Resources"][logical]
+        assert res.get("Condition") == "ImportCert", (
+            f"{logical} must be conditioned on ImportCert"
+        )
+
+
+def test_lambda_role_grants_acm_import(template_dict):
+    role = template_dict["Resources"]["CertLambdaRole"]
+    statements = role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    actions = [a for s in statements for a in s["Action"]]
+    assert "acm:ImportCertificate" in actions
+    assert "acm:DeleteCertificate" in actions
+
+
+def test_lambda_role_acm_import_unrestricted(template_dict):
+    """ACM ImportCertificate has no ARN at create time, so policy must use '*' for it."""
+    role = template_dict["Resources"]["CertLambdaRole"]
+    statements = role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    import_stmts = [s for s in statements if "acm:ImportCertificate" in s["Action"]]
+    assert import_stmts, "no statement granting acm:ImportCertificate"
+    assert all(s["Resource"] == "*" for s in import_stmts), (
+        "acm:ImportCertificate must be granted on Resource: '*'"
+    )
+
+
+def test_custom_resource_passes_pem_props(template_dict):
+    cr = template_dict["Resources"]["ImportedCertificate"]
+    props = cr["Properties"]
+    for n in ("CertificateBody", "CertificatePrivateKey", "CertificateChain",
+              "InstallIdLong"):
+        assert n in props, f"custom resource missing prop {n}"
+
+
+def test_effective_arn_output_is_conditional(template_dict):
+    out = template_dict["Outputs"]["EffectiveCertificateArn"]
+    value = out["Value"]
+    assert "Fn::If" in value
+    branches = value["Fn::If"]
+    assert branches[0] == "ImportCert"
+    # Then-branch reads from custom resource; else-branch passes through.
+    assert "Fn::GetAtt" in branches[1]
+    assert branches[1]["Fn::GetAtt"] == ["ImportedCertificate", "CertificateArn"]
+    assert branches[2] == {"Ref": "CertificateArn"}
+
+
+def test_lambda_runtime_pinned(template_dict):
+    fn = template_dict["Resources"]["CertLambda"]
+    assert fn["Properties"]["Runtime"].startswith("python3."), (
+        "Lambda runtime must be a python3.x"
+    )

--- a/tests/templates/test_root.py
+++ b/tests/templates/test_root.py
@@ -52,9 +52,9 @@ def test_storage_profiles_override_no_echo(td):
     assert td["Parameters"]["StorageProfilesOverride"]["NoEcho"] is True
 
 
-def test_eleven_nested_stacks(td):
+def test_nested_stack_count(td):
     nested = [r for r in td["Resources"].values() if r["Type"] == "AWS::CloudFormation::Stack"]
-    assert len(nested) == 11
+    assert len(nested) == 12
 
 
 def test_nested_stack_logical_ids(td):
@@ -66,6 +66,7 @@ def test_nested_stack_logical_ids(td):
         "StorageStack",
         "AlbStack",
         "ConfigStack",
+        "CertStack",
         "MigrationStack",
         "ServicesQueryStack",
         "ServicesProcessStack",

--- a/tests/templates/test_root_wiring.py
+++ b/tests/templates/test_root_wiring.py
@@ -6,7 +6,7 @@ import pytest
 
 from cardinal_cfn import root
 from cardinal_cfn.children import (
-    cluster, database, storage, alb, config, migration,
+    cluster, database, storage, alb, config, cert, migration,
     services_query, services_process, services_control, otel, maestro,
 )
 
@@ -17,6 +17,7 @@ CHILDREN = {
     "StorageStack": storage,
     "AlbStack": alb,
     "ConfigStack": config,
+    "CertStack": cert,
     "MigrationStack": migration,
     "ServicesQueryStack": services_query,
     "ServicesProcessStack": services_process,

--- a/tests/unit/test_cert_lambda.py
+++ b/tests/unit/test_cert_lambda.py
@@ -1,0 +1,223 @@
+"""Behavioral tests for the cert-import custom-resource Lambda."""
+
+import builtins
+import json
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from cardinal_cfn.children import cert_lambda
+
+
+SAMPLE_CERT = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+...AAA=\n-----END CERTIFICATE-----\n"
+SAMPLE_KEY = "-----BEGIN PRIVATE KEY-----\nMIIBOgIBAAJBA...AAA=\n-----END PRIVATE KEY-----\n"
+SAMPLE_ARN = "arn:aws:acm:us-east-1:111122223333:certificate/abc-123"
+
+
+class _ClientError(Exception):
+    """Stand-in for botocore.exceptions.ClientError used by the lambda."""
+
+    def __init__(self, code):
+        super().__init__(code)
+        self.response = {"Error": {"Code": code}}
+
+
+@pytest.fixture
+def lambda_module():
+    fake_boto3 = types.SimpleNamespace(
+        client=lambda name: mock.MagicMock(name=f"boto3.{name}")
+    )
+    fake_botocore_exceptions = types.ModuleType("botocore.exceptions")
+    fake_botocore_exceptions.ClientError = _ClientError
+    fake_botocore = types.ModuleType("botocore")
+    fake_botocore.exceptions = fake_botocore_exceptions
+
+    saved = {k: sys.modules.get(k) for k in ("boto3", "botocore", "botocore.exceptions")}
+    sys.modules["boto3"] = fake_boto3
+    sys.modules["botocore"] = fake_botocore
+    sys.modules["botocore.exceptions"] = fake_botocore_exceptions
+    try:
+        ns = {"__name__": "cert_lambda_under_test"}
+        compiled = compile(cert_lambda.SOURCE, "<cert_lambda>", "exec")
+        builtins.exec(compiled, ns)
+        ns["urllib"].request.urlopen = mock.MagicMock(
+            name="urlopen", return_value=mock.MagicMock(read=lambda: b"")
+        )
+        ns["time"].sleep = lambda *_a, **_kw: None
+        yield ns
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                sys.modules.pop(k, None)
+            else:
+                sys.modules[k] = v
+
+
+def _event(request_type, *, body=SAMPLE_CERT, key=SAMPLE_KEY, chain="",
+           install_id_long="abcdef012345", physical_id=None, old=None):
+    event = {
+        "RequestType": request_type,
+        "StackId": "arn:aws:cloudformation:us-east-1:1234567890:stack/test/abc",
+        "RequestId": "rid-1",
+        "LogicalResourceId": "ImportedCertificate",
+        "ResponseURL": "https://cfn.example.com/response",
+        "ResourceProperties": {
+            "InstallIdLong": install_id_long,
+            "CertificateBody": body,
+            "CertificatePrivateKey": key,
+            "CertificateChain": chain,
+        },
+    }
+    if physical_id is not None:
+        event["PhysicalResourceId"] = physical_id
+    if old is not None:
+        event["OldResourceProperties"] = old
+    return event
+
+
+def _context():
+    ctx = mock.MagicMock()
+    ctx.log_stream_name = "log-stream"
+    return ctx
+
+
+def _last_response_payload(lambda_module):
+    urlopen = lambda_module["urllib"].request.urlopen
+    request = urlopen.call_args.args[0]
+    return json.loads(request.data.decode("utf-8"))
+
+
+def test_create_imports_and_returns_arn(lambda_module):
+    acm = lambda_module["acm"]
+    acm.import_certificate.return_value = {"CertificateArn": SAMPLE_ARN}
+    lambda_module["lambda_handler"](_event("Create"), _context())
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+    assert body["PhysicalResourceId"] == SAMPLE_ARN
+    assert body["Data"]["CertificateArn"] == SAMPLE_ARN
+    kwargs = acm.import_certificate.call_args.kwargs
+    assert "CertificateArn" not in kwargs
+    assert kwargs["Certificate"] == SAMPLE_CERT.encode("utf-8")
+    assert kwargs["PrivateKey"] == SAMPLE_KEY.encode("utf-8")
+
+
+def test_create_with_chain_passes_chain(lambda_module):
+    acm = lambda_module["acm"]
+    acm.import_certificate.return_value = {"CertificateArn": SAMPLE_ARN}
+    chain = "-----BEGIN CERTIFICATE-----\nintermediate\n-----END CERTIFICATE-----\n"
+    lambda_module["lambda_handler"](_event("Create", chain=chain), _context())
+    kwargs = acm.import_certificate.call_args.kwargs
+    assert kwargs["CertificateChain"] == chain.encode("utf-8")
+
+
+def test_create_tags_certificate(lambda_module):
+    acm = lambda_module["acm"]
+    acm.import_certificate.return_value = {"CertificateArn": SAMPLE_ARN}
+    lambda_module["lambda_handler"](_event("Create", install_id_long="deadbeef0001"), _context())
+    acm.add_tags_to_certificate.assert_called_once()
+    tags = acm.add_tags_to_certificate.call_args.kwargs["Tags"]
+    keys = {t["Key"]: t["Value"] for t in tags}
+    assert keys["cardinal:component"] == "cert"
+    assert keys["cardinal:install-id-long"] == "deadbeef0001"
+    assert keys["Name"] == "cardinal-cert-deadbeef0001"
+
+
+def test_update_unchanged_skips_import(lambda_module):
+    acm = lambda_module["acm"]
+    old_props = {
+        "CertificateBody": SAMPLE_CERT,
+        "CertificatePrivateKey": SAMPLE_KEY,
+        "CertificateChain": "",
+    }
+    lambda_module["lambda_handler"](
+        _event("Update", physical_id=SAMPLE_ARN, old=old_props),
+        _context(),
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+    assert body["PhysicalResourceId"] == SAMPLE_ARN
+    assert not acm.import_certificate.called
+
+
+def test_update_changed_reimports_into_existing_arn(lambda_module):
+    acm = lambda_module["acm"]
+    acm.import_certificate.return_value = {"CertificateArn": SAMPLE_ARN}
+    old_props = {
+        "CertificateBody": "OLD CERT",
+        "CertificatePrivateKey": SAMPLE_KEY,
+        "CertificateChain": "",
+    }
+    lambda_module["lambda_handler"](
+        _event("Update", physical_id=SAMPLE_ARN, old=old_props),
+        _context(),
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+    assert body["PhysicalResourceId"] == SAMPLE_ARN
+    kwargs = acm.import_certificate.call_args.kwargs
+    assert kwargs["CertificateArn"] == SAMPLE_ARN
+
+
+def test_delete_removes_cert(lambda_module):
+    acm = lambda_module["acm"]
+    lambda_module["lambda_handler"](
+        _event("Delete", physical_id=SAMPLE_ARN), _context()
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+    acm.delete_certificate.assert_called_once_with(CertificateArn=SAMPLE_ARN)
+
+
+def test_delete_with_no_arn_is_noop(lambda_module):
+    acm = lambda_module["acm"]
+    lambda_module["lambda_handler"](
+        _event("Delete", physical_id="cardinal-cert-noop"), _context()
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+    assert not acm.delete_certificate.called
+
+
+def test_delete_retries_on_in_use(lambda_module):
+    acm = lambda_module["acm"]
+    acm.delete_certificate.side_effect = [
+        _ClientError("ResourceInUseException"),
+        _ClientError("ResourceInUseException"),
+        None,
+    ]
+    lambda_module["lambda_handler"](
+        _event("Delete", physical_id=SAMPLE_ARN), _context()
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+    assert acm.delete_certificate.call_count == 3
+
+
+def test_delete_swallows_already_gone(lambda_module):
+    acm = lambda_module["acm"]
+    acm.delete_certificate.side_effect = _ClientError("ResourceNotFoundException")
+    lambda_module["lambda_handler"](
+        _event("Delete", physical_id=SAMPLE_ARN), _context()
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "SUCCESS"
+
+
+def test_create_missing_pem_fails(lambda_module):
+    lambda_module["lambda_handler"](
+        _event("Create", body="", key=""), _context()
+    )
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "FAILED"
+    assert "required" in body["Reason"].lower()
+
+
+def test_create_failure_reports_failed_to_cfn(lambda_module):
+    acm = lambda_module["acm"]
+    acm.import_certificate.side_effect = RuntimeError("invalid PEM")
+    lambda_module["lambda_handler"](_event("Create"), _context())
+    body = _last_response_payload(lambda_module)
+    assert body["Status"] == "FAILED"
+    assert "invalid PEM" in body["Reason"]


### PR DESCRIPTION
Adds a customer-friendly path for the ALB HTTPS cert: paste cert/key PEM into stack parameters, the stack imports them into ACM via a custom-resource Lambda, ALB consumes the resulting ARN.

## What changed

- New child stack \`cert.yaml\` with a Lambda-backed custom resource that calls \`acm.ImportCertificate\`, gated on a new \`ImportCert\` condition (\`CertificateArn=='' && CertificateBody!=''\`).
- Root \`CertificateArn\` is now optional (default \`''\`).
- Three new \`NoEcho\` root params: \`CertificateBody\`, \`CertificatePrivateKey\`, \`CertificateChain\` (chain optional).
- Root wires \`alb.CertificateArn\` from \`cert.Outputs.EffectiveCertificateArn\` so existing-ARN and imported-ARN customers share the same downstream path.

## Lambda contract

- Create: imports, returns ARN as PhysicalResourceId and Data.CertificateArn.
- Update: re-imports into the **existing** ARN so the ALB listener attachment doesn't flap; skips the call when none of body/key/chain changed.
- Delete: deletes the cert; retries \`ResourceInUseException\` (covers the window between listener teardown and cert-deletion) and swallows \`ResourceNotFoundException\`.

## IAM scope

- \`acm:ImportCertificate\` granted on \`*\` because the Create call has no ARN to scope to.
- \`acm:DeleteCertificate\` / \`AddTags\` / \`RemoveTags\` scoped to \`arn:\${AWS::Partition}:acm:\${AWS::Region}:\${AWS::AccountId}:certificate/*\`.
- \`logs:*\` on \`*\` for the Lambda's own log group.

## Test plan

- [x] 281 tests pass locally
- [x] generated cert.yaml is cfn-lint clean
- [x] root passes the new params to cert child; alb consumes from cert output (root-wiring test catches mismatches)
- [ ] CI passes
- [ ] post-merge: tag v0.0.3 and verify publish

## Caveats documented in code

- The private key transits via CloudFormation parameter history (masked via \`NoEcho\`, encrypted at rest). Customers who need stricter key handling should still pre-import via \`aws acm import-certificate\` and pass \`CertificateArn\` directly — both flows are supported.
- ACM-imported certs don't auto-renew; rotation is on the customer.