### PR TITLE
monitoring: wire ECS autoscaler env + IAM after substack split

### DIFF
--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -150,6 +150,63 @@ def build() -> Template:
         )
     )
 
+    # Inputs the monitoring service uses to drive ECS-based autoscaling of the
+    # process-* services. ClusterName is the ECS cluster name (not ARN) — both
+    # the autoscaler's ECS_CLUSTER env var and the IAM resource ARNs need the
+    # name form. The three service-name inputs come from services-process stack
+    # outputs; the three replica inputs are the same Refs that gate the
+    # process-* DesiredCount in services-process, so the autoscaler's max
+    # tracks whatever the customer set at deploy time.
+    t.add_parameter(
+        Parameter(
+            "ClusterName",
+            Type="String",
+            Description="ECS cluster name (not ARN), used by the monitoring autoscaler.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ProcessLogsServiceName",
+            Type="String",
+            Description="ECS service name for lakerunner-process-logs.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ProcessMetricsServiceName",
+            Type="String",
+            Description="ECS service name for lakerunner-process-metrics.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ProcessTracesServiceName",
+            Type="String",
+            Description="ECS service name for lakerunner-process-traces.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ProcessLogsReplicas",
+            Type="Number",
+            Description="Maximum desired replicas for lakerunner-process-logs.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ProcessMetricsReplicas",
+            Type="Number",
+            Description="Maximum desired replicas for lakerunner-process-metrics.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ProcessTracesReplicas",
+            Type="Number",
+            Description="Maximum desired replicas for lakerunner-process-traces.",
+        )
+    )
+
     # MigrationComplete is unused inside this stack on purpose. The root passes
     # the migration-stack output through this parameter; CloudFormation cannot
     # render this nested stack until the migration stack finishes producing
@@ -203,6 +260,13 @@ def build() -> Template:
                     "ApiKeysParamName",
                     "StorageProfilesParamName",
                     "MigrationComplete",
+                    "ClusterName",
+                    "ProcessLogsServiceName",
+                    "ProcessMetricsServiceName",
+                    "ProcessTracesServiceName",
+                    "ProcessLogsReplicas",
+                    "ProcessMetricsReplicas",
+                    "ProcessTracesReplicas",
                 ],
             },
             {
@@ -325,24 +389,80 @@ def build() -> Template:
         ),
     ]
 
+    # The monitoring service drives ECS autoscaling of the process-* services.
+    # Env vars match cmd/monitoring.go + config/autoscaler.go in the lakerunner
+    # repo; IAM is scoped per-service to UpdateService/DescribeServices.
+    monitoring_extra_env = [
+        Environment(Name="LAKERUNNER_AUTOSCALER_ENABLED", Value="true"),
+        Environment(Name="LAKERUNNER_AUTOSCALER_PLATFORM", Value="ecs"),
+        Environment(Name="ECS_CLUSTER", Value=Ref("ClusterName")),
+        Environment(
+            Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT",
+            Value=Ref("ProcessLogsServiceName"),
+        ),
+        Environment(
+            Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS",
+            Value=Ref("ProcessLogsReplicas"),
+        ),
+        Environment(
+            Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT",
+            Value=Ref("ProcessMetricsServiceName"),
+        ),
+        Environment(
+            Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS",
+            Value=Ref("ProcessMetricsReplicas"),
+        ),
+        Environment(
+            Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT",
+            Value=Ref("ProcessTracesServiceName"),
+        ),
+        Environment(
+            Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS",
+            Value=Ref("ProcessTracesReplicas"),
+        ),
+    ]
+    monitoring_extra_statements = [
+        {
+            "Effect": "Allow",
+            "Action": ["ecs:DescribeServices", "ecs:UpdateService"],
+            "Resource": [
+                Sub(
+                    "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/"
+                    "${ClusterName}/${ProcessLogsServiceName}"
+                ),
+                Sub(
+                    "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/"
+                    "${ClusterName}/${ProcessMetricsServiceName}"
+                ),
+                Sub(
+                    "arn:aws:ecs:${AWS::Region}:${AWS::AccountId}:service/"
+                    "${ClusterName}/${ProcessTracesServiceName}"
+                ),
+            ],
+        },
+    ]
+
     internal_services = [
         {
             "service_key": "sweeper",
             "config": sweeper_cfg,
             "output_name": "SweeperServiceName",
             "extra_env": [],
+            "extra_statements": [],
         },
         {
             "service_key": "monitoring",
             "config": monitoring_cfg,
             "output_name": "MonitoringServiceName",
-            "extra_env": [],
+            "extra_env": monitoring_extra_env,
+            "extra_statements": monitoring_extra_statements,
         },
         {
             "service_key": "alert-evaluator",
             "config": alert_cfg,
             "output_name": "AlertEvaluatorServiceName",
             "extra_env": alert_extra_env,
+            "extra_statements": [],
         },
     ]
 
@@ -355,6 +475,7 @@ def build() -> Template:
             base_env=base_env,
             base_secrets=base_secrets,
             extra_env=spec["extra_env"],
+            extra_statements=spec["extra_statements"],
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
 
@@ -370,13 +491,17 @@ def _build_internal_service_block(
     base_env: list,
     base_secrets: list,
     extra_env: list | None = None,
+    extra_statements: list | None = None,
 ):
     """Wire up log group, task role, task def, and ECS service for one internal service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
     task_role = t.add_resource(
         services_common.build_task_role(
             service_key=service_key,
-            statements=_task_role_statements(log_group),
+            statements=_task_role_statements(
+                log_group,
+                extra_statements=extra_statements,
+            ),
         )
     )
     env = list(base_env) + _service_specific_env(config) + list(extra_env or [])
@@ -413,15 +538,21 @@ def _service_specific_env(service_cfg: dict) -> list:
     return [Environment(Name=k, Value=str(v)) for k, v in env.items()]
 
 
-def _task_role_statements(log_group_ref, extra_secret_refs: list | None = None) -> list:
+def _task_role_statements(
+    log_group_ref,
+    extra_secret_refs: list | None = None,
+    extra_statements: list | None = None,
+) -> list:
     """Inline IAM policy for a control-tier task role.
 
     Grants S3 (bucket+objects), SQS (consume+send), SSM GetParameter on the
     two config params, Secrets Manager GetSecretValue on the three shared
     secrets plus any per-service `extra_secret_refs`, and CloudWatch Logs
-    writes to the per-service log group.
+    writes to the per-service log group. Per-service `extra_statements` are
+    appended verbatim — used by the monitoring service for ECS UpdateService.
     """
     extra_secret_refs = list(extra_secret_refs or [])
+    extra_statements = list(extra_statements or [])
     return [
         {
             "Effect": "Allow",
@@ -469,7 +600,7 @@ def _task_role_statements(log_group_ref, extra_secret_refs: list | None = None) 
             "Action": ["logs:CreateLogStream", "logs:PutLogEvents"],
             "Resource": GetAtt(log_group_ref, "Arn"),
         },
-    ]
+    ] + extra_statements
 
 
 if __name__ == "__main__":

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -457,8 +457,9 @@ def build() -> Template:
         "ProcessTracesMemory": Ref("ProcessTracesMemory"),
         "PubsubSqsReplicas": Ref("PubsubSqsReplicas"),
     })
-    _add_child(t, "ServicesProcessStack", "services-process.yaml",
-               services_process_params, depends_on=["MigrationStack"])
+    services_process_stack = _add_child(
+        t, "ServicesProcessStack", "services-process.yaml",
+        services_process_params, depends_on=["MigrationStack"])
 
     services_control_params = _service_tier_common()
     services_control_params.update({
@@ -467,9 +468,24 @@ def build() -> Template:
         "AdminApiKeySecretArn": GetAtt(config_stack, "Outputs.AdminApiKeySecretArn"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceName": GetAtt(cluster_stack, "Outputs.ServiceNamespaceName"),
+        # Inputs for the monitoring service's ECS autoscaler. The service-name
+        # outputs come from services-process; the replica Refs are the same
+        # values that gate process-* DesiredCount in services-process so the
+        # autoscaler max tracks the customer's deploy-time setting.
+        "ClusterName": GetAtt(cluster_stack, "Outputs.ClusterName"),
+        "ProcessLogsServiceName":
+            GetAtt(services_process_stack, "Outputs.ProcessLogsServiceName"),
+        "ProcessMetricsServiceName":
+            GetAtt(services_process_stack, "Outputs.ProcessMetricsServiceName"),
+        "ProcessTracesServiceName":
+            GetAtt(services_process_stack, "Outputs.ProcessTracesServiceName"),
+        "ProcessLogsReplicas": Ref("ProcessLogsReplicas"),
+        "ProcessMetricsReplicas": Ref("ProcessMetricsReplicas"),
+        "ProcessTracesReplicas": Ref("ProcessTracesReplicas"),
     })
     _add_child(t, "ServicesControlStack", "services-control.yaml",
-               services_control_params, depends_on=["MigrationStack"])
+               services_control_params,
+               depends_on=["MigrationStack", "ServicesProcessStack"])
 
     _add_child(t, "OtelStack", "otel.yaml", {
         "InstallIdShort": install_short,

--- a/tests/templates/test_root.py
+++ b/tests/templates/test_root.py
@@ -94,6 +94,40 @@ def test_service_tier_stacks_depend_on_migration(td):
         assert "MigrationStack" in deps, f"{logical_id} missing MigrationStack DependsOn"
 
 
+def test_services_control_depends_on_services_process(td):
+    """The monitoring service in services-control consumes services-process
+    outputs (process-* service names) for its ECS autoscaler wiring."""
+    deps = td["Resources"]["ServicesControlStack"].get("DependsOn", [])
+    if isinstance(deps, str):
+        deps = [deps]
+    assert "ServicesProcessStack" in deps
+
+
+def test_services_control_receives_monitoring_autoscaler_inputs(td):
+    """Root must thread the cluster name + 3 process service names + 3 replica
+    parameters into services-control so the monitoring autoscaler can scale."""
+    params = td["Resources"]["ServicesControlStack"]["Properties"]["Parameters"]
+    for n in (
+        "ClusterName",
+        "ProcessLogsServiceName",
+        "ProcessMetricsServiceName",
+        "ProcessTracesServiceName",
+        "ProcessLogsReplicas",
+        "ProcessMetricsReplicas",
+        "ProcessTracesReplicas",
+    ):
+        assert n in params, f"ServicesControlStack missing parameter: {n}"
+    for n, src_output in (
+        ("ProcessLogsServiceName", "ProcessLogsServiceName"),
+        ("ProcessMetricsServiceName", "ProcessMetricsServiceName"),
+        ("ProcessTracesServiceName", "ProcessTracesServiceName"),
+    ):
+        getatt = params[n].get("Fn::GetAtt")
+        assert getatt == ["ServicesProcessStack", f"Outputs.{src_output}"], (
+            f"{n} must come from ServicesProcessStack output; got {params[n]!r}"
+        )
+
+
 def test_maestro_stack_depends_on_migration(td):
     deps = td["Resources"]["MaestroStack"].get("DependsOn", [])
     if isinstance(deps, str):

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -39,6 +39,13 @@ def test_required_cross_stack_parameters(td):
         "StorageProfilesParamName",
         "MigrationComplete",
         "LakerunnerImage",
+        "ClusterName",
+        "ProcessLogsServiceName",
+        "ProcessMetricsServiceName",
+        "ProcessTracesServiceName",
+        "ProcessLogsReplicas",
+        "ProcessMetricsReplicas",
+        "ProcessTracesReplicas",
     ):
         assert n in td["Parameters"], f"missing parameter: {n}"
 
@@ -224,6 +231,99 @@ def test_all_task_definitions_set_ssl_required(td):
             env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
             assert env.get("LRDB_SSLMODE") == "require", (
                 f"{container.get('Name')} LRDB_SSLMODE must be 'require'; got {env.get('LRDB_SSLMODE')!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# B → C boundary
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Monitoring autoscaler wiring
+# ---------------------------------------------------------------------------
+
+
+def _task_def_for(td, container_name):
+    for res in td["Resources"].values():
+        if res["Type"] != "AWS::ECS::TaskDefinition":
+            continue
+        for container in res["Properties"]["ContainerDefinitions"]:
+            if container["Name"] == container_name:
+                return res, container
+    raise AssertionError(f"no task definition with container {container_name!r}")
+
+
+def test_monitoring_container_has_autoscaler_env(td):
+    _, container = _task_def_for(td, "monitoring")
+    env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+    assert env.get("LAKERUNNER_AUTOSCALER_ENABLED") == "true"
+    assert env.get("LAKERUNNER_AUTOSCALER_PLATFORM") == "ecs"
+    assert env.get("ECS_CLUSTER") == {"Ref": "ClusterName"}
+    expected = {
+        "LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT": "ProcessLogsServiceName",
+        "LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS": "ProcessLogsReplicas",
+        "LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT": "ProcessMetricsServiceName",
+        "LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS": "ProcessMetricsReplicas",
+        "LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT": "ProcessTracesServiceName",
+        "LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS": "ProcessTracesReplicas",
+    }
+    for env_name, param_name in expected.items():
+        assert env.get(env_name) == {"Ref": param_name}, (
+            f"{env_name} must Ref {param_name}; got {env.get(env_name)!r}"
+        )
+
+
+def test_only_monitoring_has_autoscaler_env(td):
+    """Sweeper / admin-api / alert-evaluator must not see the autoscaler env."""
+    for container_name in ("admin-api", "sweeper", "alert-evaluator"):
+        _, container = _task_def_for(td, container_name)
+        env_names = {e["Name"] for e in container.get("Environment", [])}
+        leaked = {n for n in env_names if n.startswith("LAKERUNNER_AUTOSCALER_")}
+        leaked.update(env_names & {"ECS_CLUSTER"})
+        assert not leaked, f"{container_name} unexpectedly has {leaked}"
+
+
+def _task_role_for(td, service_key):
+    """Return the IAM role whose logical id starts with the title-cased service_key."""
+    title = "".join(p.capitalize() for p in service_key.split("-")) + "TaskRole"
+    return td["Resources"][title]
+
+
+def _flatten_actions(stmt_actions):
+    return [stmt_actions] if isinstance(stmt_actions, str) else list(stmt_actions)
+
+
+def test_monitoring_task_role_grants_ecs_update(td):
+    role = _task_role_for(td, "monitoring")
+    statements = role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    found = False
+    for stmt in statements:
+        actions = _flatten_actions(stmt.get("Action", []))
+        if "ecs:UpdateService" in actions and "ecs:DescribeServices" in actions:
+            found = True
+            resources = stmt["Resource"]
+            assert isinstance(resources, list) and len(resources) == 3
+            joined = json.dumps(resources)
+            for param in (
+                "ProcessLogsServiceName",
+                "ProcessMetricsServiceName",
+                "ProcessTracesServiceName",
+            ):
+                assert param in joined, f"{param} not referenced in monitoring ECS resource ARNs"
+            assert "ClusterName" in joined
+    assert found, "monitoring role missing ecs:DescribeServices/UpdateService"
+
+
+def test_other_roles_lack_ecs_update(td):
+    """Only monitoring should see ecs:UpdateService."""
+    for service_key in ("admin-api", "sweeper", "alert-evaluator"):
+        role = _task_role_for(td, service_key)
+        statements = role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+        for stmt in statements:
+            actions = _flatten_actions(stmt.get("Action", []))
+            assert "ecs:UpdateService" not in actions, (
+                f"{service_key} unexpectedly has ecs:UpdateService"
             )
 
 


### PR DESCRIPTION
## Summary

- The substack split moved `monitoring` into `services-control` and the `process-*` services into `services-process`, but the wiring the monitoring binary needs to drive ECS autoscaling was never added.
- Thread `ClusterName`, three `ProcessXxxServiceName` outputs (from `services-process`), and three `ProcessXxxReplicas` Refs into `services-control`. Set the autoscaler env vars (`LAKERUNNER_AUTOSCALER_ENABLED`, `LAKERUNNER_AUTOSCALER_PLATFORM=ecs`, `ECS_CLUSTER`, plus the three `*_DEPLOYMENT` / `*_MAX_REPLICAS` pairs) on the monitoring container only, and grant the monitoring task role `ecs:DescribeServices` + `ecs:UpdateService` scoped to the three process services. Add `DependsOn: ServicesProcessStack` so the service-name outputs exist before control renders.

Confirmed against `cardinalhq/lakerunner` `cmd/monitoring.go`, `internal/scaling/ecs_actuator.go`, and `config/autoscaler.go` — env-var names and the two ECS API actions match the binary.

## Test plan

- [x] `make build` (cfn-lint clean, only pre-existing W2001 warnings)
- [x] `make test` (289 passed, +6 new)
- [x] Inspect `generated-templates/cardinal-lakerunner/services-control.yaml` — monitoring task def + role render as expected
- [ ] Deploy to test account and confirm monitoring pod logs show `Autoscaler started platform=ecs` and a successful `DescribeServices` round-trip