### PR TITLE
maestro: grant task role bedrock:InvokeModel on foundation models

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -767,6 +767,20 @@ def _task_role_statements(*, log_group_refs: list, maestro_db_secret_ref) -> lis
             "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
             "Resource": [GetAtt(lg, "Arn") for lg in log_group_refs],
         },
+        # Bedrock embeddings + chat. mcp-gateway calls Titan for embeddings
+        # and Claude (or similar) for chat completion; both go through
+        # bedrock:InvokeModel and the streaming variant. Foundation-model
+        # ARNs are AWS-owned, hence the empty account segment.
+        {
+            "Effect": "Allow",
+            "Action": [
+                "bedrock:InvokeModel",
+                "bedrock:InvokeModelWithResponseStream",
+            ],
+            "Resource": [
+                Sub("arn:aws:bedrock:${AWS::Region}::foundation-model/*"),
+            ],
+        },
     ]
 
 


### PR DESCRIPTION
## Summary

- mcp-gateway calls Bedrock for embeddings (Titan) and chat (Claude) but the maestro task role only had Secrets Manager / SSM / CloudWatch Logs, so any feature that hits the embedding or chat provider fails with `User: ... is not authorized to perform: bedrock:InvokeModel on resource: ... amazon.titan-embed-text-v2:0`.
- Add `bedrock:InvokeModel` and `bedrock:InvokeModelWithResponseStream` (for streaming chat) on `arn:aws:bedrock:<region>::foundation-model/*`. The empty account segment is intentional — foundation-model ARNs are AWS-owned.

## Test plan

- [x] `pytest tests/`
- [ ] Tag v0.0.24, deploy, exercise a chat-or-embedding-bound feature in the maestro UI