### PR TITLE
admin-api: seed initial admin key via ADMIN_INITIAL_API_KEY

### DIFF
--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -91,6 +91,17 @@ def build() -> Template:
         )
     )
     t.add_parameter(
+        Parameter(
+            "AdminApiKeySecretArn",
+            Type="String",
+            Description=(
+                "ARN of the admin-api initial-key secret. Forwarded into the "
+                "admin-api container as ADMIN_INITIAL_API_KEY so the binary "
+                "seeds its first valid admin key on startup."
+            ),
+        )
+    )
+    t.add_parameter(
         Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="VPC ID (forwarded from root).")
     )
     t.add_parameter(
@@ -235,7 +246,10 @@ def build() -> Template:
     admin_role = t.add_resource(
         services_common.build_task_role(
             service_key="admin-api",
-            statements=_task_role_statements(admin_lg),
+            statements=_task_role_statements(
+                admin_lg,
+                extra_secret_refs=[Ref("AdminApiKeySecretArn")],
+            ),
         )
     )
     admin_tg = t.add_resource(
@@ -259,6 +273,16 @@ def build() -> Template:
         )
     )
     admin_env = list(base_env) + _service_specific_env(admin_cfg)
+    # Seed the lakerunner admin-api binary's first valid admin key. Without
+    # this, every Authorization: Bearer <key> request fails validation
+    # because the configdb has no admin keys and the binary won't accept
+    # the one we want to use.
+    admin_secrets = list(base_secrets) + [
+        Secret(
+            Name="ADMIN_INITIAL_API_KEY",
+            ValueFrom=Sub("${AdminApiKeySecretArn}:key::"),
+        ),
+    ]
     admin_task = t.add_resource(
         services_common.build_task_definition(
             service_key="admin-api",
@@ -269,7 +293,7 @@ def build() -> Template:
             execution_role_arn_param="ExecutionRoleArn",
             task_role_ref=admin_role,
             environment=admin_env,
-            secrets=base_secrets,
+            secrets=admin_secrets,
             log_group_ref=admin_lg,
             container_port=admin_container_port,
         )
@@ -389,13 +413,15 @@ def _service_specific_env(service_cfg: dict) -> list:
     return [Environment(Name=k, Value=str(v)) for k, v in env.items()]
 
 
-def _task_role_statements(log_group_ref) -> list:
+def _task_role_statements(log_group_ref, extra_secret_refs: list | None = None) -> list:
     """Inline IAM policy for a control-tier task role.
 
     Grants S3 (bucket+objects), SQS (consume+send), SSM GetParameter on the
-    two config params, Secrets Manager GetSecretValue on the three secrets,
-    and CloudWatch Logs writes to the per-service log group.
+    two config params, Secrets Manager GetSecretValue on the three shared
+    secrets plus any per-service `extra_secret_refs`, and CloudWatch Logs
+    writes to the per-service log group.
     """
+    extra_secret_refs = list(extra_secret_refs or [])
     return [
         {
             "Effect": "Allow",
@@ -436,7 +462,7 @@ def _task_role_statements(log_group_ref) -> list:
                 Ref("DbSecretArn"),
                 Ref("LicenseSecretArn"),
                 Ref("InternalServiceKeysSecretArn"),
-            ],
+            ] + extra_secret_refs,
         },
         {
             "Effect": "Allow",

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -464,6 +464,7 @@ def build() -> Template:
     services_control_params.update({
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
         "AdminHttpsListenerArn": GetAtt(alb_stack, "Outputs.AdminHttpsListenerArn"),
+        "AdminApiKeySecretArn": GetAtt(config_stack, "Outputs.AdminApiKeySecretArn"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceName": GetAtt(cluster_stack, "Outputs.ServiceNamespaceName"),
     })


### PR DESCRIPTION
## Summary

The lakerunner admin-api binary reads `ADMIN_INITIAL_API_KEY` from env to seed its first valid admin key into configdb on startup. We were generating a key in `AdminApiKeySecret` but never wiring it into the container, so every `Authorization: Bearer <key>` request returned `{"code":"UNAUTHORIZED","message":"invalid API key"}`.

- Forward `AdminApiKeySecretArn` from `config_stack` into `ServicesControlStack`.
- Add it to the admin-api task's secrets as `ADMIN_INITIAL_API_KEY` (pulling the `:key::` field).
- Extend the admin-api task role's `secretsmanager:GetSecretValue` resource list to cover the new secret. Other control-tier services don't need it, so `_task_role_statements` grew an optional `extra_secret_refs` argument rather than over-granting.

## Test plan

- [x] `pytest tests/` (283 pass)
- [ ] Tag v0.0.26, deploy, `curl -H "Authorization: Bearer <key>" https://<ALB>:9443/api/v1/ping` returns 200 / pong-ish JSON