### PR TITLE
services: add PortMappings to LB-attached tasks; fix SG description chars

### DIFF
--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -320,6 +320,7 @@ def build() -> Template:
             environment=env,
             secrets=secrets,
             log_group_ref=log_group,
+            container_port=_OTLP_GRPC_PORT,
         )
     )
 

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -13,6 +13,7 @@ from troposphere.ecs import (
     LoadBalancer as EcsLoadBalancer,
     LogConfiguration,
     NetworkConfiguration,
+    PortMapping,
     Service,
     TaskDefinition,
 )
@@ -131,6 +132,7 @@ def build_task_definition(
     environment: list,
     secrets: list | None = None,
     log_group_ref,
+    container_port: int | None = None,
 ) -> TaskDefinition:
     """ECS Fargate task definition for a service.
 
@@ -138,6 +140,12 @@ def build_task_definition(
     (from CloudFormation parameters). Ints are coerced to strings; Refs and
     other troposphere objects pass through unchanged so they serialize as
     intrinsic functions.
+
+    container_port: if provided, the container exposes a tcp PortMapping at
+    that port. Required whenever the corresponding ECS Service references
+    the container in a LoadBalancer/TargetGroup attachment — without the
+    PortMapping CFN rejects the Service with "container ... did not have a
+    container port N defined."
     """
     container_kwargs = dict(
         Name=service_key,
@@ -157,6 +165,10 @@ def build_task_definition(
         container_kwargs["Command"] = command
     if secrets:
         container_kwargs["Secrets"] = secrets
+    if container_port is not None:
+        container_kwargs["PortMappings"] = [
+            PortMapping(ContainerPort=container_port, Protocol="tcp")
+        ]
 
     return TaskDefinition(
         _resource_title(service_key, "TaskDef"),

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -243,6 +243,7 @@ def build() -> Template:
             environment=admin_env,
             secrets=base_secrets,
             log_group_ref=admin_lg,
+            container_port=admin_container_port,
         )
     )
     admin_service = t.add_resource(

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -302,6 +302,7 @@ def build() -> Template:
             environment=api_env,
             secrets=base_secrets,
             log_group_ref=api_lg,
+            container_port=api_container_port,
         )
     )
     api_service = t.add_resource(
@@ -368,7 +369,7 @@ def build() -> Template:
             FromPort=worker_port,
             ToPort=worker_port,
             SourceSecurityGroupId=Ref("TaskSecurityGroupId"),
-            Description="query-api -> query-worker (task-to-task)",
+            Description="query-api to query-worker task-to-task",
         )
     )
 


### PR DESCRIPTION
## Summary

- ECS rejects Service create when a `LoadBalancer` attachment references a container port without a matching `PortMapping`. Extend `build_task_definition` with `container_port` and pass it for the LB-attached containers: `query-api`, `admin-api`, `otel-collector` (gRPC 4317).
- `QueryWorkerIngress` SG description used `>` which is outside the AWS-allowed character set; replace with plain text.

## Test plan
- [x] `pytest tests/` (281 passed)
- [x] `./build.sh` — generates clean templates, cfn-lint warnings only
- [x] Confirmed `PortMappings` rendered in `services-query.yaml`, `services-control.yaml`, `otel.yaml`
- [x] Confirmed `QueryWorkerIngress.Description` no longer contains `>`
- [ ] Tag v0.0.8 and redeploy the lakerunner stack