### PR TITLE
services: wire configdb env + create configdb in migration

### DIFF
--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -13,6 +13,7 @@ from troposphere.awslambda import Code, Function
 from troposphere.cloudformation import CustomResource
 from troposphere.ecs import (
     ContainerDefinition,
+    ContainerDependency,
     Environment,
     LogConfiguration,
     Secret,
@@ -56,6 +57,14 @@ def build() -> Template:
             Type="String",
             Default=defaults["images"]["migration"],
             Description="Container image for the DB migrator.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "DbInitImage",
+            Type="String",
+            Default=defaults["images"]["db_init"],
+            Description="Image used by the configdb-init container (must include psql).",
         )
     )
     t.add_parameter(
@@ -133,8 +142,84 @@ def build() -> Template:
     )
 
     # ---------------------------------------------------------------------------
-    # Migrator ECS task definition
+    # Migrator ECS task definition.
+    #
+    # Two containers:
+    #   1. configdb-init (non-essential): runs psql to CREATE DATABASE configdb
+    #      if it doesn't already exist. lakerunner migrate connects to existing
+    #      DBs only and never issues CREATE DATABASE itself.
+    #   2. migrator (essential): runs `lakerunner migrate --databases=lrdb,configdb`
+    #      against both DBs. Uses dependsOn=COMPLETE so it waits for the init
+    #      container to finish first.
     # ---------------------------------------------------------------------------
+    db_init_secrets = [
+        Secret(Name="LRDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+        Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+    ]
+
+    configdb_init_container = ContainerDefinition(
+        Name="configdb-init",
+        Image=Ref("DbInitImage"),
+        Essential=False,
+        EntryPoint=["sh", "-c"],
+        Command=[
+            (
+                "PGPASSWORD=$LRDB_PASSWORD psql -h $LRDB_HOST -p $LRDB_PORT "
+                "-U $LRDB_USER -d postgres -v ON_ERROR_STOP=1 "
+                "-tAc \"SELECT 1 FROM pg_database WHERE datname='configdb'\" "
+                "| grep -q 1 || "
+                "PGPASSWORD=$LRDB_PASSWORD psql -h $LRDB_HOST -p $LRDB_PORT "
+                "-U $LRDB_USER -d postgres -v ON_ERROR_STOP=1 "
+                "-c \"CREATE DATABASE configdb\""
+            )
+        ],
+        Environment=[
+            Environment(Name="LRDB_HOST", Value=Ref("DbEndpoint")),
+            Environment(Name="LRDB_PORT", Value=Ref("DbPort")),
+        ],
+        Secrets=db_init_secrets,
+        LogConfiguration=LogConfiguration(
+            LogDriver="awslogs",
+            Options={
+                "awslogs-group": Ref(migrator_lg),
+                "awslogs-region": Ref("AWS::Region"),
+                "awslogs-stream-prefix": "configdb-init",
+            },
+        ),
+    )
+
+    migrator_container = ContainerDefinition(
+        Name="migrator",
+        Image=Ref("MigrationImage"),
+        Command=["/app/bin/lakerunner", "migrate", "--databases=lrdb,configdb"],
+        Essential=True,
+        DependsOn=[ContainerDependency(ContainerName="configdb-init", Condition="COMPLETE")],
+        Environment=[
+            Environment(Name="LRDB_HOST", Value=Ref("DbEndpoint")),
+            Environment(Name="LRDB_PORT", Value=Ref("DbPort")),
+            Environment(Name="LRDB_DBNAME", Value=Ref("DbName")),
+            Environment(Name="LRDB_SSLMODE", Value="require"),
+            Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
+            Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
+            Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
+            Environment(Name="CONFIGDB_SSLMODE", Value="require"),
+        ],
+        Secrets=[
+            Secret(Name="LRDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+            Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+            Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+            Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+        ],
+        LogConfiguration=LogConfiguration(
+            LogDriver="awslogs",
+            Options={
+                "awslogs-group": Ref(migrator_lg),
+                "awslogs-region": Ref("AWS::Region"),
+                "awslogs-stream-prefix": "migrator",
+            },
+        ),
+    )
+
     task_def = t.add_resource(
         TaskDefinition(
             "MigratorTaskDef",
@@ -145,38 +230,7 @@ def build() -> Template:
             Memory="512",
             ExecutionRoleArn=Ref("ExecutionRoleArn"),
             TaskRoleArn=GetAtt(task_role, "Arn"),
-            ContainerDefinitions=[
-                ContainerDefinition(
-                    Name="migrator",
-                    Image=Ref("MigrationImage"),
-                    Command=["/app/bin/lakerunner", "migrate"],
-                    Essential=True,
-                    Environment=[
-                        Environment(Name="LRDB_HOST", Value=Ref("DbEndpoint")),
-                        Environment(Name="LRDB_PORT", Value=Ref("DbPort")),
-                        Environment(Name="LRDB_DBNAME", Value=Ref("DbName")),
-                        Environment(Name="LRDB_SSLMODE", Value="require"),
-                    ],
-                    Secrets=[
-                        Secret(
-                            Name="LRDB_USER",
-                            ValueFrom=Sub("${DbSecretArn}:username::"),
-                        ),
-                        Secret(
-                            Name="LRDB_PASSWORD",
-                            ValueFrom=Sub("${DbSecretArn}:password::"),
-                        ),
-                    ],
-                    LogConfiguration=LogConfiguration(
-                        LogDriver="awslogs",
-                        Options={
-                            "awslogs-group": Ref(migrator_lg),
-                            "awslogs-region": Ref("AWS::Region"),
-                            "awslogs-stream-prefix": "migrator",
-                        },
-                    ),
-                )
-            ],
+            ContainerDefinitions=[configdb_init_container, migrator_container],
             Tags=cardinal_tags(component="migration", role="migrator-task"),
         )
     )

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -193,6 +193,10 @@ def build() -> Template:
         Environment(Name="LRDB_SSLMODE", Value="require"),
         Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
         Environment(Name="LRDB_SQS_QUEUE_URL", Value=Ref("QueueUrl")),
+        Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
+        Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
+        Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
+        Environment(Name="CONFIGDB_SSLMODE", Value="require"),
         Environment(Name=_API_KEYS_ENV, Value=Ref("ApiKeysParamName")),
         Environment(Name=_STORAGE_PROFILES_ENV, Value=Ref("StorageProfilesParamName")),
     ]
@@ -200,6 +204,8 @@ def build() -> Template:
     base_secrets = [
         Secret(Name="LRDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+        Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+        Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
     ]

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -272,6 +272,10 @@ def build() -> Template:
         Environment(Name="LRDB_SSLMODE", Value="require"),
         Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
         Environment(Name="LRDB_SQS_QUEUE_URL", Value=Ref("QueueUrl")),
+        Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
+        Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
+        Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
+        Environment(Name="CONFIGDB_SSLMODE", Value="require"),
         Environment(Name=_API_KEYS_ENV, Value=Ref("ApiKeysParamName")),
         Environment(Name=_STORAGE_PROFILES_ENV, Value=Ref("StorageProfilesParamName")),
     ]
@@ -279,6 +283,8 @@ def build() -> Template:
     base_secrets = [
         Secret(Name="LRDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+        Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+        Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
     ]

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -251,6 +251,10 @@ def build() -> Template:
         Environment(Name="LRDB_SSLMODE", Value="require"),
         Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
         Environment(Name="LRDB_SQS_QUEUE_URL", Value=Ref("QueueUrl")),
+        Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
+        Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
+        Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
+        Environment(Name="CONFIGDB_SSLMODE", Value="require"),
         Environment(Name=_API_KEYS_ENV, Value=Ref("ApiKeysParamName")),
         Environment(Name=_STORAGE_PROFILES_ENV, Value=Ref("StorageProfilesParamName")),
     ]
@@ -258,6 +262,8 @@ def build() -> Template:
     base_secrets = [
         Secret(Name="LRDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+        Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+        Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
     ]

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -366,6 +366,7 @@ def build() -> Template:
         "DbSecretArn": GetAtt(database_stack, "Outputs.DbSecretArn"),
         "MigrationImage": Ref("MigrationImage"),
         "MigrationImageDigest": Ref("MigrationImageDigest"),
+        "DbInitImage": Ref("DbInitImage"),
     })
 
     migration_complete = GetAtt(migration_stack, "Outputs.MigrationCustomResourceRef")

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -56,10 +56,16 @@ def test_migrator_task_uses_ssl_required(template_dict):
     task_def = next(
         r for r in template_dict["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
     )
-    container = task_def["Properties"]["ContainerDefinitions"][0]
+    container = next(
+        c for c in task_def["Properties"]["ContainerDefinitions"]
+        if c["Name"] == "migrator"
+    )
     env = {e["Name"]: e["Value"] for e in container["Environment"]}
     assert env.get("LRDB_SSLMODE") == "require", (
         f"LRDB_SSLMODE must be 'require'; got {env.get('LRDB_SSLMODE')!r}"
+    )
+    assert env.get("CONFIGDB_SSLMODE") == "require", (
+        f"CONFIGDB_SSLMODE must be 'require'; got {env.get('CONFIGDB_SSLMODE')!r}"
     )
 
 


### PR DESCRIPTION
## Summary

lakerunner v1.19.0 introduced a separate ConfigDB. Without `CONFIGDB_HOST`/`CONFIGDB_DBNAME` (and friends) every lakerunner service crashes on boot with:

```
Error: ... database connection configuration is unavailable
failed to get CONFIGDB connection string: missing required environment variable(s): CONFIGDB_HOST, CONFIGDB_DBNAME
```

This was the cause of the v0.0.8 deploy failure (all process-*, query-worker, monitoring, sweeper, alert-evaluator hit the deployment circuit breaker).

### Changes

- `services-query`, `services-process`, `services-control`: add `CONFIGDB_HOST/PORT/DBNAME/SSLMODE` env vars + `CONFIGDB_USER/CONFIGDB_PASSWORD` secrets reusing the same RDS endpoint and master credentials, dbname=`configdb`.
- `migration`: split task definition into two containers:
  1. `configdb-init` (non-essential): runs `psql` to `CREATE DATABASE configdb` if it does not already exist (lakerunner migrate doesn't issue CREATE DATABASE itself).
  2. `migrator` (essential): runs `lakerunner migrate --databases=lrdb,configdb`. Uses `dependsOn=COMPLETE` so it waits for the init container to finish first.
- `migration`: declares new `DbInitImage` parameter (default = `cardinal-defaults.yaml.images.db_init`, the existing `initcontainer-grafana`).
- `root`: pass `DbInitImage` into `MigrationStack`.
- `tests/templates/test_migration.py`: select migrator container by name and assert both `LRDB_SSLMODE` and `CONFIGDB_SSLMODE`.

## Test plan
- [x] `pytest tests/` — 281 passed
- [x] `./build.sh` — clean cfn-lint
- [x] Verified rendered services-*.yaml include CONFIGDB_* env + secrets
- [x] Verified rendered migration.yaml has configdb-init + migrator with `--databases=lrdb,configdb`
- [ ] Tag v0.0.9 and redeploy lakerunner stack