### PR TITLE
bump lakerunner image to v1.19.2 in defaults

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,13 +33,13 @@ storage_profiles:
 # root-template concern, not a default here.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.8.6"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
-  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
+  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
 
 # ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is


### PR DESCRIPTION
## Summary

- Bumps the default `lakerunner` and `migration` images in `cardinal-defaults.yaml` from `v1.19.0` to `v1.19.2`.
- v1.19.2 removes the KEDA external scaler and worklane depth monitor (cardinalhq/lakerunner#663); no CloudFormation surface is affected by that removal — image refs only.

## Test plan

- [ ] CFN lint / template validation passes
- [ ] Stack deploys cleanly with the new image