### PR TITLE
maestro: serve as default app at / so SPA /assets/* routes resolve

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -10,7 +10,7 @@ The maestro container DependsOn db-init=SUCCESS, so the service won't come up
 until the database is provisioned. Both maestro and dex are attached to the
 shared cardinal HTTPS listener via two ListenerRules:
 
-  /maestro/*  -> maestro container, priority 200
+  /*          -> maestro container, priority 49999 (catch-all default app)
   /dex/*      -> dex container,     priority 210
 
 Scope cuts vs. the pre-refactor generator: no self-signed cert Lambda, no
@@ -516,7 +516,7 @@ def build() -> Template:
             service_key=_MAESTRO_LISTENER_KEY,
             target_group_ref=maestro_tg,
             listener_arn_param="HttpsListenerArn",
-            path_patterns=["/maestro/*"],
+            path_patterns=["/*"],
         )
     )
 
@@ -585,7 +585,7 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     # Outputs
     # ---------------------------------------------------------------------
-    t.add_output(Output("MaestroUrl", Value=Sub("https://${AlbDnsName}/maestro/")))
+    t.add_output(Output("MaestroUrl", Value=Sub("https://${AlbDnsName}/")))
     t.add_output(Output("DexUrl", Value=Sub("https://${AlbDnsName}/dex/")))
     t.add_output(Output("MaestroServiceName", Value=GetAtt(service, "Name")))
     t.add_output(Output("MaestroDbSecretArn", Value=Ref(maestro_db_secret)))

--- a/src/cardinal_cfn/listener_priorities.py
+++ b/src/cardinal_cfn/listener_priorities.py
@@ -11,9 +11,11 @@ future per-service stack splits collision-free.
 LISTENER_PRIORITIES: dict = {
     "query-api":     100,
     "admin-api":     110,
-    "maestro-https": 200,
     "maestro-dex":   210,
     "otel-grpc":     300,
+    # Maestro is the default app: a true catch-all "/*" rule. It MUST be
+    # numerically the highest (lowest priority) so all other rules win.
+    "maestro-https": 49999,
 }
 
 

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -143,7 +143,7 @@ def test_two_listener_rules_with_correct_priorities(td):
         if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule"
     ]
     priorities = sorted(r["Properties"]["Priority"] for r in rules)
-    assert priorities == [200, 210]
+    assert priorities == [210, 49999]
 
 
 def test_listener_rule_path_patterns(td):
@@ -153,11 +153,11 @@ def test_listener_rule_path_patterns(td):
     ]
     by_priority = {r["Properties"]["Priority"]: r for r in rules}
 
-    maestro_conds = by_priority[200]["Properties"]["Conditions"]
+    maestro_conds = by_priority[49999]["Properties"]["Conditions"]
     found_maestro = False
     for c in maestro_conds:
         if c.get("Field") == "path-pattern":
-            assert c["PathPatternConfig"]["Values"] == ["/maestro/*"]
+            assert c["PathPatternConfig"]["Values"] == ["/*"]
             found_maestro = True
     assert found_maestro
 

--- a/tests/unit/test_listener_priorities.py
+++ b/tests/unit/test_listener_priorities.py
@@ -13,7 +13,7 @@ def test_known_services_have_unique_priorities():
 def test_priority_for_known_service_returns_int():
     assert priority_for("query-api") == 100
     assert priority_for("admin-api") == 110
-    assert priority_for("maestro-https") == 200
+    assert priority_for("maestro-https") == 49999
     assert priority_for("maestro-dex") == 210
     assert priority_for("otel-grpc") == 300
 


### PR DESCRIPTION
## Summary

The maestro UI is a Vite SPA whose `index.html` references `/assets/*` (CSS/JS chunks) with no path prefix. Hosting maestro at `/maestro/*` meant the browser fetched `/assets/index-*.js` — a path with no listener rule — and got the ALB default fixed-response 503, so every JS chunk 404'd and the UI never rendered.

Move maestro from a `/maestro/*` rule at priority 200 to a `/*` catch-all at priority 49999 (highest numeric value, lowest evaluation priority). All other services (`query-api` 100, `admin-api` 110, `dex` 210, `otel-grpc` 300) still match first; anything not matched falls through to maestro.

`MaestroUrl` output now points at `https://${AlbDnsName}/`.

## Test plan

- [x] pytest tests/ (281 passed)
- [x] verified live in test account that maestro container serves both `/` and `/assets/*` at root
- [ ] redeploy v0.0.18 and confirm SPA loads cleanly with no console 404s