### PR TITLE
admin-api: serve from a dedicated 9443 HTTPS listener

### DIFF
--- a/src/cardinal_cfn/children/alb.py
+++ b/src/cardinal_cfn/children/alb.py
@@ -93,7 +93,14 @@ def build() -> Template:
                     "ToPort": 443,
                     "CidrIp": "0.0.0.0/0",
                     "Description": "HTTPS from anywhere",
-                }
+                },
+                {
+                    "IpProtocol": "tcp",
+                    "FromPort": 9443,
+                    "ToPort": 9443,
+                    "CidrIp": "0.0.0.0/0",
+                    "Description": "Admin-API HTTPS (dedicated listener)",
+                },
             ],
             Tags=cardinal_tags(component="networking", role="alb-sg"),
         )
@@ -135,6 +142,33 @@ def build() -> Template:
         )
     )
 
+    # Dedicated listener for the lakerunner admin-api. The admin-api binary
+    # serves its embedded UI at "/" so we can't share a path-prefixed rule
+    # on 443 without either breaking the API (no path stripping in ALB) or
+    # breaking the UI's react-router. Giving admin-api its own listener at
+    # 9443 lets the container see request paths verbatim. The default
+    # action is a 503; admin-api owns a single catch-all rule on this
+    # listener (registered from services_control.py).
+    admin_listener = t.add_resource(
+        Listener(
+            "AdminHttpsListener",
+            LoadBalancerArn=Ref(alb),
+            Port=9443,
+            Protocol="HTTPS",
+            Certificates=[Certificate(CertificateArn=Ref("CertificateArn"))],
+            DefaultActions=[
+                Action(
+                    Type="fixed-response",
+                    FixedResponseConfig=FixedResponseConfig(
+                        StatusCode="503",
+                        ContentType="text/plain",
+                        MessageBody="admin-api listener rule not registered",
+                    ),
+                )
+            ],
+        )
+    )
+
     # Allow ALB to reach ECS tasks on all ports
     t.add_resource(
         SecurityGroupIngress(
@@ -152,6 +186,7 @@ def build() -> Template:
     t.add_output(Output("AlbDnsName", Value=GetAtt(alb, "DNSName")))
     t.add_output(Output("AlbSecurityGroupId", Value=Ref(alb_sg)))
     t.add_output(Output("HttpsListenerArn", Value=Ref(listener)))
+    t.add_output(Output("AdminHttpsListenerArn", Value=Ref(admin_listener)))
 
     return t
 

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -80,6 +80,17 @@ def build() -> Template:
         Parameter("HttpsListenerArn", Type="String", Description="ARN of the ALB HTTPS listener.")
     )
     t.add_parameter(
+        Parameter(
+            "AdminHttpsListenerArn",
+            Type="String",
+            Description=(
+                "ARN of the dedicated admin-api HTTPS listener (port 9443). "
+                "admin-api owns the catch-all on this listener so the "
+                "container sees unprefixed paths."
+            ),
+        )
+    )
+    t.add_parameter(
         Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="VPC ID (forwarded from root).")
     )
     t.add_parameter(
@@ -235,12 +246,16 @@ def build() -> Template:
             health_check_path=admin_health_path,
         )
     )
+    # admin-api gets a dedicated HTTPS listener (9443) so the lakerunner
+    # binary's mux sees request paths verbatim (no /admin/ prefix to strip).
+    # This is the only rule on that listener; the listener's default action
+    # is a 503 fixed response.
     t.add_resource(
         services_common.build_listener_rule(
-            service_key="admin-api",
+            service_key="admin-api-https",
             target_group_ref=admin_tg,
-            listener_arn_param="HttpsListenerArn",
-            path_patterns=["/admin/*"],
+            listener_arn_param="AdminHttpsListenerArn",
+            path_patterns=["/*"],
         )
     )
     admin_env = list(base_env) + _service_specific_env(admin_cfg)

--- a/src/cardinal_cfn/listener_priorities.py
+++ b/src/cardinal_cfn/listener_priorities.py
@@ -10,12 +10,18 @@ future per-service stack splits collision-free.
 
 LISTENER_PRIORITIES: dict = {
     "query-api":     100,
-    "admin-api":     110,
     "maestro-dex":   210,
     "otel-grpc":     300,
     # Maestro is the default app: a true catch-all "/*" rule. It MUST be
     # numerically the highest (lowest priority) so all other rules win.
     "maestro-https": 49999,
+    # admin-api lives on its OWN dedicated HTTPS listener (port 9443),
+    # not the shared 443 listener — the lakerunner binary serves its
+    # embedded UI at "/" so a path-prefixed rule on 443 would either
+    # break the API (no path stripping) or break the UI's react-router.
+    # With a dedicated listener, priority is per-listener so any int
+    # works.
+    "admin-api-https": 1,
 }
 
 

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -463,6 +463,7 @@ def build() -> Template:
     services_control_params = _service_tier_common()
     services_control_params.update({
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
+        "AdminHttpsListenerArn": GetAtt(alb_stack, "Outputs.AdminHttpsListenerArn"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceName": GetAtt(cluster_stack, "Outputs.ServiceNamespaceName"),
     })

--- a/tests/templates/test_alb.py
+++ b/tests/templates/test_alb.py
@@ -24,11 +24,12 @@ def test_creates_load_balancer(template_dict):
     assert len(lbs) == 1
 
 
-def test_creates_https_listener_on_443(template_dict):
+def test_creates_https_listeners_on_443_and_9443(template_dict):
     listeners = [r for r in template_dict["Resources"].values()
                  if r["Type"] == "AWS::ElasticLoadBalancingV2::Listener"]
-    assert len(listeners) == 1
-    assert listeners[0]["Properties"]["Port"] == 443
+    assert len(listeners) == 2
+    ports = sorted(l["Properties"]["Port"] for l in listeners)
+    assert ports == [443, 9443]
 
 
 def test_creates_alb_to_task_ingress(template_dict):
@@ -46,5 +47,11 @@ def test_alb_uses_delete_policy(template_dict):
 
 
 def test_outputs_required(template_dict):
-    for n in ("AlbArn", "AlbDnsName", "AlbSecurityGroupId", "HttpsListenerArn"):
+    for n in (
+        "AlbArn",
+        "AlbDnsName",
+        "AlbSecurityGroupId",
+        "HttpsListenerArn",
+        "AdminHttpsListenerArn",
+    ):
         assert n in template_dict["Outputs"]

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -96,13 +96,14 @@ def test_only_one_target_group_and_one_listener_rule(td):
     assert len(rules) == 1
 
 
-def test_admin_api_listener_rule_priority(td):
-    rules = [r for r in td["Resources"].values()
-             if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule"]
-    assert any(r["Properties"]["Priority"] == 110 for r in rules)
+def test_admin_api_listener_rule_uses_dedicated_listener(td):
+    rule = next(r for r in td["Resources"].values()
+                if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule")
+    assert rule["Properties"]["Priority"] == 1
+    assert rule["Properties"]["ListenerArn"] == {"Ref": "AdminHttpsListenerArn"}
 
 
-def test_admin_api_listener_rule_path_pattern(td):
+def test_admin_api_listener_rule_is_catch_all(td):
     rule = next(r for r in td["Resources"].values()
                 if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule")
     conditions = rule["Properties"]["Conditions"]
@@ -110,9 +111,13 @@ def test_admin_api_listener_rule_path_pattern(td):
     for cond in conditions:
         if cond.get("Field") == "path-pattern":
             values = cond["PathPatternConfig"]["Values"]
-            assert values == ["/admin/*"]
+            assert values == ["/*"]
             found = True
     assert found, "expected a path-pattern condition"
+
+
+def test_admin_https_listener_arn_parameter(td):
+    assert "AdminHttpsListenerArn" in td["Parameters"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_listener_priorities.py
+++ b/tests/unit/test_listener_priorities.py
@@ -12,7 +12,7 @@ def test_known_services_have_unique_priorities():
 
 def test_priority_for_known_service_returns_int():
     assert priority_for("query-api") == 100
-    assert priority_for("admin-api") == 110
+    assert priority_for("admin-api-https") == 1
     assert priority_for("maestro-https") == 49999
     assert priority_for("maestro-dex") == 210
     assert priority_for("otel-grpc") == 300


### PR DESCRIPTION
## Summary

The lakerunner admin-api binary serves an embedded UI at `/` of its mux and registers API handlers at `/api/v1/...`. Sharing the 443 listener under `/admin/*` was broken in both directions:

- **API calls** landed in the UI handler (returning HTML) because ALB doesn't strip the path; the container saw `/admin/api/v1/...` which doesn't match its `/api/v1/...` routes.
- **Browser visits** to `/admin/` loaded the lakerunner SPA, whose catch-all `*` route does `<Navigate to="/login" replace>` (relative). That client-side-navigated the URL to `/login` (top-level), and on reload `/login` fell through to maestro's catch-all `/*` and rendered as a blank Cardinal SPA shell — confusing.

Give admin-api its own HTTPS listener on port 9443 with the same cert, ALB SG ingress on 9443, and a single `/*` catch-all rule (priority 1) forwarding to the existing target group. The container now sees unprefixed request paths so the API mux works.

**Customer-facing change**: admin URL goes from `https://<ALB>/admin/...` to `https://<ALB>:9443/api/v1/...`.

## Test plan

- [x] `pytest tests/` (283 pass)
- [x] `cfn-lint` on changed templates (only pre-existing warnings)
- [ ] Tag v0.0.25, deploy, verify a `curl` against the admin-api endpoint returns JSON instead of HTML