### PR TITLE
maestro: add mcp-gateway container so DB migrations run

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -352,35 +352,85 @@ def build() -> Template:
         ),
     )
 
+    # mcp-gateway runs the maestro DB schema migrations on startup, then
+    # serves MCP. Maestro shares this DB and breaks if migrations haven't
+    # run yet (relation "maestro_*" does not exist).
+    db_env = [
+        Environment(Name="MAESTRO_DB_HOST", Value=Ref("DbEndpoint")),
+        Environment(Name="MAESTRO_DB_PORT", Value=Ref("DbPort")),
+        Environment(Name="MAESTRO_DB_NAME", Value="maestro"),
+        Environment(Name="MAESTRO_DB_USER", Value="maestro"),
+        Environment(Name="MAESTRO_DB_SSLMODE", Value="require"),
+    ]
+    db_secrets = [
+        Secret(
+            Name="MAESTRO_DB_PASSWORD",
+            ValueFrom=Sub("${MaestroDbSecret}:password::"),
+        ),
+    ]
+
+    mcp_gateway_container = ContainerDefinition(
+        Name="mcp-gateway",
+        Image=maestro_image_ref,
+        Essential=True,
+        EntryPoint=["/app/entrypoint.sh"],
+        Command=["mcp-gateway"],
+        PortMappings=[PortMapping(ContainerPort=mcp_gateway_port, Protocol="tcp")],
+        Environment=db_env + [
+            Environment(Name="MCP_PORT", Value=str(mcp_gateway_port)),
+        ],
+        Secrets=list(db_secrets),
+        DependsOn=[{"ContainerName": "db-init", "Condition": "SUCCESS"}],
+        LogConfiguration=LogConfiguration(
+            LogDriver="awslogs",
+            Options={
+                "awslogs-group": Ref(maestro_lg),
+                "awslogs-region": Ref("AWS::Region"),
+                "awslogs-stream-prefix": "mcp-gateway",
+            },
+        ),
+    )
+
+    # Sidecar that polls localhost:<mcp_port> until it accepts a connection,
+    # then exits. Maestro depends on this completing so it doesn't start
+    # before mcp-gateway has finished migrating.
+    wait_for_mcp_container = ContainerDefinition(
+        Name="wait-for-mcp",
+        Image=maestro_image_ref,
+        Essential=False,
+        EntryPoint=["/app/entrypoint.sh"],
+        Command=["wait-for-tcp", "localhost", str(mcp_gateway_port)],
+        DependsOn=[{"ContainerName": "mcp-gateway", "Condition": "START"}],
+        LogConfiguration=LogConfiguration(
+            LogDriver="awslogs",
+            Options={
+                "awslogs-group": Ref(maestro_lg),
+                "awslogs-region": Ref("AWS::Region"),
+                "awslogs-stream-prefix": "wait-for-mcp",
+            },
+        ),
+    )
+
     maestro_container = ContainerDefinition(
         Name="maestro",
         Image=maestro_image_ref,
         Essential=True,
-        PortMappings=[
-            PortMapping(ContainerPort=maestro_port, Protocol="tcp"),
-            PortMapping(ContainerPort=mcp_gateway_port, Protocol="tcp"),
-        ],
-        Environment=[
-            Environment(Name="MAESTRO_DB_HOST", Value=Ref("DbEndpoint")),
-            Environment(Name="MAESTRO_DB_PORT", Value=Ref("DbPort")),
-            Environment(Name="MAESTRO_DB_NAME", Value="maestro"),
-            Environment(Name="MAESTRO_DB_USER", Value="maestro"),
-            Environment(Name="MAESTRO_DB_SSLMODE", Value="require"),
+        PortMappings=[PortMapping(ContainerPort=maestro_port, Protocol="tcp")],
+        Environment=db_env + [
             Environment(
                 Name="DEX_ISSUER_URL",
                 Value=Sub("https://${AlbDnsName}/dex"),
             ),
             Environment(Name="DEX_CLIENT_ID", Value=Ref("DexClientId")),
         ],
-        Secrets=[
-            Secret(
-                Name="MAESTRO_DB_PASSWORD",
-                ValueFrom=Sub("${MaestroDbSecret}:password::"),
-            ),
+        Secrets=list(db_secrets) + [
             Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
             Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         ],
-        DependsOn=[{"ContainerName": "db-init", "Condition": "SUCCESS"}],
+        DependsOn=[
+            {"ContainerName": "db-init", "Condition": "SUCCESS"},
+            {"ContainerName": "wait-for-mcp", "Condition": "SUCCESS"},
+        ],
         LogConfiguration=LogConfiguration(
             LogDriver="awslogs",
             Options={
@@ -422,7 +472,13 @@ def build() -> Template:
             Memory=Ref("MaestroTaskMemory"),
             ExecutionRoleArn=Ref("ExecutionRoleArn"),
             TaskRoleArn=GetAtt(task_role, "Arn"),
-            ContainerDefinitions=[db_init_container, maestro_container, dex_container],
+            ContainerDefinitions=[
+                db_init_container,
+                mcp_gateway_container,
+                wait_for_mcp_container,
+                maestro_container,
+                dex_container,
+            ],
             Tags=cardinal_tags(component="compute", role=_SERVICE_KEY),
         )
     )

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -69,14 +69,13 @@ def test_creates_one_task_definition(td):
     assert len(task_defs) == 1
 
 
-def test_task_definition_has_three_containers(td):
+def test_task_definition_has_expected_containers(td):
     task_def = next(
         r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
     )
     containers = task_def["Properties"]["ContainerDefinitions"]
-    assert len(containers) == 3
     names = {c["Name"] for c in containers}
-    assert names == {"db-init", "maestro", "dex"}
+    assert names == {"db-init", "mcp-gateway", "wait-for-mcp", "maestro", "dex"}
 
 
 def test_db_init_is_not_essential(td):


### PR DESCRIPTION
## Summary

v0.0.11 deploy of MaestroService crashed: every background worker errored with `relation \"maestro_*\" does not exist`. The Node.js maestro process does not run migrations. Migrations are owned by the `mcp-gateway` Go binary on startup, which the chart deploys as a separate workload.

### Changes

- `maestro.py`: factor MAESTRO_DB_* env/secrets into shared lists, then add two containers to the maestro task:
  - **mcp-gateway** (essential): `/app/entrypoint.sh mcp-gateway`. Applies migrations on startup, then serves MCP on `mcp_gateway_port`. Owns that PortMapping (was incorrectly on the maestro container).
  - **wait-for-mcp** (non-essential): `/app/entrypoint.sh wait-for-tcp localhost <port>`. Polls until mcp-gateway accepts connections, then exits.
  - **maestro** now dependsOn `wait-for-mcp = SUCCESS` so it never starts before migrations complete.
- `tests/templates/test_maestro.py`: rename test, expect 5-container layout (db-init, mcp-gateway, wait-for-mcp, maestro, dex).

## Test plan
- [x] `pytest tests/` (281 pass)
- [x] Build clean
- [x] Rendered maestro.yaml has mcp-gateway with PortMapping 8080, wait-for-mcp with `Condition: START` on mcp-gateway, maestro with `Condition: SUCCESS` on wait-for-mcp.
- [ ] Tag v0.0.12 and redeploy