### PR TITLE
maestro: NODE_TLS_REJECT_UNAUTHORIZED=0 so JWKS fetch trusts self-signed ALB

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -476,6 +476,12 @@ def build() -> Template:
                 Value=Sub("https://${AlbDnsName}/dex"),
             ),
             Environment(Name="DEX_CLIENT_ID", Value=Ref("DexClientId")),
+            # Maestro fetches the JWKS from the ALB's HTTPS endpoint, but the
+            # bundled self-signed cert isn't trusted by Node's TLS stack so
+            # undici's fetch fails before it can read the keys, surfacing as
+            # "JWT verification failed: fetch failed" and a 401 on /api/me.
+            # The CA-signed-cert path leaves this unset.
+            Environment(Name="NODE_TLS_REJECT_UNAUTHORIZED", Value="0"),
         ],
         Secrets=list(db_secrets) + [
             Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),


### PR DESCRIPTION
## Summary

- After the dex-init port (#42) the OIDC flow completes through the dex login form and redirects back to maestro, but `/api/me` still returns 401. Maestro logs show `JWT verification failed: fetch failed` — undici's fetch is rejecting the ALB's self-signed cert when the JWT verifier tries to fetch JWKS from `https://<ALB>/dex/keys`.
- Setting `NODE_TLS_REJECT_UNAUTHORIZED=0` on the maestro container is the standard escape hatch for the self-signed-cert path. CA-signed-cert deployments leave this unset and stay strict.

## Test plan

- [x] `pytest tests/`
- [ ] Tag v0.0.21, deploy, verify maestro UI signs in and `/api/me` returns 200