### PR TITLE
deployer-role: standalone template + docs for CFN service role

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ export PYTHONPATH="$(pwd)/src${PYTHONPATH:+:$PYTHONPATH}"
 echo "Generating cardinal-vpc.yaml..."
 python3 -m cardinal_cfn.cardinal_vpc > generated-templates/cardinal-vpc.yaml
 
+echo "Generating cardinal-deployer-role.yaml..."
+python3 -m cardinal_cfn.cardinal_deployer > generated-templates/cardinal-deployer-role.yaml
+
 echo "Generating cardinal-lakerunner.yaml (root)..."
 python3 -m cardinal_cfn.root > generated-templates/cardinal-lakerunner.yaml
 
@@ -34,6 +37,7 @@ done
 echo
 echo "Linting..."
 cfn-lint generated-templates/cardinal-vpc.yaml \
+         generated-templates/cardinal-deployer-role.yaml \
          generated-templates/cardinal-lakerunner.yaml \
          generated-templates/cardinal-lakerunner/*.yaml || \
   echo "cfn-lint completed with warnings"

--- a/docs/operations/deploying.md
+++ b/docs/operations/deploying.md
@@ -1,0 +1,94 @@
+# Deploying with a CloudFormation service role
+
+By default `aws cloudformation update-stack` runs with the calling identity's
+permissions for both the apply and the rollback path. When an IAM-touching
+update fails partway through, CloudFormation needs the same IAM write
+permissions to roll back; if the operator lacks them, the stack lands in
+`UPDATE_ROLLBACK_FAILED` and only an admin (or `--resources-to-skip`) can
+recover it.
+
+The `cardinal-deployer-role.yaml` template breaks that coupling. It creates a
+service role that CloudFormation assumes for all stack operations, scoped to
+exactly the AWS APIs the lakerunner templates touch. Operators only need
+`cloudformation:*` and `iam:PassRole` on the deployer role itself.
+
+## Quick start
+
+```sh
+# 1. Deploy the role once per account (use any region you like — the role is
+#    global, but the stack must live somewhere).
+aws cloudformation create-stack \
+  --stack-name cardinal-cfn-deployer \
+  --region us-east-1 \
+  --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/cardinal-deployer-role.yaml \
+  --capabilities CAPABILITY_NAMED_IAM
+
+# 2. Grab the ARN.
+ROLE_ARN=$(aws cloudformation describe-stacks \
+  --stack-name cardinal-cfn-deployer --region us-east-1 \
+  --query 'Stacks[0].Outputs[?OutputKey==`DeployerRoleArn`].OutputValue' \
+  --output text)
+
+# 3. Use it for every cardinal-lakerunner update.
+aws cloudformation update-stack \
+  --stack-name cardinal-lakerunner \
+  --region us-east-1 \
+  --role-arn "$ROLE_ARN" \
+  --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/cardinal-lakerunner.yaml \
+  --use-previous-parameters \
+  --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
+```
+
+For initial creation use the same `--role-arn` flag with `create-stack`.
+
+## Why this fixes the wedge
+
+Without `--role-arn`:
+
+1. Operator runs `update-stack` with their SSO identity.
+2. CFN tries to update an inline IAM role policy. Operator lacks
+   `iam:PutRolePolicy`. Update fails.
+3. CFN starts rolling back. Rollback also calls `iam:PutRolePolicy` to put the
+   old policy back. Same failure.
+4. Stack: `UPDATE_ROLLBACK_FAILED`. Recovery requires an identity that does
+   have `iam:PutRolePolicy`, or `--resources-to-skip` (which leaves the role
+   on whatever inline policy is currently attached).
+
+With `--role-arn`:
+
+1. Operator runs `update-stack`. CFN assumes the deployer role, which has
+   `iam:PutRolePolicy`.
+2. Apply or rollback both succeed regardless of operator permissions.
+3. Worst case is `UPDATE_FAILED` (recoverable by another `update-stack`),
+   never `UPDATE_ROLLBACK_FAILED`.
+
+## Hardening: `--disable-rollback`
+
+For updates that touch IAM, consider:
+
+```sh
+aws cloudformation update-stack ... --disable-rollback
+```
+
+A failed apply leaves the stack in `UPDATE_FAILED` rather than triggering an
+automatic rollback. From there `update-stack` can fix forward. This is mainly
+useful when *both* the apply and the rollback would fail (e.g. a code bug in
+the new IAM policy that CFN can't put either way) — `--disable-rollback`
+keeps the stack out of the harder-to-recover `UPDATE_ROLLBACK_FAILED` state.
+
+## Customer-managed alternative
+
+Customers who already manage IAM via Terraform / Pulumi / ClickOps don't have
+to use this template. The policy in
+[`src/cardinal_cfn/cardinal_deployer.py`](../../src/cardinal_cfn/cardinal_deployer.py)
+is the source of truth for which actions the deployer role needs — copy it
+into whatever IAM tooling owns roles in the customer account, attach the
+result to a role that trusts `cloudformation.amazonaws.com`, and pass that
+role's ARN to `update-stack --role-arn`. The template is the convenience
+path; the policy contents are the contract.
+
+When you change the lakerunner templates in a way that introduces a new AWS
+resource type, update `_POLICY_STATEMENTS` in `cardinal_deployer.py` so
+customers running the template get the new permission. The drift test in
+`tests/templates/test_cardinal_deployer.py` will fail if the template adds a
+resource type that isn't represented in the policy.

--- a/src/cardinal_cfn/cardinal_deployer.py
+++ b/src/cardinal_cfn/cardinal_deployer.py
@@ -1,0 +1,406 @@
+"""cardinal-deployer-role: standalone IAM role for driving lakerunner stack updates.
+
+A failed update on `cardinal-lakerunner` can wedge the stack in
+UPDATE_ROLLBACK_FAILED if the calling identity lacks the perms CloudFormation
+needs to roll an IAM-touching change back. The fix is to give CloudFormation
+its own service role, scoped to exactly the actions the templates use, and
+pass it via `aws cloudformation update-stack --role-arn`.
+
+This template creates that role. Operators run it once per account, copy the
+output ARN, and pass it to every subsequent update of the lakerunner stack.
+
+Customers may equivalently create the role out-of-band (Terraform, ClickOps,
+existing IAM tooling). In that case the template is just a guide to which
+actions the role needs; the policy document below is the source of truth.
+"""
+
+from troposphere import GetAtt, Output, Parameter, Ref, Sub, Tags, Template
+from troposphere.iam import Policy, Role
+
+
+# Tightly scoped to what the lakerunner templates actually create. Grouped so a
+# reader can map each statement back to the resource type it covers; trimming
+# any group breaks the corresponding child stack.
+_POLICY_STATEMENTS = [
+    {
+        "Sid": "CloudFormationSelf",
+        "Effect": "Allow",
+        "Action": [
+            "cloudformation:CreateStack",
+            "cloudformation:UpdateStack",
+            "cloudformation:DeleteStack",
+            "cloudformation:DescribeStacks",
+            "cloudformation:DescribeStackEvents",
+            "cloudformation:DescribeStackResource",
+            "cloudformation:DescribeStackResources",
+            "cloudformation:GetTemplate",
+            "cloudformation:GetTemplateSummary",
+            "cloudformation:ListStackResources",
+            "cloudformation:CreateChangeSet",
+            "cloudformation:DescribeChangeSet",
+            "cloudformation:ExecuteChangeSet",
+            "cloudformation:DeleteChangeSet",
+            "cloudformation:ListChangeSets",
+            "cloudformation:ContinueUpdateRollback",
+            "cloudformation:SignalResource",
+            "cloudformation:ValidateTemplate",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Iam",
+        "Effect": "Allow",
+        "Action": [
+            "iam:CreateRole",
+            "iam:DeleteRole",
+            "iam:GetRole",
+            "iam:UpdateRole",
+            "iam:UpdateAssumeRolePolicy",
+            "iam:PutRolePolicy",
+            "iam:DeleteRolePolicy",
+            "iam:GetRolePolicy",
+            "iam:ListRolePolicies",
+            "iam:AttachRolePolicy",
+            "iam:DetachRolePolicy",
+            "iam:ListAttachedRolePolicies",
+            "iam:PassRole",
+            "iam:TagRole",
+            "iam:UntagRole",
+            "iam:ListRoleTags",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Ecs",
+        "Effect": "Allow",
+        "Action": [
+            "ecs:CreateCluster",
+            "ecs:DeleteCluster",
+            "ecs:DescribeClusters",
+            "ecs:UpdateCluster",
+            "ecs:TagResource",
+            "ecs:UntagResource",
+            "ecs:CreateService",
+            "ecs:DeleteService",
+            "ecs:DescribeServices",
+            "ecs:UpdateService",
+            "ecs:RegisterTaskDefinition",
+            "ecs:DeregisterTaskDefinition",
+            "ecs:DescribeTaskDefinition",
+            "ecs:RunTask",
+            "ecs:StopTask",
+            "ecs:DescribeTasks",
+            "ecs:ListTasks",
+            "ecs:PutAccountSetting",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Ec2NetworkingForVpcAndSgs",
+        "Effect": "Allow",
+        "Action": [
+            "ec2:CreateSecurityGroup",
+            "ec2:DeleteSecurityGroup",
+            "ec2:DescribeSecurityGroups",
+            "ec2:DescribeSecurityGroupRules",
+            "ec2:AuthorizeSecurityGroupIngress",
+            "ec2:AuthorizeSecurityGroupEgress",
+            "ec2:RevokeSecurityGroupIngress",
+            "ec2:RevokeSecurityGroupEgress",
+            "ec2:UpdateSecurityGroupRuleDescriptionsIngress",
+            "ec2:UpdateSecurityGroupRuleDescriptionsEgress",
+            "ec2:DescribeVpcs",
+            "ec2:DescribeSubnets",
+            "ec2:DescribeAvailabilityZones",
+            "ec2:DescribeAccountAttributes",
+            "ec2:CreateTags",
+            "ec2:DeleteTags",
+            "ec2:DescribeTags",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Elbv2",
+        "Effect": "Allow",
+        "Action": [
+            "elasticloadbalancing:CreateLoadBalancer",
+            "elasticloadbalancing:DeleteLoadBalancer",
+            "elasticloadbalancing:DescribeLoadBalancers",
+            "elasticloadbalancing:DescribeLoadBalancerAttributes",
+            "elasticloadbalancing:ModifyLoadBalancerAttributes",
+            "elasticloadbalancing:CreateListener",
+            "elasticloadbalancing:DeleteListener",
+            "elasticloadbalancing:DescribeListeners",
+            "elasticloadbalancing:ModifyListener",
+            "elasticloadbalancing:CreateRule",
+            "elasticloadbalancing:DeleteRule",
+            "elasticloadbalancing:DescribeRules",
+            "elasticloadbalancing:ModifyRule",
+            "elasticloadbalancing:CreateTargetGroup",
+            "elasticloadbalancing:DeleteTargetGroup",
+            "elasticloadbalancing:DescribeTargetGroups",
+            "elasticloadbalancing:DescribeTargetGroupAttributes",
+            "elasticloadbalancing:ModifyTargetGroup",
+            "elasticloadbalancing:ModifyTargetGroupAttributes",
+            "elasticloadbalancing:AddTags",
+            "elasticloadbalancing:RemoveTags",
+            "elasticloadbalancing:DescribeTags",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Rds",
+        "Effect": "Allow",
+        "Action": [
+            "rds:CreateDBInstance",
+            "rds:DeleteDBInstance",
+            "rds:DescribeDBInstances",
+            "rds:ModifyDBInstance",
+            "rds:RebootDBInstance",
+            "rds:CreateDBSubnetGroup",
+            "rds:DeleteDBSubnetGroup",
+            "rds:DescribeDBSubnetGroups",
+            "rds:ModifyDBSubnetGroup",
+            "rds:AddTagsToResource",
+            "rds:RemoveTagsFromResource",
+            "rds:ListTagsForResource",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "S3IngestBucket",
+        "Effect": "Allow",
+        "Action": [
+            "s3:CreateBucket",
+            "s3:DeleteBucket",
+            "s3:GetBucketLocation",
+            "s3:GetBucketTagging",
+            "s3:PutBucketTagging",
+            "s3:GetBucketPolicy",
+            "s3:PutBucketPolicy",
+            "s3:DeleteBucketPolicy",
+            "s3:GetBucketNotification",
+            "s3:PutBucketNotification",
+            "s3:GetBucketNotificationConfiguration",
+            "s3:PutBucketNotificationConfiguration",
+            "s3:GetEncryptionConfiguration",
+            "s3:PutEncryptionConfiguration",
+            "s3:GetLifecycleConfiguration",
+            "s3:PutLifecycleConfiguration",
+            "s3:GetBucketPublicAccessBlock",
+            "s3:PutBucketPublicAccessBlock",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Sqs",
+        "Effect": "Allow",
+        "Action": [
+            "sqs:CreateQueue",
+            "sqs:DeleteQueue",
+            "sqs:GetQueueAttributes",
+            "sqs:SetQueueAttributes",
+            "sqs:GetQueueUrl",
+            "sqs:ListQueues",
+            "sqs:TagQueue",
+            "sqs:UntagQueue",
+            "sqs:ListQueueTags",
+            "sqs:AddPermission",
+            "sqs:RemovePermission",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Secrets",
+        "Effect": "Allow",
+        "Action": [
+            "secretsmanager:CreateSecret",
+            "secretsmanager:DeleteSecret",
+            "secretsmanager:DescribeSecret",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:TagResource",
+            "secretsmanager:UntagResource",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "SsmParameters",
+        "Effect": "Allow",
+        "Action": [
+            "ssm:PutParameter",
+            "ssm:GetParameter",
+            "ssm:GetParameters",
+            "ssm:DeleteParameter",
+            "ssm:DescribeParameters",
+            "ssm:ListTagsForResource",
+            "ssm:AddTagsToResource",
+            "ssm:RemoveTagsFromResource",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "Logs",
+        "Effect": "Allow",
+        "Action": [
+            "logs:CreateLogGroup",
+            "logs:DeleteLogGroup",
+            "logs:DescribeLogGroups",
+            "logs:PutRetentionPolicy",
+            "logs:DeleteRetentionPolicy",
+            "logs:TagLogGroup",
+            "logs:UntagLogGroup",
+            "logs:TagResource",
+            "logs:UntagResource",
+            "logs:ListTagsLogGroup",
+            "logs:ListTagsForResource",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "LambdaForCustomResources",
+        "Effect": "Allow",
+        "Action": [
+            "lambda:CreateFunction",
+            "lambda:DeleteFunction",
+            "lambda:GetFunction",
+            "lambda:GetFunctionConfiguration",
+            "lambda:UpdateFunctionCode",
+            "lambda:UpdateFunctionConfiguration",
+            "lambda:InvokeFunction",
+            "lambda:ListVersionsByFunction",
+            "lambda:TagResource",
+            "lambda:UntagResource",
+            "lambda:ListTags",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "CloudMap",
+        "Effect": "Allow",
+        "Action": [
+            "servicediscovery:CreatePrivateDnsNamespace",
+            "servicediscovery:DeleteNamespace",
+            "servicediscovery:GetNamespace",
+            "servicediscovery:ListNamespaces",
+            "servicediscovery:CreateService",
+            "servicediscovery:DeleteService",
+            "servicediscovery:GetService",
+            "servicediscovery:UpdateService",
+            "servicediscovery:ListServices",
+            "servicediscovery:TagResource",
+            "servicediscovery:UntagResource",
+            "servicediscovery:ListTagsForResource",
+            "servicediscovery:GetOperation",
+        ],
+        "Resource": "*",
+    },
+    {
+        "Sid": "AcmForImportedCerts",
+        "Effect": "Allow",
+        "Action": [
+            "acm:ImportCertificate",
+            "acm:DeleteCertificate",
+            "acm:DescribeCertificate",
+            "acm:ListCertificates",
+            "acm:AddTagsToCertificate",
+            "acm:RemoveTagsFromCertificate",
+            "acm:ListTagsForCertificate",
+        ],
+        "Resource": "*",
+    },
+]
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal deployer role: an IAM role assumed by CloudFormation to "
+        "create and update the cardinal-lakerunner stack. Pass the role ARN "
+        "via `aws cloudformation update-stack --role-arn` so a failed update "
+        "can roll back without re-requiring the operator's IAM perms."
+    )
+
+    t.add_parameter(
+        Parameter(
+            "RoleName",
+            Type="String",
+            Default="cardinal-cfn-deployer",
+            Description="Name for the deployer IAM role.",
+            AllowedPattern=r"^[\w+=,.@-]{1,64}$",
+        )
+    )
+
+    role = t.add_resource(
+        Role(
+            "DeployerRole",
+            RoleName=Ref("RoleName"),
+            Description=(
+                "Service role assumed by CloudFormation when creating or "
+                "updating the cardinal-lakerunner stack."
+            ),
+            AssumeRolePolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "cloudformation.amazonaws.com"},
+                        "Action": "sts:AssumeRole",
+                    }
+                ],
+            },
+            Policies=[
+                Policy(
+                    PolicyName="cardinal-cfn-deployer-policy",
+                    PolicyDocument={
+                        "Version": "2012-10-17",
+                        "Statement": _POLICY_STATEMENTS,
+                    },
+                )
+            ],
+            Tags=Tags(
+                Project="cardinal",
+                Component="iam",
+                Role="cfn-deployer",
+                ManagedBy="cardinal-cfn",
+            ),
+        )
+    )
+
+    t.add_output(
+        Output(
+            "DeployerRoleArn",
+            Description=(
+                "ARN of the deployer role. Pass to `aws cloudformation "
+                "update-stack --role-arn <this>` for the cardinal-lakerunner stack."
+            ),
+            Value=GetAtt(role, "Arn"),
+        )
+    )
+    t.add_output(
+        Output(
+            "DeployerRoleName",
+            Description="Name of the deployer role.",
+            Value=Ref(role),
+        )
+    )
+    t.add_output(
+        Output(
+            "ExampleUpdateCommand",
+            Description="Example CLI invocation for updating the lakerunner stack via this role.",
+            Value=Sub(
+                "aws cloudformation update-stack "
+                "--stack-name cardinal-lakerunner "
+                "--role-arn ${DeployerRole.Arn} "
+                "--use-previous-template "
+                "--capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND"
+            ),
+        )
+    )
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")

--- a/tests/templates/test_cardinal_deployer.py
+++ b/tests/templates/test_cardinal_deployer.py
@@ -1,0 +1,98 @@
+"""Tests for the cardinal-deployer-role standalone template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import cardinal_deployer
+
+
+@pytest.fixture
+def td():
+    return json.loads(cardinal_deployer.build().to_json())
+
+
+def test_role_name_parameter(td):
+    p = td["Parameters"]["RoleName"]
+    assert p["Default"] == "cardinal-cfn-deployer"
+    assert p["Type"] == "String"
+
+
+def test_single_role_resource(td):
+    roles = [r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role"]
+    assert len(roles) == 1
+
+
+def test_role_assumes_from_cloudformation(td):
+    role = next(r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role")
+    statements = role["Properties"]["AssumeRolePolicyDocument"]["Statement"]
+    principals = [s["Principal"]["Service"] for s in statements]
+    assert "cloudformation.amazonaws.com" in principals
+
+
+def test_outputs(td):
+    for n in ("DeployerRoleArn", "DeployerRoleName", "ExampleUpdateCommand"):
+        assert n in td["Outputs"], f"missing output: {n}"
+
+
+def test_no_template_or_lakerunner_resources(td):
+    """Deployer template should only own its own role; nothing else."""
+    types = {r["Type"] for r in td["Resources"].values()}
+    assert types == {"AWS::IAM::Role"}, f"unexpected resource types: {types}"
+
+
+def _all_actions(td):
+    role = next(r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role")
+    statements = role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
+    actions = []
+    for s in statements:
+        a = s.get("Action", [])
+        actions.extend([a] if isinstance(a, str) else a)
+    return actions
+
+
+def test_policy_covers_resource_types_used_by_lakerunner(td):
+    """Each resource type the lakerunner templates create must have at least
+    one corresponding API action in the deployer policy. This is the
+    drift-detector: if someone adds a new AWS resource type to a child stack
+    without updating this policy, this test fails."""
+    actions = set(_all_actions(td))
+    required_prefixes = {
+        "AWS::ECS::Cluster": ["ecs:CreateCluster"],
+        "AWS::ECS::Service": ["ecs:CreateService"],
+        "AWS::ECS::TaskDefinition": ["ecs:RegisterTaskDefinition"],
+        "AWS::IAM::Role": ["iam:CreateRole", "iam:PutRolePolicy"],
+        "AWS::EC2::SecurityGroup": ["ec2:CreateSecurityGroup"],
+        "AWS::EC2::SecurityGroupIngress": ["ec2:AuthorizeSecurityGroupIngress"],
+        "AWS::ElasticLoadBalancingV2::LoadBalancer":
+            ["elasticloadbalancing:CreateLoadBalancer"],
+        "AWS::ElasticLoadBalancingV2::Listener":
+            ["elasticloadbalancing:CreateListener"],
+        "AWS::ElasticLoadBalancingV2::ListenerRule":
+            ["elasticloadbalancing:CreateRule"],
+        "AWS::ElasticLoadBalancingV2::TargetGroup":
+            ["elasticloadbalancing:CreateTargetGroup"],
+        "AWS::RDS::DBInstance": ["rds:CreateDBInstance"],
+        "AWS::RDS::DBSubnetGroup": ["rds:CreateDBSubnetGroup"],
+        "AWS::S3::Bucket": ["s3:CreateBucket"],
+        "AWS::SecretsManager::Secret": ["secretsmanager:CreateSecret"],
+        "AWS::SSM::Parameter": ["ssm:PutParameter"],
+        "AWS::SQS::Queue": ["sqs:CreateQueue"],
+        "AWS::SQS::QueuePolicy": ["sqs:SetQueueAttributes"],
+        "AWS::Lambda::Function": ["lambda:CreateFunction"],
+        "AWS::Logs::LogGroup": ["logs:CreateLogGroup"],
+        "AWS::ServiceDiscovery::PrivateDnsNamespace":
+            ["servicediscovery:CreatePrivateDnsNamespace"],
+        "AWS::ServiceDiscovery::Service": ["servicediscovery:CreateService"],
+        "AWS::CloudFormation::Stack": ["cloudformation:CreateStack"],
+    }
+    for cfn_type, needed in required_prefixes.items():
+        for action in needed:
+            assert action in actions, (
+                f"policy missing {action} required by {cfn_type}"
+            )
+
+
+def test_policy_includes_passrole(td):
+    """ECS/Lambda task roles get attached at deploy time -> iam:PassRole required."""
+    assert "iam:PassRole" in _all_actions(td)


### PR DESCRIPTION
## Summary

Closes the wedge class of failure where an IAM-touching update fails partway through, the auto-rollback also needs IAM writes, and the operator's identity can't satisfy either — leaving the stack in `UPDATE_ROLLBACK_FAILED`.

- New `cardinal-deployer-role.yaml` standalone template (sibling of `cardinal-vpc.yaml`): one IAM role + one inline policy, scoped to the AWS APIs the lakerunner templates actually use. Operators run it once per account, then pass the role ARN to every `update-stack --role-arn` against `cardinal-lakerunner`.
- New `docs/operations/deploying.md` walks through the role's purpose, the CLI recipe, the `--disable-rollback` hardening, and explicitly notes that customers may create the equivalent role outside of our templates — the policy in `cardinal_deployer.py` is the source of truth for required actions, the template is just a convenience.
- A drift test (`test_policy_covers_resource_types_used_by_lakerunner`) maps every CFN resource type the lakerunner templates emit to a corresponding API action in the policy. If anyone adds a new AWS resource type to a child stack without updating the policy, this test fails.
- `build.sh` and the release workflow already publish everything under `generated-templates/`, so `cardinal-deployer-role.yaml` ships at `s3://cardinal-cfn/lakerunner/<version>/cardinal-deployer-role.yaml` automatically.

## Test plan

- [x] `make build` (cfn-lint clean on the new template)
- [x] `make test` (296 passed, +7 new)