### PR TITLE
jenkins: safe lakerunner stack upgrade pipeline + driving script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Makefile for Cardinal CloudFormation project.
 
-.PHONY: help install build test test-unit test-templates check lint clean all
+.PHONY: help install build test test-unit test-templates test-jenkins check lint clean all
 
 VENV_DIR := .venv
 PYTHON   := $(VENV_DIR)/bin/python
@@ -28,6 +28,9 @@ test-unit:	## Run unit tests only
 
 test-templates:	## Run per-template tests only
 	$(PYTEST) tests/templates/ -v
+
+test-jenkins:	## Run Jenkins/upgrade-script tests only
+	$(PYTEST) tests/unit/test_upgrade_lakerunner.py tests/unit/test_upgrade_lakerunner_lint.py tests/unit/test_jenkinsfile_upgrade.py -v
 
 check: test	## Pre-push gate (alias for test)
 

--- a/docs/operations/jenkins-upgrade.md
+++ b/docs/operations/jenkins-upgrade.md
@@ -1,0 +1,139 @@
+# Upgrading the lakerunner stack from Jenkins
+
+`jenkins/Jenkinsfile.upgrade-lakerunner` is a declarative pipeline that upgrades a single existing `cardinal-lakerunner` CloudFormation stack to a newer published template version. All upgrade behaviour lives in `scripts/upgrade-lakerunner.sh`; the Jenkinsfile is a thin wrapper.
+
+One Jenkins job per install. Multi-install operators copy the Jenkinsfile into a separate job per stack and edit the parameter defaults at the top to match.
+
+## What the pipeline does
+
+1. **Pre-flight** — the script verifies `aws`, `jq`, and `curl` are on `PATH`. Missing tools fail fast with an actionable message naming the missing tool.
+2. **Resolve parameters** — for each parameter declared by the new template:
+    - `*Image` parameters with a default in the new template take that default (refresh the image set on every upgrade).
+    - Parameters present in the running stack carry forward via `UsePreviousValue=true`.
+    - Parameters new in the new template that have a default take the default.
+    - Parameters new in the new template with no default fail the upgrade and name the missing parameter so the operator can supply it.
+3. **Plan** — create a CloudFormation change set named `cardinal-upgrade-<unix-timestamp>`, wait for it to settle, print the resource changes (adds / modifies / replacements / removes) to the build log.
+4. **Approval** — only when `AutoApprove=false`: the pipeline pauses on a Jenkins `input` step.
+5. **Apply** — execute the change set and wait for `UPDATE_COMPLETE`. Any other terminal state fails the build.
+6. **Cleanup** — best-effort `delete-change-set` on any `cardinal-upgrade-*` change set still pending on the stack.
+
+The script's exit code is the build's exit code. Non-zero leaves the build red.
+
+## Prerequisites
+
+On the Jenkins agent that will run the job:
+
+- POSIX shell (`/bin/sh`)
+- AWS CLI v2
+- `jq` (1.6+)
+- `curl`
+- The Jenkins **AWS Credentials** plugin
+
+The script will refuse to start if `aws`, `jq`, or `curl` is missing, with a one-liner naming the missing tool. Common install commands:
+
+| OS | Install |
+|---|---|
+| Debian / Ubuntu | `sudo apt-get install -y awscli jq curl` |
+| Amazon Linux | `sudo yum install -y aws-cli jq curl` |
+| Alpine | `sudo apk add aws-cli jq curl` |
+| macOS (Homebrew) | `brew install awscli jq curl` |
+
+In your AWS account: a CloudFormation deployer role created from `cardinal-deployer-role.yaml` (see `docs/operations/deploying.md`). Strongly recommended; the upgrade pipeline passes its ARN via `--role-arn` and avoids the `UPDATE_ROLLBACK_FAILED` wedge.
+
+## Per-install setup
+
+1. Copy `jenkins/Jenkinsfile.upgrade-lakerunner` into a Jenkins **Pipeline** job (either inline, or pointed at this repo via "Pipeline script from SCM").
+2. Edit the `parameters {}` defaults near the top of the file:
+    - `StackName` — the install's stack name.
+    - `Region` — the install's AWS region.
+    - `AwsCredentialsId` — the Jenkins credential binding ID with permission to run CloudFormation against this account.
+    - `DeployerRoleArn` — the ARN of the deployer role for this account.
+3. Optionally pin `Version` to a specific release (e.g. `v1.20.0`) instead of `latest`.
+4. Save the job. Run.
+
+For multiple installs, repeat for each — one job per install.
+
+## Job parameters
+
+| Parameter | Default | Notes |
+|---|---|---|
+| `StackName` | `cardinal-lakerunner` | Edit per install |
+| `Region` | `us-east-2` | Edit per install |
+| `TemplateBaseUrl` | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` | Override for air-gapped customers |
+| `Version` | `latest` | Pin to a release for reproducibility |
+| `DeployerRoleArn` | (empty) | Strongly recommended; see `docs/operations/deploying.md` |
+| `AutoApprove` | `true` | When `false`, the pipeline pauses for manual approval after the change set is described |
+| `RefreshImageDefaults` | `true` | When `false`, `*Image` parameters carry forward instead of taking new template defaults |
+| `AwsCredentialsId` | `aws-cardinal-deploy` | Jenkins AWS Credentials plugin binding ID |
+
+## AWS auth alternatives
+
+The default uses the Jenkins AWS Credentials plugin (recommended). Two alternatives:
+
+- **IAM instance profile on the Jenkins agent.** Set `AwsCredentialsId` to a binding that returns no credentials, and ensure the agent's instance profile has the required permissions. The AWS CLI will pick up the instance role automatically.
+- **Assume role from the agent.** Wrap the script invocation in `aws sts assume-role` + `eval "$(aws sts ... | jq ... )"` to export `AWS_*` env vars before calling the script. Keep this in the Jenkinsfile rather than the script — the script reads `AWS_*` env vars directly and stays auth-agnostic.
+
+## Air-gapped variant
+
+Mirror `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/` to a private bucket (or any HTTPS-reachable location). Set the `TemplateBaseUrl` parameter on the Jenkins job to point at your mirror. Override per-image parameters via your stack defaults so customer images come from your private registry rather than `public.ecr.aws/...`.
+
+## Reading the change set summary
+
+The Plan stage prints a table per resource change:
+
+```
+| Action     | Type                          | Logical              | Replacement |
+| ---------- | ----------------------------- | -------------------- | ----------- |
+| Modify     | AWS::ECS::Service             | QueryApi             | False       |
+| Modify     | AWS::ECS::TaskDefinition      | QueryApiTaskDef      | True        |
+| Add        | AWS::IAM::Policy              | NewServicePolicy     | -           |
+```
+
+What to look for:
+
+- **`Replacement: True`** on a stateful resource (RDS, S3, persistent EBS): stop and investigate. Image-tag bumps should never replace storage.
+- **`Action: Remove`** on something you didn't expect: stop and investigate. The published templates do not remove resources during an in-place upgrade.
+- A flood of `Modify` rows across all services on a published image bump is normal.
+
+When `AutoApprove=false`, the pipeline pauses here and waits for an operator to click "Apply".
+
+## Recovery
+
+If the upgrade lands the stack in `UPDATE_FAILED` or `UPDATE_ROLLBACK_COMPLETE`, the build is red and the stack has either applied nothing or fully rolled back automatically. Re-run the job once the underlying issue is fixed:
+
+- **Bad image tag** → publish a fixed image, re-run.
+- **Parameter without default required** → the script prints the parameter name; supply it on the next run (currently via the script's flags or by adding it as a job parameter).
+- **AWS API throttling / transient error** → re-run.
+
+If the stack lands in `UPDATE_ROLLBACK_FAILED`, you are in the IAM-rollback wedge described in `docs/operations/deploying.md`. The fix is to ensure all upgrades use a deployer role; see that document for one-time recovery steps.
+
+## Pinning vs. tracking `latest`
+
+Use `Version=latest` for environments where you want to follow the published rolling tag (development, internal staging). Pin to an explicit version (`v1.20.0`) for environments where you want reproducible upgrades — production, regulated installs, anything an audit trail must explain.
+
+When pinning, bumping the install means changing the `Version` parameter on the Jenkins job and re-running. This pattern also makes a rollback trivial: re-run with the previous `Version`.
+
+## What the pipeline does *not* do
+
+- Does not orchestrate multiple installs in sequence. One job per install.
+- Does not rotate sensitive parameters (`LicenseData`, `ApiKeysOverride`, `StorageProfilesOverride`). Those carry forward via `UsePreviousValue=true`. Rotation is a separate operation.
+- Does not perform application-level health probes after the upgrade. The success signal is "CloudFormation reached `UPDATE_COMPLETE`". Anything richer (HTTP probes, target group health, etc.) is a follow-on responsibility.
+- Does not fall back to retries on its own. CloudFormation's automatic rollback on update failure handles the bad-update case; the per-service ECS deployment circuit breaker (already configured in the stack) handles bad image tags.
+
+## Running the script standalone
+
+The script is self-contained and runnable outside Jenkins for emergency upgrades or dry runs:
+
+```sh
+export AWS_REGION=us-east-2
+export AWS_PROFILE=cardinal-prod  # or AWS_ACCESS_KEY_ID, etc.
+
+sh scripts/upgrade-lakerunner.sh \
+    --stack-name cardinal-lakerunner \
+    --region us-east-2 \
+    --version v1.20.0 \
+    --deployer-role-arn arn:aws:iam::123456789012:role/cardinal-cfn-deployer \
+    --no-execute
+```
+
+`--no-execute` plans only; the change set is left in place for manual inspection. Drop the flag to apply.

--- a/docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md
@@ -10,10 +10,10 @@ Multiple installs are managed by copying the Jenkinsfile per install and editing
 
 ## Deliverables
 
-- `scripts/upgrade_lakerunner.py` — Python driving script that does the actual deploy and reports success or failure via exit code.
+- `scripts/upgrade-lakerunner.sh` — POSIX shell driving script that does the actual deploy and reports success or failure via exit code.
 - `jenkins/Jenkinsfile.upgrade-lakerunner` — declarative Jenkins pipeline that binds AWS credentials and invokes the script.
 - `docs/operations/jenkins-upgrade.md` — operator documentation.
-- `tests/unit/test_upgrade_lakerunner.py` — unit tests covering parameter resolution and no-op detection.
+- `tests/unit/test_upgrade_lakerunner.py` — pytest unit tests that drive the script's `--internal-resolve-params` mode against fixture inputs to validate parameter resolution and no-op detection.
 
 ## Non-goals
 
@@ -24,13 +24,20 @@ Multiple installs are managed by copying the Jenkinsfile per install and editing
 - Drift detection.
 - Application-level health probes after the upgrade. Confirmation is "did CloudFormation reach `UPDATE_COMPLETE`" — nothing more.
 - A standalone Cardinal-internal pipeline. The customer-facing template is the canonical artifact and Cardinal uses it directly.
-- New runtime dependencies on the Jenkins worker beyond `python3`, `pyyaml` (already in `requirements.txt`), and the `aws` CLI.
+- Any runtime dependency on the `cardinal_cfn` Python package or other contents of this repo. The script is self-contained — at runtime it sees only the published `cardinal-lakerunner.yaml` in S3 and the AWS CLI.
 
-## Driving script — `scripts/upgrade_lakerunner.py`
+## Runtime dependencies on the Jenkins worker
 
-The script is the single source of truth for upgrade behavior. The Jenkinsfile is a thin wrapper around it.
+- POSIX shell (`/bin/sh`).
+- `aws` CLI v2.
+- `jq` (1.6 or later — for building and inspecting JSON).
+- `curl` (for the HTTP HEAD probe of the template URL).
 
-Implemented in Python because the parameter-resolution logic is non-trivial and benefits from pytest coverage. It shells out to the `aws` CLI for all AWS API calls, avoiding a `boto3` dependency. It uses `pyyaml` to parse the new template (already in `requirements.txt`).
+No Python, no `boto3`, no `pyyaml`. The script does not parse the template YAML directly — it uses `aws cloudformation get-template-summary` to discover the new template's parameter schema, which returns names, types, defaults, and `NoEcho` flags as structured JSON.
+
+## Driving script — `scripts/upgrade-lakerunner.sh`
+
+The script is the single source of truth for upgrade behavior. The Jenkinsfile is a thin wrapper around it. It is also runnable standalone from an operator laptop or any other CI system, so customers can use it outside Jenkins for emergency upgrades or dry runs.
 
 ### Inputs
 
@@ -56,7 +63,7 @@ The script runs these stages in order. Any non-zero result from a stage aborts t
 
 2. **Resolve template URL.** `${template_base_url}/${version}/cardinal-lakerunner.yaml`. Probe with an HTTP HEAD; abort on 404.
 
-3. **Fetch new template** to a temp file and parse its `Parameters` block with `pyyaml`. Capture each parameter's name, default (or absence of default), and type.
+3. **Discover new template parameters.** `aws cloudformation get-template-summary --template-url <resolved url> --query 'Parameters'` returns the new template's parameter schema as JSON: name, type, default (when present), `NoEcho` flag. No local YAML parsing.
 
 4. **Resolve parameters.** Walk the new template's parameter list. For each parameter, choose exactly one of these outcomes:
 
@@ -110,8 +117,8 @@ A declarative pipeline. Customers copy this file once per install and edit the `
 
 ### Stages
 
-1. **Setup** — `withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AwsCredentialsId]])`. Verify `aws` and `python3` are on PATH.
-2. **Plan** — invoke `python3 scripts/upgrade_lakerunner.py --no-execute ...`. The build log captures the change set summary. Always runs.
+1. **Setup** — `withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AwsCredentialsId]])`. Verify `aws`, `jq`, and `curl` are on PATH.
+2. **Plan** — invoke `sh scripts/upgrade-lakerunner.sh --no-execute ...`. The build log captures the change set summary. Always runs.
 3. **Approval** — only when `params.AutoApprove == false`: a Jenkins `input` step. Skipped entirely when `true` (no human required).
 4. **Apply** — invoke the script again *without* `--no-execute`. The script's no-op detector ensures this second run is cheap when the Plan stage already created an equivalent change set, and the operator (or auto-approval) is committing to applying whatever the live state requires at apply time.
 5. **Post (always)** — best-effort cleanup pass: list change sets on the stack and `delete-change-set` any whose name starts with `cardinal-upgrade-` and is still in a pending (non-executed) state.
@@ -128,7 +135,7 @@ The script's exit code is the build's exit code. Jenkins shows the build red on 
 
 Covers:
 
-- Pre-reqs (AWS Credentials plugin, deployer role, Jenkins agent with `aws` CLI and `python3` available, `pyyaml` available).
+- Pre-reqs (AWS Credentials plugin, deployer role, Jenkins agent with `aws` CLI v2, `jq`, and `curl` available).
 - Per-install setup: copy the Jenkinsfile, set the parameter defaults at the top, point a Jenkins job at it.
 - AWS auth alternatives: AWS Credentials plugin (default), IAM instance profile on the worker, assume-role from the worker.
 - Air-gapped variant: customer-mirrored `TemplateBaseUrl` plus image override parameters.
@@ -138,9 +145,19 @@ Covers:
 
 ## Testing
 
-- **Unit, parameter resolution.** Pure-function pytest of the resolution function. Inputs: a fixture template parsed dict, a fixture current-stack parameters list, the resolution flags. Output: the expected `parameters.json` array. Covers all four resolution rules and a known-bad case (rule 4 hard-fail).
-- **Unit, no-op detection.** Feed the no-op detector each documented `StatusReason` phrasing AWS has used for empty change sets, plus a real failure phrasing. Assert the function classifies them correctly.
-- **Lint, Jenkinsfile.** A pytest test that loads the file and runs the Groovy parser via `groovy -e` if available; soft-skips when Groovy is not installed (so PRs without Groovy on the runner still pass).
+To make the shell script testable in isolation, it exposes two internal-only flags used by tests:
+
+- `--internal-resolve-params <new-template-summary.json> <current-stack-params.json>` — given two pre-fetched JSON blobs (instead of calling AWS), runs the parameter-resolution function and prints the resulting `parameters.json` to stdout. No AWS calls. No side effects. Pure data transform.
+- `--internal-classify-changeset-status <status> <status-reason>` — classifies a change set status into `success`, `noop`, or `failure`. No AWS calls.
+
+These flags are documented as test hooks only and are not part of the public CLI surface.
+
+Tests:
+
+- **Unit, parameter resolution** (`tests/unit/test_upgrade_lakerunner.py`). Each pytest case writes JSON fixtures to a temp dir, invokes the script via `subprocess` with `--internal-resolve-params`, captures stdout, and asserts on the JSON. Coverage: all four resolution rules (image refresh, carry forward, take new default, hard fail) plus the `--no-refresh-image-defaults` variant.
+- **Unit, no-op detection.** Same harness, calling `--internal-classify-changeset-status` with each documented AWS phrasing for empty change sets, plus a real failure phrasing.
+- **Lint, shell.** `shellcheck scripts/upgrade-lakerunner.sh` run from a pytest test that soft-skips if `shellcheck` is not on PATH (so contributor environments without shellcheck still pass).
+- **Lint, Jenkinsfile.** A pytest test that runs `groovy -e` against the file if Groovy is available; soft-skips when not.
 - **No live AWS test.** The `aws cloudformation` surface is well-trusted; integration tests against real stacks are out of scope.
 
 The Makefile gains a `make test-jenkins` target that runs the new tests in isolation, and `make check` (the pre-push gate) includes them via the existing test runner.

--- a/docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md
@@ -1,0 +1,161 @@
+# Jenkins lakerunner stack upgrade — design
+
+Date: 2026-05-01
+
+## Goal
+
+Ship a Jenkins job template plus an extracted driving script that customers (and Cardinal itself) use to safely upgrade an existing `cardinal-lakerunner` CloudFormation stack to a newer published template version. Design favors the common case — published templates ship with refreshed image defaults — while leaving every other parameter untouched.
+
+Multiple installs are managed by copying the Jenkinsfile per install and editing the parameter defaults at the top. There is one Jenkins job per install.
+
+## Deliverables
+
+- `scripts/upgrade_lakerunner.py` — Python driving script that does the actual deploy and reports success or failure via exit code.
+- `jenkins/Jenkinsfile.upgrade-lakerunner` — declarative Jenkins pipeline that binds AWS credentials and invokes the script.
+- `docs/operations/jenkins-upgrade.md` — operator documentation.
+- `tests/unit/test_upgrade_lakerunner.py` — unit tests covering parameter resolution and no-op detection.
+
+## Non-goals
+
+- Multi-install orchestration (sequential dev → staging → prod rollout). Out of scope; each install is its own job.
+- Slack / email / chat notifications.
+- Multi-region simultaneous upgrade.
+- Rotation of sensitive parameters (`LicenseData`, `ApiKeysOverride`, `StorageProfilesOverride`). They carry forward via `UsePreviousValue=true`.
+- Drift detection.
+- Application-level health probes after the upgrade. Confirmation is "did CloudFormation reach `UPDATE_COMPLETE`" — nothing more.
+- A standalone Cardinal-internal pipeline. The customer-facing template is the canonical artifact and Cardinal uses it directly.
+- New runtime dependencies on the Jenkins worker beyond `python3`, `pyyaml` (already in `requirements.txt`), and the `aws` CLI.
+
+## Driving script — `scripts/upgrade_lakerunner.py`
+
+The script is the single source of truth for upgrade behavior. The Jenkinsfile is a thin wrapper around it.
+
+Implemented in Python because the parameter-resolution logic is non-trivial and benefits from pytest coverage. It shells out to the `aws` CLI for all AWS API calls, avoiding a `boto3` dependency. It uses `pyyaml` to parse the new template (already in `requirements.txt`).
+
+### Inputs
+
+Every input is provided as a long-form flag. Flags that are also exposed as Jenkins job parameters share names (kebab-case for flags, PascalCase in Jenkins) and meaning.
+
+| Flag | Required | Default | Purpose |
+|---|---|---|---|
+| `--stack-name` | yes | — | Existing stack to upgrade |
+| `--region` | yes | — | AWS region of the stack |
+| `--template-base-url` | no | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` | Published template prefix; override for air-gapped mirrors |
+| `--version` | no | `latest` | Path segment between the base URL and `cardinal-lakerunner.yaml` |
+| `--deployer-role-arn` | no | (empty) | When set, passed via `--role-arn` to all CloudFormation calls |
+| `--refresh-image-defaults` / `--no-refresh-image-defaults` | no | refresh on | When on, parameters whose name ends in `Image` take the new template's defaults; when off, they carry forward |
+| `--no-execute` | no | (off) | Create and describe the change set, then stop without executing. Leaves the change set in place for inspection |
+
+The script reads `AWS_*` environment variables for credentials. It does not touch `~/.aws/credentials`.
+
+### Behavior
+
+The script runs these stages in order. Any non-zero result from a stage aborts the script with a clear error pointing at the failed stage.
+
+1. **Validate inputs.** Confirm required flags are present and `aws --version` runs. Confirm `--stack-name` exists in `--region` via `describe-stacks`. If the stack doesn't exist, exit code 2 — this script does upgrades, not initial creates.
+
+2. **Resolve template URL.** `${template_base_url}/${version}/cardinal-lakerunner.yaml`. Probe with an HTTP HEAD; abort on 404.
+
+3. **Fetch new template** to a temp file and parse its `Parameters` block with `pyyaml`. Capture each parameter's name, default (or absence of default), and type.
+
+4. **Resolve parameters.** Walk the new template's parameter list. For each parameter, choose exactly one of these outcomes:
+
+   1. **Refresh image default.** Name ends in `Image`, `--refresh-image-defaults` is on, and the new template declares a default. Result: `{ParameterKey, ParameterValue=<new template default>}`.
+   2. **Carry forward.** The parameter exists in the current stack's parameter set (per `describe-stacks`). Result: `{ParameterKey, UsePreviousValue=true}`.
+   3. **Take new default.** The parameter is new in the new template (didn't exist in the current stack) and the new template declares a default. Result: `{ParameterKey, ParameterValue=<new template default>}`.
+   4. **Hard fail.** None of the above. Exit non-zero with a message naming the parameter and explaining the operator must supply a value.
+
+   The script never sets `--use-previous-parameters`; every decision is explicit and visible in the resolved `parameters.json`.
+
+5. **Create change set.** `aws cloudformation create-change-set --change-set-type UPDATE` with the resolved parameters. Change set name is `cardinal-upgrade-<unix-timestamp>` so cleanup logic can identify and remove change sets created by this script. Pass `--role-arn` when set. Wait for the change set to reach a terminal state.
+
+   - Terminal `CREATE_COMPLETE`: proceed.
+   - Terminal `FAILED` whose `StatusReason` contains the no-op marker (AWS uses several phrasings; the script matches a small set including `didn't contain changes` and `The submitted information didn't contain changes`): delete the change set and exit success. No-op upgrades are normal and quiet.
+   - Any other terminal state: delete the change set and exit non-zero with the AWS-supplied reason.
+
+6. **Describe and print change set summary.** Always print the resource changes — additions, modifications, replacements, removals — to stdout via `aws cloudformation describe-change-set`. Always printed regardless of `--no-execute`.
+
+7. **Stop here on `--no-execute`.** Do not delete the change set. Print its name and ARN so the operator can inspect or execute it manually. Exit success.
+
+8. **Execute change set.** `aws cloudformation execute-change-set`, then `aws cloudformation wait stack-update-complete`. The waiter exits non-zero if the stack lands in any state other than `UPDATE_COMPLETE`.
+
+9. **Cleanup on abort.** If any stage between 5 and 8 fails or the script is interrupted, attempt a best-effort `delete-change-set`. Failure to delete the change set does not change the script's exit code.
+
+10. **Print stack outputs** on success — `AlbDnsName`, `MaestroUrl`, `QueryApiUrl`, etc.
+
+### Exit codes
+
+- `0` — change set executed and stack reached `UPDATE_COMPLETE`, or change set was a no-op, or `--no-execute` completed.
+- `1` — generic error (AWS API failure, change set failed, stack ended in a non-`UPDATE_COMPLETE` state).
+- `2` — input validation failure (missing flag, stack not found, parameter has no resolvable value).
+
+CloudFormation does its own automatic rollback on update failure; the per-service deployment circuit breaker (already configured in the stack) handles bad image deploys at the ECS level. The script does not implement its own rollback.
+
+## Jenkinsfile — `jenkins/Jenkinsfile.upgrade-lakerunner`
+
+A declarative pipeline. Customers copy this file once per install and edit the `parameters {}` defaults at the top to match that install's stack name, region, and credentials binding ID.
+
+### Job parameters
+
+| Parameter | Type | Default | Notes |
+|---|---|---|---|
+| `StackName` | string | `cardinal-lakerunner` | Edit per install |
+| `Region` | string | `us-east-2` | Edit per install |
+| `TemplateBaseUrl` | string | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` | Edit for air-gapped customers |
+| `Version` | string | `latest` | Use a pinned version (`v1.20.0`) for reproducibility |
+| `DeployerRoleArn` | string | (empty) | Strongly recommended; see `docs/operations/deploying.md` |
+| `AutoApprove` | bool | `true` | When `false`, the pipeline pauses at a Jenkins `input` step after the change set is described |
+| `RefreshImageDefaults` | bool | `true` | Pass through to the script |
+| `AwsCredentialsId` | string | `aws-cardinal-deploy` | Jenkins AWS Credentials plugin binding ID |
+
+### Stages
+
+1. **Setup** — `withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AwsCredentialsId]])`. Verify `aws` and `python3` are on PATH.
+2. **Plan** — invoke `python3 scripts/upgrade_lakerunner.py --no-execute ...`. The build log captures the change set summary. Always runs.
+3. **Approval** — only when `params.AutoApprove == false`: a Jenkins `input` step. Skipped entirely when `true` (no human required).
+4. **Apply** — invoke the script again *without* `--no-execute`. The script's no-op detector ensures this second run is cheap when the Plan stage already created an equivalent change set, and the operator (or auto-approval) is committing to applying whatever the live state requires at apply time.
+5. **Post (always)** — best-effort cleanup pass: list change sets on the stack and `delete-change-set` any whose name starts with `cardinal-upgrade-` and is still in a pending (non-executed) state.
+
+### Why two full script invocations rather than create-then-execute the same change set?
+
+Reusing a change set across stages requires the Jenkinsfile to track the change set ARN and pass it to a separate `execute-change-set` step. That spreads the upgrade logic across the script and the Jenkinsfile. Re-running the script keeps each invocation self-contained and the Jenkinsfile trivial. The cost is a few extra seconds for the second `create-change-set`; the benefit is that the script remains the single source of truth for upgrade behavior. Customers who need stronger plan-vs-apply equivalence pin `Version` so the template body cannot drift between the two runs.
+
+### Failure surfacing
+
+The script's exit code is the build's exit code. Jenkins shows the build red on any non-zero exit. The script's stderr is captured in the build log.
+
+## Operator documentation — `docs/operations/jenkins-upgrade.md`
+
+Covers:
+
+- Pre-reqs (AWS Credentials plugin, deployer role, Jenkins agent with `aws` CLI and `python3` available, `pyyaml` available).
+- Per-install setup: copy the Jenkinsfile, set the parameter defaults at the top, point a Jenkins job at it.
+- AWS auth alternatives: AWS Credentials plugin (default), IAM instance profile on the worker, assume-role from the worker.
+- Air-gapped variant: customer-mirrored `TemplateBaseUrl` plus image override parameters.
+- How to read a change set summary in the build log.
+- Recovery if the upgrade lands in `UPDATE_FAILED` or `UPDATE_ROLLBACK_COMPLETE` (re-run with the same or fixed parameters; CFN's automatic rollback restores the previous state on most failures).
+- Pinning a version vs. tracking `latest`.
+
+## Testing
+
+- **Unit, parameter resolution.** Pure-function pytest of the resolution function. Inputs: a fixture template parsed dict, a fixture current-stack parameters list, the resolution flags. Output: the expected `parameters.json` array. Covers all four resolution rules and a known-bad case (rule 4 hard-fail).
+- **Unit, no-op detection.** Feed the no-op detector each documented `StatusReason` phrasing AWS has used for empty change sets, plus a real failure phrasing. Assert the function classifies them correctly.
+- **Lint, Jenkinsfile.** A pytest test that loads the file and runs the Groovy parser via `groovy -e` if available; soft-skips when Groovy is not installed (so PRs without Groovy on the runner still pass).
+- **No live AWS test.** The `aws cloudformation` surface is well-trusted; integration tests against real stacks are out of scope.
+
+The Makefile gains a `make test-jenkins` target that runs the new tests in isolation, and `make check` (the pre-push gate) includes them via the existing test runner.
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|---|---|
+| New template adds a required parameter with no default | Resolution rule 4 fails with a clear error naming the parameter; operator either pins to a previous version, supplies it via a future job parameter, or runs the underlying `aws cloudformation update-stack` once with the new value |
+| Change set creation succeeds but execution races with another in-flight update | The `wait stack-update-complete` waiter surfaces this as a non-zero exit; operator re-runs after the other update settles |
+| Operator runs the job against the wrong account | `DeployerRoleArn` is account-scoped; `StackName` and `Region` are explicit per job; the script prints the resolved AWS account ID before any mutation |
+| `latest` template silently changes between Plan and Apply | Customers who need stronger guarantees pin `Version`. The risk is small in practice because publishing a new `latest` mid-upgrade is a Cardinal-side operational rarity |
+| Bad image tag bricks a service | ECS deployment circuit breaker (already in the stack) rolls the failed service back; the stack lands in `UPDATE_ROLLBACK_COMPLETE`; script exits non-zero; build is red |
+| Pending change sets accumulate over time | The Post stage of the Jenkinsfile deletes pending change sets on the stack whose name starts with `cardinal-upgrade-` |
+
+## Out of scope but worth noting
+
+A future per-install `params.json` checked into a separate config repo, or a future multi-install orchestrator that calls this job in sequence per install, both layer cleanly on top of this design without changing the script's interface.

--- a/docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md
+++ b/docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md
@@ -59,13 +59,15 @@ The script reads `AWS_*` environment variables for credentials. It does not touc
 
 The script runs these stages in order. Any non-zero result from a stage aborts the script with a clear error pointing at the failed stage.
 
-1. **Validate inputs.** Confirm required flags are present and `aws --version` runs. Confirm `--stack-name` exists in `--region` via `describe-stacks`. If the stack doesn't exist, exit code 2 — this script does upgrades, not initial creates.
+1. **Pre-flight tool check.** The script's first action, before parsing flags or making AWS calls. It runs `aws --version`, `jq --version`, and `curl --version` (each piped to `>/dev/null 2>&1`) and on any failure exits code 2 with a single-line message naming the missing tool and a hint at how to install it on the common runner OSes (`apt-get install jq`, `yum install jq`, `apk add jq`, etc.). This is the bulkhead that turns "missing tool" into an obvious operator error rather than a confusing failure halfway through the upgrade.
 
-2. **Resolve template URL.** `${template_base_url}/${version}/cardinal-lakerunner.yaml`. Probe with an HTTP HEAD; abort on 404.
+2. **Validate inputs.** Confirm required flags are present. Confirm `--stack-name` exists in `--region` via `describe-stacks`. If the stack doesn't exist, exit code 2 — this script does upgrades, not initial creates.
 
-3. **Discover new template parameters.** `aws cloudformation get-template-summary --template-url <resolved url> --query 'Parameters'` returns the new template's parameter schema as JSON: name, type, default (when present), `NoEcho` flag. No local YAML parsing.
+3. **Resolve template URL.** `${template_base_url}/${version}/cardinal-lakerunner.yaml`. Probe with an HTTP HEAD; abort on 404.
 
-4. **Resolve parameters.** Walk the new template's parameter list. For each parameter, choose exactly one of these outcomes:
+4. **Discover new template parameters.** `aws cloudformation get-template-summary --template-url <resolved url> --query 'Parameters'` returns the new template's parameter schema as JSON: name, type, default (when present), `NoEcho` flag. No local YAML parsing.
+
+5. **Resolve parameters.** Walk the new template's parameter list. For each parameter, choose exactly one of these outcomes:
 
    1. **Refresh image default.** Name ends in `Image`, `--refresh-image-defaults` is on, and the new template declares a default. Result: `{ParameterKey, ParameterValue=<new template default>}`.
    2. **Carry forward.** The parameter exists in the current stack's parameter set (per `describe-stacks`). Result: `{ParameterKey, UsePreviousValue=true}`.
@@ -74,27 +76,27 @@ The script runs these stages in order. Any non-zero result from a stage aborts t
 
    The script never sets `--use-previous-parameters`; every decision is explicit and visible in the resolved `parameters.json`.
 
-5. **Create change set.** `aws cloudformation create-change-set --change-set-type UPDATE` with the resolved parameters. Change set name is `cardinal-upgrade-<unix-timestamp>` so cleanup logic can identify and remove change sets created by this script. Pass `--role-arn` when set. Wait for the change set to reach a terminal state.
+6. **Create change set.** `aws cloudformation create-change-set --change-set-type UPDATE` with the resolved parameters. Change set name is `cardinal-upgrade-<unix-timestamp>` so cleanup logic can identify and remove change sets created by this script. Pass `--role-arn` when set. Wait for the change set to reach a terminal state.
 
    - Terminal `CREATE_COMPLETE`: proceed.
    - Terminal `FAILED` whose `StatusReason` contains the no-op marker (AWS uses several phrasings; the script matches a small set including `didn't contain changes` and `The submitted information didn't contain changes`): delete the change set and exit success. No-op upgrades are normal and quiet.
    - Any other terminal state: delete the change set and exit non-zero with the AWS-supplied reason.
 
-6. **Describe and print change set summary.** Always print the resource changes — additions, modifications, replacements, removals — to stdout via `aws cloudformation describe-change-set`. Always printed regardless of `--no-execute`.
+7. **Describe and print change set summary.** Always print the resource changes — additions, modifications, replacements, removals — to stdout via `aws cloudformation describe-change-set`. Always printed regardless of `--no-execute`.
 
-7. **Stop here on `--no-execute`.** Do not delete the change set. Print its name and ARN so the operator can inspect or execute it manually. Exit success.
+8. **Stop here on `--no-execute`.** Do not delete the change set. Print its name and ARN so the operator can inspect or execute it manually. Exit success.
 
-8. **Execute change set.** `aws cloudformation execute-change-set`, then `aws cloudformation wait stack-update-complete`. The waiter exits non-zero if the stack lands in any state other than `UPDATE_COMPLETE`.
+9. **Execute change set.** `aws cloudformation execute-change-set`, then `aws cloudformation wait stack-update-complete`. The waiter exits non-zero if the stack lands in any state other than `UPDATE_COMPLETE`.
 
-9. **Cleanup on abort.** If any stage between 5 and 8 fails or the script is interrupted, attempt a best-effort `delete-change-set`. Failure to delete the change set does not change the script's exit code.
+10. **Cleanup on abort.** If any stage between 6 and 9 fails or the script is interrupted, attempt a best-effort `delete-change-set`. Failure to delete the change set does not change the script's exit code.
 
-10. **Print stack outputs** on success — `AlbDnsName`, `MaestroUrl`, `QueryApiUrl`, etc.
+11. **Print stack outputs** on success — `AlbDnsName`, `MaestroUrl`, `QueryApiUrl`, etc.
 
 ### Exit codes
 
 - `0` — change set executed and stack reached `UPDATE_COMPLETE`, or change set was a no-op, or `--no-execute` completed.
 - `1` — generic error (AWS API failure, change set failed, stack ended in a non-`UPDATE_COMPLETE` state).
-- `2` — input validation failure (missing flag, stack not found, parameter has no resolvable value).
+- `2` — pre-flight or input validation failure (missing tool, missing flag, stack not found, parameter has no resolvable value).
 
 CloudFormation does its own automatic rollback on update failure; the per-service deployment circuit breaker (already configured in the stack) handles bad image deploys at the ECS level. The script does not implement its own rollback.
 
@@ -117,7 +119,7 @@ A declarative pipeline. Customers copy this file once per install and edit the `
 
 ### Stages
 
-1. **Setup** — `withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AwsCredentialsId]])`. Verify `aws`, `jq`, and `curl` are on PATH.
+1. **Setup** — `withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AwsCredentialsId]])`. The script's pre-flight check handles tool verification; the Jenkinsfile does not duplicate it.
 2. **Plan** — invoke `sh scripts/upgrade-lakerunner.sh --no-execute ...`. The build log captures the change set summary. Always runs.
 3. **Approval** — only when `params.AutoApprove == false`: a Jenkins `input` step. Skipped entirely when `true` (no human required).
 4. **Apply** — invoke the script again *without* `--no-execute`. The script's no-op detector ensures this second run is cheap when the Plan stage already created an equivalent change set, and the operator (or auto-approval) is committing to applying whatever the live state requires at apply time.

--- a/jenkins/Jenkinsfile.upgrade-lakerunner
+++ b/jenkins/Jenkinsfile.upgrade-lakerunner
@@ -1,0 +1,158 @@
+// Jenkins pipeline that upgrades a single cardinal-lakerunner CloudFormation
+// stack via scripts/upgrade-lakerunner.sh.
+//
+// Per-install setup: copy this file into a Jenkins job (Pipeline script from
+// SCM), then edit the parameter defaults below to match that install's stack
+// name, region, and credentials binding ID.  All upgrade behaviour lives in
+// the shell script; this file is a thin wrapper.
+//
+// See docs/operations/jenkins-upgrade.md for prerequisites and usage.
+
+pipeline {
+    agent any
+
+    parameters {
+        string(
+            name: 'StackName',
+            defaultValue: 'cardinal-lakerunner',
+            description: 'Existing CloudFormation stack to upgrade.'
+        )
+        string(
+            name: 'Region',
+            defaultValue: 'us-east-2',
+            description: 'AWS region of the stack.'
+        )
+        string(
+            name: 'TemplateBaseUrl',
+            defaultValue: 'https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner',
+            description: 'Published template prefix.  Override for air-gapped mirrors.'
+        )
+        string(
+            name: 'Version',
+            defaultValue: 'latest',
+            description: 'Template version to upgrade to.  Pin to a specific tag (e.g. v1.20.0) for reproducibility.'
+        )
+        string(
+            name: 'DeployerRoleArn',
+            defaultValue: '',
+            description: 'Optional CloudFormation service role ARN (--role-arn).  Strongly recommended; see docs/operations/deploying.md.'
+        )
+        booleanParam(
+            name: 'AutoApprove',
+            defaultValue: true,
+            description: 'When false, the pipeline pauses for manual approval after the change set is described.'
+        )
+        booleanParam(
+            name: 'RefreshImageDefaults',
+            defaultValue: true,
+            description: 'When true, *Image parameters take the new template defaults.  When false, they carry forward.'
+        )
+        string(
+            name: 'AwsCredentialsId',
+            defaultValue: 'aws-cardinal-deploy',
+            description: 'Jenkins AWS Credentials plugin binding ID.'
+        )
+    }
+
+    options {
+        timestamps()
+        disableConcurrentBuilds()
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    stages {
+        stage('Setup') {
+            steps {
+                script {
+                    if (!params.StackName?.trim()) {
+                        error('StackName is required.')
+                    }
+                    if (!params.Region?.trim()) {
+                        error('Region is required.')
+                    }
+                }
+                echo "Stack: ${params.StackName}  Region: ${params.Region}  Version: ${params.Version}"
+            }
+        }
+
+        stage('Plan') {
+            steps {
+                withCredentials([[
+                    $class: 'AmazonWebServicesCredentialsBinding',
+                    credentialsId: params.AwsCredentialsId
+                ]]) {
+                    sh """
+                        sh scripts/upgrade-lakerunner.sh \\
+                            --stack-name '${params.StackName}' \\
+                            --region '${params.Region}' \\
+                            --template-base-url '${params.TemplateBaseUrl}' \\
+                            --version '${params.Version}' \\
+                            ${params.DeployerRoleArn ? "--deployer-role-arn '${params.DeployerRoleArn}'" : ''} \\
+                            ${params.RefreshImageDefaults ? '--refresh-image-defaults' : '--no-refresh-image-defaults'} \\
+                            --no-execute
+                    """
+                }
+            }
+        }
+
+        stage('Approval') {
+            when {
+                expression { return !params.AutoApprove }
+            }
+            steps {
+                input(message: 'Apply this change set?', ok: 'Apply')
+            }
+        }
+
+        stage('Apply') {
+            steps {
+                withCredentials([[
+                    $class: 'AmazonWebServicesCredentialsBinding',
+                    credentialsId: params.AwsCredentialsId
+                ]]) {
+                    sh """
+                        sh scripts/upgrade-lakerunner.sh \\
+                            --stack-name '${params.StackName}' \\
+                            --region '${params.Region}' \\
+                            --template-base-url '${params.TemplateBaseUrl}' \\
+                            --version '${params.Version}' \\
+                            ${params.DeployerRoleArn ? "--deployer-role-arn '${params.DeployerRoleArn}'" : ''} \\
+                            ${params.RefreshImageDefaults ? '--refresh-image-defaults' : '--no-refresh-image-defaults'}
+                    """
+                }
+            }
+        }
+    }
+
+    post {
+        always {
+            // Best-effort cleanup of leftover plan-only change sets created
+            // by this job.  Fails silently if AWS calls fail; the build status
+            // is determined by the upgrade itself, not the cleanup.
+            withCredentials([[
+                $class: 'AmazonWebServicesCredentialsBinding',
+                credentialsId: params.AwsCredentialsId
+            ]]) {
+                sh """
+                    set +e
+                    aws cloudformation list-change-sets \\
+                        --stack-name '${params.StackName}' \\
+                        --region '${params.Region}' \\
+                        --query "Summaries[?starts_with(ChangeSetName, 'cardinal-upgrade-') && (Status=='CREATE_COMPLETE' || Status=='CREATE_PENDING')].ChangeSetName" \\
+                        --output text 2>/dev/null \\
+                    | tr '\\t' '\\n' \\
+                    | while read cs; do
+                        if [ -n "\$cs" ]; then
+                            echo "cleanup: deleting pending change set \$cs"
+                            aws cloudformation delete-change-set \\
+                                --stack-name '${params.StackName}' \\
+                                --change-set-name "\$cs" \\
+                                --region '${params.Region}' >/dev/null 2>&1 || true
+                        fi
+                    done
+                    exit 0
+                """
+            }
+        }
+    }
+}

--- a/scripts/upgrade-lakerunner.sh
+++ b/scripts/upgrade-lakerunner.sh
@@ -1,0 +1,397 @@
+#!/bin/sh
+# Safely upgrade an existing cardinal-lakerunner CloudFormation stack to a
+# newer published template version.
+#
+# Self-contained: depends only on a POSIX shell, the AWS CLI v2, jq, and curl.
+# Does not depend on the cardinal_cfn Python package or any other contents of
+# the lakerunner-cloudformation repo.
+#
+# See docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md for the
+# full design.
+
+set -eu
+
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_VERSION="latest"
+CHANGE_SET_PREFIX="cardinal-upgrade-"
+
+stack_name=""
+region=""
+template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
+version="$DEFAULT_VERSION"
+deployer_role_arn=""
+refresh_image_defaults="true"
+no_execute="false"
+internal_resolve_params=""
+internal_resolve_params_arg2=""
+internal_classify_status=""
+internal_classify_reason=""
+
+# State held across stages so the abort handler can clean up.
+change_set_name=""
+work_dir=""
+
+usage() {
+    cat <<'EOF'
+Usage: upgrade-lakerunner.sh [options]
+
+Required:
+  --stack-name NAME           Existing stack to upgrade.
+  --region    REGION          AWS region of the stack.
+
+Optional:
+  --template-base-url URL     Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
+  --version VERSION           Default: latest
+  --deployer-role-arn ARN     Pass via --role-arn to all CloudFormation calls.
+  --no-refresh-image-defaults Carry image params forward instead of taking new template defaults.
+  --no-execute                Create and describe the change set, then stop.
+
+Exit codes:
+  0  success or no-op
+  1  generic / AWS / change set failure
+  2  pre-flight / input validation failure
+EOF
+}
+
+log() {
+    printf '[%s] %s\n' "upgrade-lakerunner" "$*" >&2
+}
+
+fail() {
+    code="$1"
+    shift
+    printf '[upgrade-lakerunner] ERROR: %s\n' "$*" >&2
+    exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: pure parameter-resolution function used by tests and by the main
+# pipeline.  Reads two JSON files, prints the resolved parameters list to
+# stdout.
+# ---------------------------------------------------------------------------
+resolve_params() {
+    new_template_file="$1"
+    current_stack_file="$2"
+    refresh_images="$3"
+
+    if [ ! -r "$new_template_file" ]; then
+        fail 2 "cannot read template-summary file: $new_template_file"
+    fi
+    if [ ! -r "$current_stack_file" ]; then
+        fail 2 "cannot read current-stack-params file: $current_stack_file"
+    fi
+
+    # Build the resolved parameter list.  jq does the per-rule branching.
+    resolved=$(jq -nc \
+        --slurpfile newp "$new_template_file" \
+        --slurpfile curp "$current_stack_file" \
+        --arg refresh "$refresh_images" \
+        '
+        ($newp[0] // []) as $newparams
+        | ($curp[0] // []) as $current
+        | ($current | map({(.ParameterKey): .ParameterValue}) | add // {}) as $current_by_key
+        | $newparams
+        | map(
+            . as $p
+            | $p.ParameterKey as $k
+            | (($k | endswith("Image")) and ($refresh == "true") and (has("DefaultValue"))) as $rule_image_refresh
+            | ($current_by_key | has($k)) as $rule_carry
+            | (has("DefaultValue")) as $rule_new_default
+            | if $rule_image_refresh then
+                {ParameterKey: $k, ParameterValue: $p.DefaultValue}
+              elif $rule_carry then
+                {ParameterKey: $k, UsePreviousValue: true}
+              elif $rule_new_default then
+                {ParameterKey: $k, ParameterValue: $p.DefaultValue}
+              else
+                {ParameterKey: $k, _missing: true}
+              end
+          )
+        '
+    )
+
+    # Detect missing parameters (rule 4 hard-fail).
+    missing=$(printf '%s' "$resolved" | jq -r '[.[] | select(._missing == true) | .ParameterKey] | join(", ")')
+    if [ -n "$missing" ]; then
+        fail 2 "new template requires values for parameter(s) with no default and no current value: $missing"
+    fi
+
+    printf '%s\n' "$resolved" | jq '.'
+}
+
+# ---------------------------------------------------------------------------
+# Internal: classify a change set status + reason as one of {success, noop,
+# failure}.  Used by tests and by the main pipeline.
+# ---------------------------------------------------------------------------
+classify_status() {
+    status="$1"
+    reason="$2"
+
+    case "$status" in
+        CREATE_COMPLETE)
+            printf 'success\n'
+            return 0
+            ;;
+    esac
+
+    # AWS reports several phrasings when a change set has no actual changes.
+    # Match the common ones.
+    case "$reason" in
+        *"didn't contain changes"*|*"No updates are to be performed"*)
+            printf 'noop\n'
+            return 0
+            ;;
+    esac
+
+    printf 'failure\n'
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight tool check.  First action; clear errors when a tool is missing.
+# ---------------------------------------------------------------------------
+preflight() {
+    missing=""
+    for tool in aws jq curl; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            missing="$missing $tool"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        cat >&2 <<EOF
+[upgrade-lakerunner] ERROR: required tool(s) not found:$missing
+Install hints:
+  Debian/Ubuntu : sudo apt-get install -y awscli jq curl
+  Amazon Linux  : sudo yum install -y aws-cli jq curl
+  Alpine        : sudo apk add aws-cli jq curl
+  macOS (brew)  : brew install awscli jq curl
+EOF
+        exit 2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# CFN call wrapper that adds --role-arn when configured.
+# ---------------------------------------------------------------------------
+cfn() {
+    if [ -n "$deployer_role_arn" ]; then
+        aws cloudformation "$@" --role-arn "$deployer_role_arn"
+    else
+        aws cloudformation "$@"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Best-effort cleanup on abort.
+# ---------------------------------------------------------------------------
+cleanup() {
+    rc=$?
+    if [ "$rc" -ne 0 ] && [ -n "$change_set_name" ] && [ -n "$stack_name" ] && [ -n "$region" ]; then
+        log "cleanup: deleting change set $change_set_name"
+        aws cloudformation delete-change-set \
+            --stack-name "$stack_name" \
+            --change-set-name "$change_set_name" \
+            --region "$region" >/dev/null 2>&1 || true
+    fi
+    if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+        rm -rf "$work_dir"
+    fi
+    exit "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Main pipeline.
+# ---------------------------------------------------------------------------
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --stack-name) stack_name="$2"; shift 2 ;;
+            --region) region="$2"; shift 2 ;;
+            --template-base-url) template_base_url="$2"; shift 2 ;;
+            --version) version="$2"; shift 2 ;;
+            --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
+            --refresh-image-defaults) refresh_image_defaults="true"; shift ;;
+            --no-refresh-image-defaults) refresh_image_defaults="false"; shift ;;
+            --no-execute) no_execute="true"; shift ;;
+            --internal-resolve-params)
+                internal_resolve_params="$2"
+                internal_resolve_params_arg2="$3"
+                shift 3
+                ;;
+            --internal-classify-changeset-status)
+                internal_classify_status="$2"
+                internal_classify_reason="$3"
+                shift 3
+                ;;
+            -h|--help) usage; exit 0 ;;
+            *) fail 2 "unknown argument: $1" ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    # Internal test hooks.  These do not touch AWS and bypass the rest of the
+    # pipeline.  jq is required; aws and curl are not.
+    if [ -n "$internal_resolve_params" ]; then
+        if ! command -v jq >/dev/null 2>&1; then
+            fail 2 "jq is required for --internal-resolve-params"
+        fi
+        resolve_params \
+            "$internal_resolve_params" \
+            "$internal_resolve_params_arg2" \
+            "$refresh_image_defaults"
+        return 0
+    fi
+    if [ -n "$internal_classify_status" ]; then
+        classify_status "$internal_classify_status" "$internal_classify_reason"
+        return 0
+    fi
+
+    preflight
+
+    if [ -z "$stack_name" ] || [ -z "$region" ]; then
+        usage >&2
+        fail 2 "--stack-name and --region are required"
+    fi
+
+    log "verifying stack $stack_name exists in $region"
+    if ! aws cloudformation describe-stacks \
+            --stack-name "$stack_name" \
+            --region "$region" >/dev/null 2>&1; then
+        fail 2 "stack '$stack_name' not found in region '$region'"
+    fi
+
+    account_id=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "unknown")
+    log "AWS account: $account_id  region: $region  stack: $stack_name"
+
+    template_url="$template_base_url/$version/cardinal-lakerunner.yaml"
+    log "resolving template: $template_url"
+    if ! curl -sIfL "$template_url" >/dev/null; then
+        fail 1 "template URL not reachable (HTTP HEAD failed): $template_url"
+    fi
+
+    work_dir=$(mktemp -d)
+
+    log "fetching new template parameter schema via get-template-summary"
+    cfn get-template-summary \
+        --template-url "$template_url" \
+        --region "$region" \
+        --query 'Parameters' \
+        --output json >"$work_dir/new-params.json"
+
+    log "fetching current stack parameters"
+    aws cloudformation describe-stacks \
+        --stack-name "$stack_name" \
+        --region "$region" \
+        --query 'Stacks[0].Parameters' \
+        --output json >"$work_dir/current-params.json"
+
+    log "resolving parameters (refresh-image-defaults=$refresh_image_defaults)"
+    resolve_params \
+        "$work_dir/new-params.json" \
+        "$work_dir/current-params.json" \
+        "$refresh_image_defaults" \
+        >"$work_dir/parameters.json"
+
+    change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
+    log "creating change set: $change_set_name"
+    cfn create-change-set \
+        --stack-name "$stack_name" \
+        --change-set-name "$change_set_name" \
+        --change-set-type UPDATE \
+        --template-url "$template_url" \
+        --parameters "file://$work_dir/parameters.json" \
+        --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
+        --region "$region" >/dev/null
+
+    log "waiting for change set to reach a terminal state"
+    # The waiter exits non-zero on FAILED; we handle that ourselves so we can
+    # distinguish no-op from real failure.
+    aws cloudformation wait change-set-create-complete \
+        --stack-name "$stack_name" \
+        --change-set-name "$change_set_name" \
+        --region "$region" >/dev/null 2>&1 || true
+
+    cs_status=$(aws cloudformation describe-change-set \
+        --stack-name "$stack_name" \
+        --change-set-name "$change_set_name" \
+        --region "$region" \
+        --query 'Status' --output text)
+    cs_reason=$(aws cloudformation describe-change-set \
+        --stack-name "$stack_name" \
+        --change-set-name "$change_set_name" \
+        --region "$region" \
+        --query 'StatusReason' --output text 2>/dev/null || echo "")
+
+    classification=$(classify_status "$cs_status" "$cs_reason")
+    case "$classification" in
+        noop)
+            log "change set is a no-op; nothing to apply"
+            aws cloudformation delete-change-set \
+                --stack-name "$stack_name" \
+                --change-set-name "$change_set_name" \
+                --region "$region" >/dev/null 2>&1 || true
+            change_set_name=""
+            return 0
+            ;;
+        failure)
+            fail 1 "change set $change_set_name failed: status=$cs_status reason=$cs_reason"
+            ;;
+    esac
+
+    log "change set summary:"
+    aws cloudformation describe-change-set \
+        --stack-name "$stack_name" \
+        --change-set-name "$change_set_name" \
+        --region "$region" \
+        --query 'Changes[*].ResourceChange.{Action:Action,Type:ResourceType,Logical:LogicalResourceId,Replacement:Replacement}' \
+        --output table
+
+    if [ "$no_execute" = "true" ]; then
+        cs_arn=$(aws cloudformation describe-change-set \
+            --stack-name "$stack_name" \
+            --change-set-name "$change_set_name" \
+            --region "$region" \
+            --query 'ChangeSetId' --output text)
+        log "--no-execute set; leaving change set in place"
+        log "change set name: $change_set_name"
+        log "change set ARN:  $cs_arn"
+        change_set_name=""
+        return 0
+    fi
+
+    log "executing change set"
+    cfn execute-change-set \
+        --stack-name "$stack_name" \
+        --change-set-name "$change_set_name" \
+        --region "$region" >/dev/null
+
+    log "waiting for stack-update-complete"
+    if ! aws cloudformation wait stack-update-complete \
+            --stack-name "$stack_name" \
+            --region "$region"; then
+        final_status=$(aws cloudformation describe-stacks \
+            --stack-name "$stack_name" \
+            --region "$region" \
+            --query 'Stacks[0].StackStatus' --output text)
+        fail 1 "stack did not reach UPDATE_COMPLETE; final status: $final_status"
+    fi
+
+    change_set_name=""
+
+    log "stack outputs:"
+    aws cloudformation describe-stacks \
+        --stack-name "$stack_name" \
+        --region "$region" \
+        --query 'Stacks[0].Outputs' \
+        --output table
+
+    log "upgrade complete"
+    return 0
+}
+
+trap cleanup EXIT INT TERM HUP
+
+main "$@"

--- a/tests/unit/test_jenkinsfile_upgrade.py
+++ b/tests/unit/test_jenkinsfile_upgrade.py
@@ -1,0 +1,86 @@
+"""Lint and structural smoke tests for the upgrade Jenkinsfile.
+
+These tests soft-skip when Groovy is not installed, so contributors and CI
+runners without a Groovy parser are not blocked.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+JENKINSFILE = REPO_ROOT / "jenkins" / "Jenkinsfile.upgrade-lakerunner"
+
+
+def test_jenkinsfile_exists():
+    assert JENKINSFILE.exists(), f"missing {JENKINSFILE}"
+
+
+def test_jenkinsfile_balanced_braces():
+    """Cheap structural check that catches gross truncation or typos."""
+    text = JENKINSFILE.read_text()
+    # Quoted braces don't count - strip strings before counting. Quick-and-dirty.
+    cleaned = []
+    in_single = False
+    in_double = False
+    triple_double = False
+    i = 0
+    while i < len(text):
+        if not in_single and not in_double and text[i:i + 3] == '"""':
+            triple_double = not triple_double
+            i += 3
+            continue
+        if triple_double:
+            i += 1
+            continue
+        ch = text[i]
+        if ch == "'" and not in_double:
+            in_single = not in_single
+        elif ch == '"' and not in_single:
+            in_double = not in_double
+        elif not in_single and not in_double:
+            cleaned.append(ch)
+        i += 1
+    cleaned_text = "".join(cleaned)
+    assert cleaned_text.count("{") == cleaned_text.count("}"), (
+        f"unbalanced braces in {JENKINSFILE.name}"
+    )
+
+
+def test_jenkinsfile_required_blocks_present():
+    text = JENKINSFILE.read_text()
+    for marker in [
+        "pipeline {",
+        "parameters {",
+        "stage('Plan')",
+        "stage('Apply')",
+        "stage('Approval')",
+        "post {",
+        "scripts/upgrade-lakerunner.sh",
+        "AmazonWebServicesCredentialsBinding",
+    ]:
+        assert marker in text, f"Jenkinsfile missing expected block: {marker}"
+
+
+def test_groovy_parse_if_available():
+    if shutil.which("groovy") is None:
+        pytest.skip("groovy not installed on this runner")
+    # `groovy -e` evaluates a snippet; we can't easily do a parse-only mode for
+    # a Jenkinsfile (which depends on the Jenkins DSL).  Instead, wrap the file
+    # in a function so Groovy parses it without trying to execute the pipeline
+    # DSL methods.
+    wrapper = f"""
+def pipeline(Closure c) {{}}
+def parameters(Closure c) {{}}
+{JENKINSFILE.read_text()}
+"""
+    result = subprocess.run(
+        ["groovy", "-e", wrapper],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"groovy parse failed:\n{result.stdout}\n{result.stderr}"
+    )

--- a/tests/unit/test_upgrade_lakerunner.py
+++ b/tests/unit/test_upgrade_lakerunner.py
@@ -1,0 +1,274 @@
+"""Tests for the standalone upgrade-lakerunner.sh script.
+
+The script is shell + jq + AWS CLI. To keep its parameter-resolution logic
+testable without AWS or shellcheck-style guesswork, the script exposes two
+internal-only flags used by these tests:
+
+- --internal-resolve-params <new-template-params.json> <current-stack-params.json>
+- --internal-classify-changeset-status <status> <status-reason>
+
+Both run pure data transforms with no AWS calls and no side effects.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "upgrade-lakerunner.sh"
+
+
+def _write(path: Path, payload):
+    path.write_text(json.dumps(payload))
+
+
+def _run_resolve(tmp_path, new_template_params, current_stack_params, *extra_args):
+    new_path = tmp_path / "new.json"
+    cur_path = tmp_path / "cur.json"
+    _write(new_path, new_template_params)
+    _write(cur_path, current_stack_params)
+    result = subprocess.run(
+        [
+            "sh",
+            str(SCRIPT),
+            "--internal-resolve-params",
+            str(new_path),
+            str(cur_path),
+            *extra_args,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    return result
+
+
+def _by_key(parameters):
+    return {p["ParameterKey"]: p for p in parameters}
+
+
+def _require_jq():
+    if shutil.which("jq") is None:
+        pytest.skip("jq not installed on this runner")
+
+
+@pytest.fixture(autouse=True)
+def _script_exists():
+    if not SCRIPT.exists():
+        pytest.fail(
+            f"Script missing: {SCRIPT}. Implement it before running these tests."
+        )
+
+
+def test_image_param_takes_new_template_default_when_refresh_on(tmp_path):
+    _require_jq()
+    new_template = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "DefaultValue": "public.ecr.aws/cardinalhq/lakerunner:1.20.0",
+            "ParameterType": "String",
+        }
+    ]
+    current = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "ParameterValue": "public.ecr.aws/cardinalhq/lakerunner:1.19.2",
+        }
+    ]
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["LakerunnerImage"] == {
+        "ParameterKey": "LakerunnerImage",
+        "ParameterValue": "public.ecr.aws/cardinalhq/lakerunner:1.20.0",
+    }
+
+
+def test_image_param_carries_forward_when_refresh_off(tmp_path):
+    _require_jq()
+    new_template = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "DefaultValue": "public.ecr.aws/cardinalhq/lakerunner:1.20.0",
+            "ParameterType": "String",
+        }
+    ]
+    current = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "ParameterValue": "public.ecr.aws/cardinalhq/lakerunner:1.19.2",
+        }
+    ]
+    result = _run_resolve(
+        tmp_path, new_template, current, "--no-refresh-image-defaults"
+    )
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["LakerunnerImage"] == {
+        "ParameterKey": "LakerunnerImage",
+        "UsePreviousValue": True,
+    }
+
+
+def test_non_image_param_carries_forward(tmp_path):
+    _require_jq()
+    new_template = [
+        {"ParameterKey": "VpcId", "ParameterType": "AWS::EC2::VPC::Id"},
+    ]
+    current = [
+        {"ParameterKey": "VpcId", "ParameterValue": "vpc-0abc123"},
+    ]
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["VpcId"] == {"ParameterKey": "VpcId", "UsePreviousValue": True}
+
+
+def test_new_param_takes_template_default(tmp_path):
+    _require_jq()
+    new_template = [
+        {
+            "ParameterKey": "NewKnob",
+            "DefaultValue": "default-value",
+            "ParameterType": "String",
+        }
+    ]
+    current = []  # parameter didn't exist in the previous stack
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["NewKnob"] == {
+        "ParameterKey": "NewKnob",
+        "ParameterValue": "default-value",
+    }
+
+
+def test_required_new_param_with_no_default_fails_loudly(tmp_path):
+    _require_jq()
+    new_template = [
+        {"ParameterKey": "NewRequired", "ParameterType": "String"},
+    ]
+    current = []
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}: {result.stderr}"
+    )
+    assert "NewRequired" in result.stderr
+
+
+def test_image_param_with_no_default_carries_forward(tmp_path):
+    _require_jq()
+    new_template = [
+        {"ParameterKey": "LakerunnerImage", "ParameterType": "String"},
+    ]
+    current = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "ParameterValue": "private.example.com/lakerunner:1.19.2",
+        }
+    ]
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["LakerunnerImage"] == {
+        "ParameterKey": "LakerunnerImage",
+        "UsePreviousValue": True,
+    }
+
+
+def test_full_template_mix(tmp_path):
+    _require_jq()
+    new_template = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "DefaultValue": "public.ecr.aws/cardinalhq/lakerunner:1.20.0",
+            "ParameterType": "String",
+        },
+        {
+            "ParameterKey": "MaestroImage",
+            "DefaultValue": "public.ecr.aws/cardinalhq/maestro:0.5.0",
+            "ParameterType": "String",
+        },
+        {"ParameterKey": "VpcId", "ParameterType": "AWS::EC2::VPC::Id"},
+        {
+            "ParameterKey": "PrivateSubnets",
+            "ParameterType": "CommaDelimitedList",
+        },
+        {
+            "ParameterKey": "NewKnob",
+            "DefaultValue": "off",
+            "ParameterType": "String",
+        },
+    ]
+    current = [
+        {
+            "ParameterKey": "LakerunnerImage",
+            "ParameterValue": "public.ecr.aws/cardinalhq/lakerunner:1.19.2",
+        },
+        {
+            "ParameterKey": "MaestroImage",
+            "ParameterValue": "public.ecr.aws/cardinalhq/maestro:0.4.0",
+        },
+        {"ParameterKey": "VpcId", "ParameterValue": "vpc-0abc123"},
+        {
+            "ParameterKey": "PrivateSubnets",
+            "ParameterValue": "subnet-1,subnet-2,subnet-3",
+        },
+    ]
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["LakerunnerImage"]["ParameterValue"].endswith("1.20.0")
+    assert out["MaestroImage"]["ParameterValue"].endswith("0.5.0")
+    assert out["VpcId"] == {"ParameterKey": "VpcId", "UsePreviousValue": True}
+    assert out["PrivateSubnets"] == {
+        "ParameterKey": "PrivateSubnets",
+        "UsePreviousValue": True,
+    }
+    assert out["NewKnob"] == {"ParameterKey": "NewKnob", "ParameterValue": "off"}
+
+
+def _classify(status, reason):
+    return subprocess.run(
+        [
+            "sh",
+            str(SCRIPT),
+            "--internal-classify-changeset-status",
+            status,
+            reason,
+        ],
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "status,reason",
+    [
+        ("FAILED", "The submitted information didn't contain changes."),
+        ("FAILED", "No updates are to be performed."),
+        ("FAILED", "didn't contain changes"),
+    ],
+)
+def test_classify_noop_phrasings(status, reason):
+    result = _classify(status, reason)
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "noop"
+
+
+def test_classify_create_complete_is_success():
+    result = _classify("CREATE_COMPLETE", "")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "success"
+
+
+def test_classify_real_failure_is_failure():
+    result = _classify(
+        "FAILED",
+        "Parameters: [BogusParam] must have values",
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "failure"

--- a/tests/unit/test_upgrade_lakerunner_lint.py
+++ b/tests/unit/test_upgrade_lakerunner_lint.py
@@ -1,0 +1,49 @@
+"""Lint tests for the upgrade-lakerunner.sh script.
+
+These tests soft-skip when their respective tools are not on PATH so that
+contributors and CI runners without shellcheck installed are not blocked.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "upgrade-lakerunner.sh"
+
+
+def test_script_is_executable():
+    assert SCRIPT.exists(), f"missing {SCRIPT}"
+    assert SCRIPT.stat().st_mode & 0o111, "script should be executable"
+
+
+def test_shellcheck_clean():
+    if shutil.which("shellcheck") is None:
+        pytest.skip("shellcheck not installed on this runner")
+    result = subprocess.run(
+        ["shellcheck", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"shellcheck reported issues:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_runs_with_no_args_and_fails_loudly():
+    """A bare invocation should hit the 'required flags missing' branch and
+    exit code 2, not blow up with a syntax error."""
+    result = subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"},
+    )
+    # Exit 2 means we made it past the parser into the validation branch.
+    # (Or exit 2 from preflight if a tool is missing on the runner; either is
+    # an expected validation-class failure.)
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}: {result.stderr}"
+    )


### PR DESCRIPTION
## Summary

- Adds `scripts/upgrade-lakerunner.sh`, a self-contained POSIX-shell driving script that safely upgrades an existing `cardinal-lakerunner` stack. Deps are AWS CLI v2 + `jq` + `curl`; pre-flight tool check fails fast with an actionable message if anything is missing.
- Adds `jenkins/Jenkinsfile.upgrade-lakerunner`, a declarative pipeline (one job per install) that wraps the script: Plan (`--no-execute`) → optional Approval gate → Apply → always-on cleanup of leftover `cardinal-upgrade-*` change sets.
- Adds operator docs at `docs/operations/jenkins-upgrade.md` (prereqs, per-install setup, AWS auth alternatives, reading change sets, recovery, pinning vs. `latest`, standalone usage).
- Design spec at `docs/superpowers/specs/2026-05-01-jenkins-stack-upgrade-design.md`.

## Behaviour highlights

- Explicit per-parameter resolution (no `--use-previous-parameters`): `*Image` parameters take new template defaults by default, everything else carries forward, new parameters take the new template default, missing-and-required hard-fails with the parameter named.
- Change set name format `cardinal-upgrade-<unix-timestamp>` so cleanup can identify and delete strays.
- No-op detection (`didn't contain changes` / `No updates are to be performed`) → exit 0 quietly.
- Confirmation is "stack reached `UPDATE_COMPLETE`" — anything else exits non-zero, build is red.
- Script is also runnable standalone for emergency upgrades (see ops doc).

## Test plan

- [x] `make test-jenkins` — 18 passed, 1 skipped (Groovy soft-skip)
- [x] Full suite (`pytest tests/`) — 314 passed, 1 skipped, no regressions
- [x] `shellcheck scripts/upgrade-lakerunner.sh` — clean
- [x] `sh scripts/upgrade-lakerunner.sh --help` — prints usage and exits 0
- [x] `sh scripts/upgrade-lakerunner.sh` (no args) — exits 2 with clear validation error
- [ ] Smoke test against a real test-account stack with `--no-execute` (manual, post-merge)
- [ ] End-to-end Jenkins job run against a non-prod install (manual, post-merge)