### PR TITLE
maestro: wire OIDC_* env vars

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -433,6 +433,16 @@ def build() -> Template:
         Essential=True,
         PortMappings=[PortMapping(ContainerPort=maestro_port, Protocol="tcp")],
         Environment=db_env + [
+            # Maestro reads OIDC_* (see packages/maestro/src/index.ts).
+            # Without OIDC_ISSUER_URL the UI renders an "Authentication
+            # not configured" placeholder instead of mounting routes.
+            Environment(
+                Name="OIDC_ISSUER_URL",
+                Value=Sub("https://${AlbDnsName}/dex"),
+            ),
+            Environment(Name="OIDC_CLIENT_ID", Value=Ref("DexClientId")),
+            Environment(Name="OIDC_AUDIENCE", Value=Ref("DexClientId")),
+            # DEX_* kept for any tooling that still reads the legacy names.
             Environment(
                 Name="DEX_ISSUER_URL",
                 Value=Sub("https://${AlbDnsName}/dex"),


### PR DESCRIPTION
Maestro's TypeScript app reads `OIDC_ISSUER_URL`, `OIDC_CLIENT_ID`, and `OIDC_AUDIENCE` (per packages/maestro/src/index.ts). Without these the UI renders an 'Authentication not configured' placeholder. We were only setting the legacy DEX_* names. Set both. - [x] pytest tests/ (281 passed)