### PR TITLE
config: SSM param names need leading slash

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -541,8 +541,8 @@ def _task_role_statements(*, log_group_refs: list, maestro_db_secret_ref) -> lis
             "Effect": "Allow",
             "Action": ["ssm:GetParameter", "ssm:GetParameters"],
             "Resource": [
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ApiKeysParamName}"),
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${StorageProfilesParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ApiKeysParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StorageProfilesParamName}"),
             ],
         },
         {

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -413,8 +413,8 @@ def _task_role_statements(log_group_ref) -> list:
             "Effect": "Allow",
             "Action": ["ssm:GetParameter", "ssm:GetParameters"],
             "Resource": [
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ApiKeysParamName}"),
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${StorageProfilesParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ApiKeysParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StorageProfilesParamName}"),
             ],
         },
         {

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -382,8 +382,8 @@ def _task_role_statements(log_group_ref) -> list:
             "Effect": "Allow",
             "Action": ["ssm:GetParameter", "ssm:GetParameters"],
             "Resource": [
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ApiKeysParamName}"),
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${StorageProfilesParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ApiKeysParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StorageProfilesParamName}"),
             ],
         },
         {

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -440,8 +440,8 @@ def _task_role_statements(log_group_ref) -> list:
             "Effect": "Allow",
             "Action": ["ssm:GetParameter", "ssm:GetParameters"],
             "Resource": [
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ApiKeysParamName}"),
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${StorageProfilesParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ApiKeysParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StorageProfilesParamName}"),
             ],
         },
         {

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -423,8 +423,8 @@ def _task_role_statements(log_group_ref) -> list:
             "Effect": "Allow",
             "Action": ["ssm:GetParameter", "ssm:GetParameters"],
             "Resource": [
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ApiKeysParamName}"),
-                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${StorageProfilesParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ApiKeysParamName}"),
+                Sub("arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StorageProfilesParamName}"),
             ],
         },
         {

--- a/src/cardinal_cfn/naming.py
+++ b/src/cardinal_cfn/naming.py
@@ -37,8 +37,13 @@ def name_tag(*, role: str):
 
 
 def ssm_param_name(*, key: str):
-    """Explicit SSM parameter name. AWS requires Name on SSM parameters."""
-    return Sub(f"cardinal/${{InstallIdLong}}/{key}")
+    """Explicit SSM parameter name. AWS requires Name on SSM parameters.
+
+    The leading slash is required: SSM rejects PutParameter with
+    "Parameter name must be a fully qualified name" when a name contains
+    slashes but does not start with one.
+    """
+    return Sub(f"/cardinal/${{InstallIdLong}}/{key}")
 
 
 def secret_name(*, purpose: str):

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -34,8 +34,9 @@ def test_name_tag_returns_just_the_name_dict():
 
 
 def test_ssm_param_name_uses_install_id_long():
+    """SSM rejects PutParameter on names that contain slashes without a leading slash."""
     rendered = _render(ssm_param_name(key="storage-profiles"))
-    assert rendered == {"Fn::Sub": "cardinal/${InstallIdLong}/storage-profiles"}
+    assert rendered == {"Fn::Sub": "/cardinal/${InstallIdLong}/storage-profiles"}
 
 
 def test_secret_name_uses_install_id_long():


### PR DESCRIPTION
The first lakerunner deploy failed at the ConfigStack level with:

> ValidationException: Parameter name must be a fully qualified name.

\`ssm_param_name\` was producing \`cardinal/\${InstallIdLong}/api-keys\` (no leading slash). SSM rejects PutParameter for names that contain slashes but don't start with one.

## Fix

- \`ssm_param_name\`: prepend \`/\` so names are \`/cardinal/<install-id>/<key>\`.
- IAM resource ARNs in services_*, maestro, otel: change \`parameter/\${ApiKeysParamName}\` → \`parameter\${ApiKeysParamName}\` so the rendered ARN stays canonical (\`parameter/cardinal/.../api-keys\`) instead of becoming \`parameter//cardinal/.../api-keys\` after the new leading-slash names propagate.
- naming unit test updated to assert the leading-slash form.

## Test plan
- [x] 281 tests pass
- [x] generated config.yaml shows \`Name: !Sub '/cardinal/...\`
- [x] generated services-*.yaml IAM ARNs render to single-slash \`parameter/cardinal/...\`
- [ ] CI passes
- [ ] post-merge: tag v0.0.4, redeploy lakerunner stack