### PR TITLE
monitoring: enable autoscaler writes (OBSERVE_ONLY=false, MIN_REPLICAS=1)

### DIFF
--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -392,14 +392,21 @@ def build() -> Template:
     # The monitoring service drives ECS autoscaling of the process-* services.
     # Env vars match cmd/monitoring.go + config/autoscaler.go in the lakerunner
     # repo; IAM is scoped per-service to UpdateService/DescribeServices.
+    # The lakerunner binary defaults Autoscaler.ObserveOnly=true and per-service
+    # MinReplicas=0, which would log decisions but never scale and would scale
+    # services to zero on idle. Override both: the customer set max replicas to
+    # opt into actual scaling, and 1 is the documented floor (lakerunner
+    # docs/guides/admin/autoscaling.md: "Set to 1 to prevent scale-to-zero").
     monitoring_extra_env = [
         Environment(Name="LAKERUNNER_AUTOSCALER_ENABLED", Value="true"),
+        Environment(Name="LAKERUNNER_AUTOSCALER_OBSERVE_ONLY", Value="false"),
         Environment(Name="LAKERUNNER_AUTOSCALER_PLATFORM", Value="ecs"),
         Environment(Name="ECS_CLUSTER", Value=Ref("ClusterName")),
         Environment(
             Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT",
             Value=Ref("ProcessLogsServiceName"),
         ),
+        Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS", Value="1"),
         Environment(
             Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS",
             Value=Ref("ProcessLogsReplicas"),
@@ -408,6 +415,7 @@ def build() -> Template:
             Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT",
             Value=Ref("ProcessMetricsServiceName"),
         ),
+        Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS", Value="1"),
         Environment(
             Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS",
             Value=Ref("ProcessMetricsReplicas"),
@@ -416,6 +424,7 @@ def build() -> Template:
             Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT",
             Value=Ref("ProcessTracesServiceName"),
         ),
+        Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS", Value="1"),
         Environment(
             Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS",
             Value=Ref("ProcessTracesReplicas"),

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -258,6 +258,9 @@ def test_monitoring_container_has_autoscaler_env(td):
     _, container = _task_def_for(td, "monitoring")
     env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
     assert env.get("LAKERUNNER_AUTOSCALER_ENABLED") == "true"
+    # Without ObserveOnly=false the autoscaler defaults to compute-don't-write,
+    # which would silently no-op the whole feature.
+    assert env.get("LAKERUNNER_AUTOSCALER_OBSERVE_ONLY") == "false"
     assert env.get("LAKERUNNER_AUTOSCALER_PLATFORM") == "ecs"
     assert env.get("ECS_CLUSTER") == {"Ref": "ClusterName"}
     expected = {
@@ -272,6 +275,9 @@ def test_monitoring_container_has_autoscaler_env(td):
         assert env.get(env_name) == {"Ref": param_name}, (
             f"{env_name} must Ref {param_name}; got {env.get(env_name)!r}"
         )
+    for signal in ("LOGS", "METRICS", "TRACES"):
+        key = f"LAKERUNNER_AUTOSCALER_SERVICES_{signal}_MIN_REPLICAS"
+        assert env.get(key) == "1", f"{key} must default to 1, got {env.get(key)!r}"
 
 
 def test_only_monitoring_has_autoscaler_env(td):


### PR DESCRIPTION
## Summary

- v0.0.27 wired all the autoscaler env + IAM but the lakerunner binary defaults `Autoscaler.ObserveOnly=true`, so it logged decisions and never called `UpdateService`. Set `LAKERUNNER_AUTOSCALER_OBSERVE_ONLY=false` to make it actually scale.
- Default per-service `MIN_REPLICAS=1` so idle workloads don't surprise-scale to zero. Matches `cardinal-defaults.yaml` and the lakerunner docs (`docs/guides/admin/autoscaling.md`: "Set to 1 to prevent scale-to-zero").

## Test plan

- [x] `make test` (289 passed)
- [ ] Tag v0.0.28; deploy to test account; observe a `Scaling decision ... skip_write=false` line and an `UpdateService` log entry within ~2 min of idle patience expiring.