### PR TITLE
otel: ship default config, use run-with-env-config wrapper

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -209,7 +209,10 @@ maestro:
 # ---------------------------------------------------------------------------
 otel:
   otel-gateway:
-    command: ["/app/bin/cardinalhq-otel-collector", "--config=/etc/otel/config.yaml"]
+    # The image's run-with-env-config wrapper writes the YAML from the
+    # CHQ_COLLECTOR_CONFIG_YAML env var (set by otel.py) to /tmp and runs
+    # the collector against it.
+    command: ["/app/bin/run-with-env-config"]
     cpu: 1024
     memory_mib: 2048
     replicas: 1

--- a/cardinal-otel-config.yaml
+++ b/cardinal-otel-config.yaml
@@ -1,0 +1,86 @@
+# Default cardinalhq-otel-collector configuration. The container's
+# run-with-env-config wrapper writes this YAML (passed via the
+# CHQ_COLLECTOR_CONFIG_YAML env var) to /tmp and runs the collector
+# against it. Customers can override the entire config via the root
+# OtelConfigYaml parameter.
+#
+# Pipeline shape: OTLP in (gRPC 4317 / HTTP 4318) -> memory_limiter +
+# batch -> awss3 exporter writing partitioned otlp_proto blobs into the
+# lakerunner ingest bucket. The lakerunner-pubsub-sqs service consumes
+# the resulting S3:ObjectCreated notifications and fans them out to the
+# process-{logs,metrics,traces} workers.
+#
+# Env-var contract (set by the otel child stack):
+#   LRDB_S3_BUCKET  - lakerunner ingest bucket
+#   LRDB_S3_REGION  - bucket region
+#   ORG             - organization UUID for the s3_prefix path
+#   COLLECTOR       - collector name (defaults to "lakerunner")
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    limit_mib: 1024
+    check_interval: 1s
+  batch:
+    timeout: 10s
+    send_batch_max_size: 2000
+    send_batch_size: 1000
+
+exporters:
+  awss3/logs:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    marshaler: otlp_proto
+
+  awss3/metrics:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    marshaler: otlp_proto
+
+  awss3/traces:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    marshaler: otlp_proto
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions:
+    - health_check
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/metrics]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/traces]

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -23,6 +23,7 @@ from troposphere import (
     GetAtt,
     Equals,
     If,
+    Not,
     Output,
     Parameter,
     Ref,
@@ -42,7 +43,7 @@ from troposphere.ecs import (
 )
 
 from cardinal_cfn.children import services_common
-from cardinal_cfn.defaults import load_defaults
+from cardinal_cfn.defaults import load_defaults, load_otel_default_config
 from cardinal_cfn.images import add_image_override
 from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import (
@@ -194,18 +195,18 @@ def build() -> Template:
             ),
         )
     )
-    # Surfaced as the OTEL_CONFIG_OVERRIDE container env var. The image's
-    # baked-in /etc/otel/config.yaml is the default; customers wanting a
-    # custom collector config can pass the YAML through this parameter.
+    # The cardinalhq-otel-collector image's run-with-env-config wrapper reads
+    # the collector YAML from CHQ_COLLECTOR_CONFIG_YAML at task start. We
+    # ship a sensible default (cardinal-otel-config.yaml) and pass it via
+    # If(HasOtelConfigOverride, Ref(OtelConfigYaml), default).
     t.add_parameter(
         Parameter(
             "OtelConfigYaml",
             Type="String",
             Default="",
             Description=(
-                "Optional inline OTEL collector config YAML. Surfaced to the "
-                "container as the OTEL_CONFIG_OVERRIDE env var; empty leaves "
-                "the image's baked-in config in place."
+                "Optional inline OTEL collector config YAML. Empty uses the "
+                "default ingest-to-S3 pipeline shipped with this stack."
             ),
         )
     )
@@ -214,6 +215,9 @@ def build() -> Template:
     # Conditions
     # ---------------------------------------------------------------------
     t.add_condition("ExposeOtelOnAlb", Equals(Ref("OtelExposeOnAlb"), "Yes"))
+    t.add_condition(
+        "HasOtelConfigOverride", Not(Equals(Ref("OtelConfigYaml"), ""))
+    )
 
     # ---------------------------------------------------------------------
     # Console parameter grouping
@@ -271,9 +275,30 @@ def build() -> Template:
         )
     )
 
+    storage_profiles = defaults.get("storage_profiles") or []
+    default_org = (
+        storage_profiles[0].get("organization_id")
+        if storage_profiles else "default"
+    )
+    default_collector = (
+        otel_cfg.get("collector_name")
+        or (storage_profiles[0].get("collector_name") if storage_profiles else None)
+        or "lakerunner"
+    )
+
     env = [
-        Environment(Name="OTEL_CONFIG_OVERRIDE", Value=Ref("OtelConfigYaml")),
+        Environment(
+            Name="CHQ_COLLECTOR_CONFIG_YAML",
+            Value=If(
+                "HasOtelConfigOverride",
+                Ref("OtelConfigYaml"),
+                load_otel_default_config(),
+            ),
+        ),
         Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
+        Environment(Name="LRDB_S3_REGION", Value=Ref("AWS::Region")),
+        Environment(Name="ORG", Value=default_org),
+        Environment(Name="COLLECTOR", Value=default_collector),
         Environment(Name=_API_KEYS_ENV, Value=Ref("ApiKeysParamName")),
         Environment(Name=_STORAGE_PROFILES_ENV, Value=Ref("StorageProfilesParamName")),
     ] + _service_specific_env(otel_cfg)

--- a/src/cardinal_cfn/defaults.py
+++ b/src/cardinal_cfn/defaults.py
@@ -7,6 +7,7 @@ import yaml
 
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 _DEFAULTS_PATH = os.path.join(_REPO_ROOT, "cardinal-defaults.yaml")
+_OTEL_CONFIG_PATH = os.path.join(_REPO_ROOT, "cardinal-otel-config.yaml")
 
 
 def load_defaults() -> dict:
@@ -23,3 +24,15 @@ def load_defaults() -> dict:
             f"got {type(data).__name__}"
         )
     return data
+
+
+def load_otel_default_config() -> str:
+    """Return the cardinal-otel-config.yaml file as a YAML string.
+
+    The cardinalhq-otel-collector image uses a run-with-env-config wrapper
+    that reads the config from the CHQ_COLLECTOR_CONFIG_YAML env var. The
+    otel child stack passes this string in by default; customers can
+    override it via the OtelConfigYaml root parameter.
+    """
+    with open(_OTEL_CONFIG_PATH, "r") as f:
+        return f.read()

--- a/tests/templates/test_otel.py
+++ b/tests/templates/test_otel.py
@@ -136,13 +136,16 @@ def test_ecs_service_load_balancers_is_conditional(td):
 # ---------------------------------------------------------------------------
 
 
-def test_container_has_otel_config_override_env(td):
+def test_container_has_collector_config_env(td):
+    """run-with-env-config in the image reads YAML from CHQ_COLLECTOR_CONFIG_YAML."""
     task_def = next(
         r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
     )
     container = task_def["Properties"]["ContainerDefinitions"][0]
     env_names = {e["Name"] for e in container.get("Environment", [])}
-    assert "OTEL_CONFIG_OVERRIDE" in env_names
+    assert "CHQ_COLLECTOR_CONFIG_YAML" in env_names
+    for n in ("LRDB_S3_BUCKET", "LRDB_S3_REGION", "ORG", "COLLECTOR"):
+        assert n in env_names, f"missing env var {n}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The v1.7.0 (and earlier) cardinalhq-otel-collector image does NOT ship with a baked-in /etc/otel/config.yaml. The container was failing immediately with:

> Error: failed to get config: ... open /etc/otel/config.yaml: no such file or directory

The image does ship with a small wrapper script /app/bin/run-with-env-config that reads the collector YAML from the CHQ_COLLECTOR_CONFIG_YAML env var, writes it to /tmp, and execs the collector against it. That's the intended pattern for ECS / Cloud Run.

## Fix

- New file cardinal-otel-config.yaml: a minimal default config that does OTLP-in (gRPC 4317 / HTTP 4318) -> memory_limiter+batch -> awss3 exporter writing partitioned otlp_proto blobs into the lakerunner ingest bucket.
- defaults.py: load_otel_default_config() returns the file contents.
- cardinal-defaults.yaml: otel-gateway command is now /app/bin/run-with-env-config.
- otel.py: sets CHQ_COLLECTOR_CONFIG_YAML via If(HasOtelConfigOverride, OtelConfigYaml, default). Adds LRDB_S3_REGION, ORG, COLLECTOR env vars to satisfy the default config's \${env:...} substitutions.
- Test updated: env contract check now asserts CHQ_COLLECTOR_CONFIG_YAML + the awss3 exporter inputs.

## Test plan
- [x] 281 tests pass
- [ ] CI passes
- [ ] post-merge: tag v0.0.6, redeploy, watch for next failure mode