### PR TITLE
bump maestro image to v1.8.6

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,7 +34,7 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.8.4"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.8.6"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
## Summary

- Bump default \`MaestroImage\` to \`public.ecr.aws/cardinalhq.io/maestro:v1.8.6\`. v1.8.6 includes the conductor migration that fixes the trial-SKU feature names (\`process.logs\`, \`process.metrics\`, \`process.traces\`, \`query.read\`, \`alerting\`) so trial licenses actually unblock lakerunner enforcement (cardinalhq/conductor#436).

## Test plan

- [x] pytest tests/ (281 passed)