### PR TITLE
maestro: set OIDC_JWKS_URL to dex /keys path

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -470,6 +470,13 @@ def build() -> Template:
             ),
             Environment(Name="OIDC_CLIENT_ID", Value=Ref("DexClientId")),
             Environment(Name="OIDC_AUDIENCE", Value=Ref("DexClientId")),
+            # Maestro defaults to Keycloak's JWKS path
+            # (<issuer>/protocol/openid-connect/certs) but Dex serves keys
+            # at <issuer>/keys, so we have to override it here.
+            Environment(
+                Name="OIDC_JWKS_URL",
+                Value=Sub("https://${AlbDnsName}/dex/keys"),
+            ),
             # DEX_* kept for any tooling that still reads the legacy names.
             Environment(
                 Name="DEX_ISSUER_URL",


### PR DESCRIPTION
## Summary

- Maestro's JWT verifier defaults its JWKS URL to `<issuer>/protocol/openid-connect/certs` (the Keycloak path) when `OIDC_JWKS_URL` is unset. Dex serves its JWKS at `<issuer>/keys`, so every token verification was getting a 404 from the JWKS request, surfacing as `Expected 200 OK from the JSON Web Key Set HTTP response` and a 401 on `/api/me`.
- Setting `OIDC_JWKS_URL=https://<ALB>/dex/keys` on the maestro container points the verifier at the right path.

## Test plan

- [x] `pytest tests/`
- [ ] Tag v0.0.22, deploy, sign in, confirm `/api/me` returns 200 and the UI loads