### PR TITLE
services: rename LRDB_LICENSE -> LICENSE_DATA

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -424,7 +424,7 @@ def build() -> Template:
             Environment(Name="DEX_CLIENT_ID", Value=Ref("DexClientId")),
         ],
         Secrets=list(db_secrets) + [
-            Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
+            Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
             Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         ],
         DependsOn=[

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -305,7 +305,7 @@ def build() -> Template:
 
     secrets = [
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
-        Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
+        Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 
     task_def = t.add_resource(

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -214,7 +214,7 @@ def build() -> Template:
         Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
-        Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
+        Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 
     # ---------------------------------------------------------------------

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -288,7 +288,7 @@ def build() -> Template:
         Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
-        Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
+        Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 
     # ---------------------------------------------------------------------

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -278,7 +278,7 @@ def build() -> Template:
         Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
-        Secret(Name="LRDB_LICENSE", ValueFrom=Ref("LicenseSecretArn")),
+        Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The lakerunner license loader (`internal/licensing/loader.go`) reads `LICENSE_DATA` from env (or the file at `/app/license/license.json`), not `LRDB_LICENSE`. Our previous wiring named the ECS Secret env var `LRDB_LICENSE`, so the binary never saw the license and every service logged:

```
License enforcement failed, continuing ... reading license file \"/app/license/license.json\": open /app/license/license.json: no such file or directory ... no_license_source=true
```

The license Secrets Manager secret already stores the raw `z64:...` payload as `SecretString` (not a JSON object), which is exactly the format `LICENSE_DATA` expects.

Renamed the env var across services-query, services-process, services-control, otel, and maestro. Mirrors `LICENSE_DATA` usage in the helm chart.

## Test plan
- [x] `pytest tests/` (281 pass)
- [x] Build clean
- [x] `LICENSE_DATA` renders as a Secret in all five child stacks
- [ ] Tag v0.0.14 and redeploy