### PR TITLE
service discovery + pubsub-sqs/alert-evaluator env fixes

### DIFF
--- a/src/cardinal_cfn/children/cluster.py
+++ b/src/cardinal_cfn/children/cluster.py
@@ -12,6 +12,7 @@ from troposphere.ecs import Cluster as ECSCluster, ClusterSetting
 from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
 from troposphere.iam import Policy, Role
 from troposphere.logs import LogGroup
+from troposphere.servicediscovery import PrivateDnsNamespace
 
 from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import add_install_id_parameters
@@ -152,11 +153,25 @@ def build() -> Template:
     )
     apply_policy(base_lg, "log-group")
 
+    # Cloud Map private DNS namespace for in-cluster service-to-service routing
+    # (e.g. alert-evaluator -> query-api). Services can register and resolve
+    # each other via DNS without going through the ALB.
+    sd_namespace = t.add_resource(
+        PrivateDnsNamespace(
+            "ServiceNamespace",
+            Name=Sub("cardinal-${InstallIdShort}.local"),
+            Vpc=Ref("VpcId"),
+            Description="Internal service-to-service DNS for the Cardinal cluster.",
+        )
+    )
+
     t.add_output(Output("ClusterArn", Value=GetAtt(cluster_res, "Arn")))
     t.add_output(Output("ClusterName", Value=Ref(cluster_res)))
     t.add_output(Output("TaskSecurityGroupId", Value=Ref(task_sg)))
     t.add_output(Output("ExecutionRoleArn", Value=GetAtt(exec_role, "Arn")))
     t.add_output(Output("BaseLogGroupName", Value=Ref(base_lg)))
+    t.add_output(Output("ServiceNamespaceId", Value=Ref(sd_namespace)))
+    t.add_output(Output("ServiceNamespaceName", Value=Sub("cardinal-${InstallIdShort}.local")))
 
     return t
 

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -15,6 +15,7 @@ from troposphere.ecs import (
     NetworkConfiguration,
     PortMapping,
     Service,
+    ServiceRegistry,
     TaskDefinition,
 )
 from troposphere.elasticloadbalancingv2 import (
@@ -201,8 +202,14 @@ def build_ecs_service(
     target_group_ref=None,
     container_name: str,
     container_port: int | None = None,
+    service_registry_ref=None,
 ) -> Service:
-    """ECS Fargate Service with rolling deploy + circuit breaker."""
+    """ECS Fargate Service with rolling deploy + circuit breaker.
+
+    service_registry_ref: optional Cloud Map ServiceDiscovery::Service to attach
+    so the ECS Service registers each task in private DNS for in-cluster
+    routing (e.g. alert-evaluator -> query-api).
+    """
     kwargs: dict = dict(
         Cluster=Ref(cluster_arn_param),
         LaunchType="FARGATE",
@@ -233,6 +240,11 @@ def build_ecs_service(
                 ContainerPort=container_port,
                 TargetGroupArn=Ref(target_group_ref),
             )
+        ]
+
+    if service_registry_ref is not None:
+        kwargs["ServiceRegistries"] = [
+            ServiceRegistry(RegistryArn=GetAtt(service_registry_ref, "Arn"))
         ]
 
     return Service(_resource_title(service_key, "Service"), **kwargs)

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -82,6 +82,13 @@ def build() -> Template:
     t.add_parameter(
         Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="VPC ID (forwarded from root).")
     )
+    t.add_parameter(
+        Parameter(
+            "ServiceNamespaceName",
+            Type="String",
+            Description="Cloud Map private DNS namespace name (e.g. cardinal-<id>.local).",
+        )
+    )
     t.add_parameter(Parameter("DbEndpoint", Type="String", Description="RDS endpoint hostname."))
     t.add_parameter(Parameter("DbPort", Type="String", Default="5432", Description="RDS port."))
     t.add_parameter(
@@ -270,21 +277,33 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     # Internal services (no ALB attachment)
     # ---------------------------------------------------------------------
+    # alert-evaluator reaches query-api over the in-cluster Cloud Map DNS.
+    # Container port is 8080 (matches lakerunner-query-api.ingress.container_port).
+    alert_extra_env = [
+        Environment(
+            Name="ALERT_EVALUATOR_QUERY_API_URL",
+            Value=Sub("http://query-api.${ServiceNamespaceName}:8080"),
+        ),
+    ]
+
     internal_services = [
         {
             "service_key": "sweeper",
             "config": sweeper_cfg,
             "output_name": "SweeperServiceName",
+            "extra_env": [],
         },
         {
             "service_key": "monitoring",
             "config": monitoring_cfg,
             "output_name": "MonitoringServiceName",
+            "extra_env": [],
         },
         {
             "service_key": "alert-evaluator",
             "config": alert_cfg,
             "output_name": "AlertEvaluatorServiceName",
+            "extra_env": alert_extra_env,
         },
     ]
 
@@ -296,6 +315,7 @@ def build() -> Template:
             image_ref=image_ref,
             base_env=base_env,
             base_secrets=base_secrets,
+            extra_env=spec["extra_env"],
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
 
@@ -310,6 +330,7 @@ def _build_internal_service_block(
     image_ref,
     base_env: list,
     base_secrets: list,
+    extra_env: list | None = None,
 ):
     """Wire up log group, task role, task def, and ECS service for one internal service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
@@ -319,7 +340,7 @@ def _build_internal_service_block(
             statements=_task_role_statements(log_group),
         )
     )
-    env = list(base_env) + _service_specific_env(config)
+    env = list(base_env) + _service_specific_env(config) + list(extra_env or [])
     task_def = t.add_resource(
         services_common.build_task_definition(
             service_key=service_key,

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -272,6 +272,8 @@ def build() -> Template:
         Environment(Name="LRDB_SSLMODE", Value="require"),
         Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
         Environment(Name="LRDB_SQS_QUEUE_URL", Value=Ref("QueueUrl")),
+        Environment(Name="LAKERUNNER_PUBSUB_SQS_QUEUE_URL", Value=Ref("QueueUrl")),
+        Environment(Name="LAKERUNNER_PUBSUB_SQS_REGION", Value=Ref("AWS::Region")),
         Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
         Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
         Environment(Name="CONFIGDB_DBNAME", Value="configdb"),

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -15,6 +15,11 @@ from troposphere import (
 )
 from troposphere.ec2 import SecurityGroupIngress
 from troposphere.ecs import Environment, Secret
+from troposphere.servicediscovery import (
+    DnsConfig,
+    DnsRecord,
+    Service as DiscoveryService,
+)
 
 from cardinal_cfn.children import services_common
 from cardinal_cfn.defaults import load_defaults
@@ -74,6 +79,13 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="VPC ID (forwarded from root).")
+    )
+    t.add_parameter(
+        Parameter(
+            "ServiceNamespaceId",
+            Type="String",
+            Description="Cloud Map private DNS namespace ID for in-cluster service discovery.",
+        )
     )
     t.add_parameter(Parameter("DbEndpoint", Type="String", Description="RDS endpoint hostname."))
     t.add_parameter(Parameter("DbPort", Type="String", Default="5432", Description="RDS port."))
@@ -311,6 +323,20 @@ def build() -> Template:
             container_port=api_container_port,
         )
     )
+    # Register query-api in Cloud Map so other services in the cluster can
+    # reach it at http://query-api.<namespace>:<port> without going through
+    # the ALB (alert-evaluator does this).
+    api_discovery = t.add_resource(
+        DiscoveryService(
+            "QueryApiDiscoveryService",
+            Name="query-api",
+            NamespaceId=Ref("ServiceNamespaceId"),
+            DnsConfig=DnsConfig(
+                DnsRecords=[DnsRecord(Type="A", TTL="10")],
+                RoutingPolicy="MULTIVALUE",
+            ),
+        )
+    )
     api_service = t.add_resource(
         services_common.build_ecs_service(
             service_key="query-api",
@@ -322,6 +348,7 @@ def build() -> Template:
             target_group_ref=api_tg,
             container_name="query-api",
             container_port=api_container_port,
+            service_registry_ref=api_discovery,
         )
     )
 

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -401,6 +401,7 @@ def build() -> Template:
     services_query_params.update({
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
         "VpcId": Ref("VpcId"),
+        "ServiceNamespaceId": GetAtt(cluster_stack, "Outputs.ServiceNamespaceId"),
         "QueryApiReplicas": Ref("QueryApiReplicas"),
         "QueryApiCpu": Ref("QueryApiCpu"),
         "QueryApiMemory": Ref("QueryApiMemory"),
@@ -428,6 +429,7 @@ def build() -> Template:
     services_control_params.update({
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
         "VpcId": Ref("VpcId"),
+        "ServiceNamespaceName": GetAtt(cluster_stack, "Outputs.ServiceNamespaceName"),
     })
     _add_child(t, "ServicesControlStack", "services-control.yaml",
                services_control_params, depends_on=["MigrationStack"])


### PR DESCRIPTION
## Summary

Three v0.0.9 deploy failures fixed:

- **pubsub-sqs** crash: lakerunner v1.19.0 renamed the SQS queue env var to `LAKERUNNER_PUBSUB_SQS_QUEUE_URL`. Add it (and `LAKERUNNER_PUBSUB_SQS_REGION`) alongside the legacy `LRDB_SQS_QUEUE_URL` on the process tier.
- **alert-evaluator** crash: requires `ALERT_EVALUATOR_QUERY_API_URL`. Add a Cloud Map private DNS namespace `cardinal-<id>.local` in `cluster.yaml`, register query-api as a Cloud Map service, and point alert-evaluator at `http://query-api.<namespace>:8080`. Plain HTTP avoids the self-signed-cert problem on the ALB.
- **services_common.build_ecs_service**: grows a `service_registry_ref` kwarg so services can opt in to Cloud Map registration.

## Test plan
- [x] `pytest tests/` (281 passed)
- [x] `./build.sh` clean (cfn-lint warnings only)
- [x] `services-query.yaml` includes `QueryApiDiscoveryService` and `ServiceRegistries` on `QueryApiService`
- [x] `services-control.yaml` sets `ALERT_EVALUATOR_QUERY_API_URL=http://query-api.${ServiceNamespaceName}:8080` only on alert-evaluator
- [x] `services-process.yaml` sets both `LRDB_SQS_QUEUE_URL` and `LAKERUNNER_PUBSUB_SQS_QUEUE_URL`
- [ ] Tag v0.0.10 and redeploy