### PR TITLE
cluster: ExecutionRole needs GetSecretValue for ECS task secrets

### DIFF
--- a/src/cardinal_cfn/children/cluster.py
+++ b/src/cardinal_cfn/children/cluster.py
@@ -6,10 +6,11 @@ from troposphere import (
     Ref,
     GetAtt,
     Output,
+    Sub,
 )
 from troposphere.ecs import Cluster as ECSCluster, ClusterSetting
 from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
-from troposphere.iam import Role
+from troposphere.iam import Policy, Role
 from troposphere.logs import LogGroup
 
 from cardinal_cfn.naming import cardinal_tags
@@ -82,6 +83,62 @@ def build() -> Template:
             },
             ManagedPolicyArns=[
                 "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+            ],
+            Policies=[
+                Policy(
+                    PolicyName="cardinal-execution-secrets",
+                    # ECS uses ExecutionRole to fetch values for the
+                    # `secrets` block at task launch (Secrets Manager + SSM).
+                    # AmazonECSTaskExecutionRolePolicy does not include either,
+                    # so we add tightly-scoped inline grants here. Patterns
+                    # cover the named cardinal/* secrets and the
+                    # logical-ID-derived auto-generated ones.
+                    PolicyDocument={
+                        "Version": "2012-10-17",
+                        "Statement": [
+                            {
+                                "Effect": "Allow",
+                                "Action": ["secretsmanager:GetSecretValue"],
+                                "Resource": [
+                                    Sub(
+                                        "arn:${AWS::Partition}:secretsmanager:"
+                                        "${AWS::Region}:${AWS::AccountId}:"
+                                        "secret:cardinal/${InstallIdLong}/*"
+                                    ),
+                                    Sub(
+                                        "arn:${AWS::Partition}:secretsmanager:"
+                                        "${AWS::Region}:${AWS::AccountId}:"
+                                        "secret:DbMasterSecret-*"
+                                    ),
+                                    Sub(
+                                        "arn:${AWS::Partition}:secretsmanager:"
+                                        "${AWS::Region}:${AWS::AccountId}:"
+                                        "secret:MaestroDbSecret-*"
+                                    ),
+                                    Sub(
+                                        "arn:${AWS::Partition}:secretsmanager:"
+                                        "${AWS::Region}:${AWS::AccountId}:"
+                                        "secret:InternalServiceKeysSecret-*"
+                                    ),
+                                ],
+                            },
+                            {
+                                "Effect": "Allow",
+                                "Action": [
+                                    "ssm:GetParameter",
+                                    "ssm:GetParameters",
+                                ],
+                                "Resource": [
+                                    Sub(
+                                        "arn:${AWS::Partition}:ssm:"
+                                        "${AWS::Region}:${AWS::AccountId}:"
+                                        "parameter/cardinal/${InstallIdLong}/*"
+                                    ),
+                                ],
+                            },
+                        ],
+                    },
+                )
             ],
             Tags=cardinal_tags(component="compute", role="exec-role"),
         )


### PR DESCRIPTION
The v0.0.4 deploy reached MigrationStack and failed at the ECS task launch with:

> AccessDeniedException: User: ...assumed-role/.../ExecutionRole-... is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:...:secret:DbMasterSecret-...

The ExecutionRole only had \`AmazonECSTaskExecutionRolePolicy\` (which covers ECR + Logs but NOT Secrets Manager / SSM). ECS needs ExecutionRole permissions to resolve the \`secrets:\` block of TaskDefinitions at task launch.

## Fix

Inline policy on ExecutionRole granting:
- \`secretsmanager:GetSecretValue\` on:
  - \`cardinal/\${InstallIdLong}/*\` — named cardinal secrets (license, admin-api-key)
  - \`DbMasterSecret-*\` — RDS master credential
  - \`MaestroDbSecret-*\` — maestro DB credential
  - \`InternalServiceKeysSecret-*\` — internal service keys
- \`ssm:GetParameter*\` on \`/cardinal/\${InstallIdLong}/*\` (for any future SSM \`secrets:\` references)

All scoped to \${AWS::AccountId} and \${AWS::Region}; no wildcards across accounts/regions.

## Test plan
- [x] 281 tests pass
- [ ] CI passes
- [ ] post-merge: tag v0.0.5, redeploy