### PR TITLE
migration: pass LRDB_USER from DB master secret

### DIFF
--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -159,9 +159,13 @@ def build() -> Template:
                     ],
                     Secrets=[
                         Secret(
+                            Name="LRDB_USER",
+                            ValueFrom=Sub("${DbSecretArn}:username::"),
+                        ),
+                        Secret(
                             Name="LRDB_PASSWORD",
                             ValueFrom=Sub("${DbSecretArn}:password::"),
-                        )
+                        ),
                     ],
                     LogConfiguration=LogConfiguration(
                         LogDriver="awslogs",


### PR DESCRIPTION
The migration container was missing LRDB_USER, so the lakerunner binary fell back to its built-in default of \`nonroot\` and authentication failed:

> failed to connect to user=nonroot database=lakerunner: dial tcp 10.200.x.y:5432: connect: connection refused

Other tier templates (services_*.py, maestro.py) already do this — only migration.py was missing the secret. Adds:

\`\`\`python
Secret(Name=\"LRDB_USER\", ValueFrom=Sub(\"\${DbSecretArn}:username::\"))
\`\`\`

## Test plan
- [x] 281 tests pass
- [ ] CI passes
- [ ] post-merge: tag v0.0.7, redeploy