### PR TITLE
maestro: grant the dex admin superadmin via OIDC_SUPERADMIN_EMAILS

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -236,6 +236,18 @@ def build() -> Template:
             Description="Email address for the DEX local-DB admin login.",
         )
     )
+    t.add_parameter(
+        Parameter(
+            "OidcSuperadminEmails",
+            Type="String",
+            Default="admin@cardinal.local",
+            Description=(
+                "Comma-separated email allowlist whose holders get maestro "
+                "superadmin. Default matches DexAdminEmail so the bundled "
+                "DEX admin can bootstrap orgs."
+            ),
+        )
+    )
     add_no_echo_parameter(
         t,
         "DexAdminPasswordHash",
@@ -284,7 +296,12 @@ def build() -> Template:
             },
             {
                 "label": "DEX configuration",
-                "parameters": ["DexClientId", "DexAdminEmail", "DexAdminPasswordHash"],
+                "parameters": [
+                    "DexClientId",
+                    "DexAdminEmail",
+                    "DexAdminPasswordHash",
+                    "OidcSuperadminEmails",
+                ],
             },
         ],
     )
@@ -489,6 +506,10 @@ def build() -> Template:
             # "JWT verification failed: fetch failed" and a 401 on /api/me.
             # The CA-signed-cert path leaves this unset.
             Environment(Name="NODE_TLS_REJECT_UNAUTHORIZED", Value="0"),
+            # Email allowlist that grants maestro superadmin. The dex login
+            # token has groups=[], so without this the DEX admin lands on
+            # /onboard with no way to bootstrap an org.
+            Environment(Name="OIDC_SUPERADMIN_EMAILS", Value=Ref("OidcSuperadminEmails")),
         ],
         Secrets=list(db_secrets) + [
             Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -222,6 +222,15 @@ def build() -> Template:
         ),
     )
     t.add_parameter(Parameter(
+        "OidcSuperadminEmails",
+        Type="String",
+        Default="admin@cardinal.local",
+        Description=(
+            "Comma-separated email allowlist that grants maestro superadmin. "
+            "Default matches DexAdminEmail."
+        ),
+    ))
+    t.add_parameter(Parameter(
         "TemplateBaseUrl",
         Type="String",
         Default=DEFAULT_TEMPLATE_BASE_URL,
@@ -311,6 +320,7 @@ def build() -> Template:
              "parameters": ["LicenseData", "ApiKeysOverride",
                             "StorageProfilesOverride",
                             "DexAdminEmail", "DexAdminPasswordHash",
+                            "OidcSuperadminEmails",
                             "TemplateBaseUrl"]},
         ],
     )
@@ -513,6 +523,7 @@ def build() -> Template:
         "DexClientId": Ref("DexClientId"),
         "DexAdminEmail": Ref("DexAdminEmail"),
         "DexAdminPasswordHash": Ref("DexAdminPasswordHash"),
+        "OidcSuperadminEmails": Ref("OidcSuperadminEmails"),
     }, depends_on=["MigrationStack"])
 
     # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The bundled dex login emits tokens with `groups=[]` (we use `staticPasswords`, not a group-aware connector), so maestro's default group-based superadmin gate never matches and the dex admin lands on `/onboard` with the "no pending invitations" dead end.
- Wire `OIDC_SUPERADMIN_EMAILS` through CFN as a new root parameter (default `admin@cardinal.local`, matching the default `DexAdminEmail`) and forward it as an env var on the maestro container so the bundled admin gets superadmin without us having to plumb groups through dex.

## Test plan

- [x] `pytest tests/`
- [ ] Tag v0.0.23, deploy, sign in, confirm the admin sees the superadmin pages instead of `/onboard`