### PR TITLE
bump lakerunner image to v1.19.2

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,13 +33,13 @@ storage_profiles:
 # root-template concern, not a default here.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.8.6"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
-  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.0"
+  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
 
 # ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is


### PR DESCRIPTION
## Summary

- Bump default `lakerunner` and `migration` image tags from v1.19.0 to v1.19.2 in `cardinal-defaults.yaml`.

## Test plan

- [x] `make test` (289 passed)
- [ ] Tag, deploy to test account