### PR TITLE
upgrade-lakerunner: drop --role-arn from get-template-summary

### DIFF
--- a/scripts/upgrade-lakerunner.sh
+++ b/scripts/upgrade-lakerunner.sh
@@ -172,6 +172,10 @@ EOF
 
 # ---------------------------------------------------------------------------
 # CFN call wrapper that adds --role-arn when configured.
+#
+# Only use for stack-mutation calls (create/update/delete stack, create/execute
+# change set).  Read-only calls (get-template-summary, describe-*, wait, ...)
+# do not accept --role-arn and must invoke `aws cloudformation` directly.
 # ---------------------------------------------------------------------------
 cfn() {
     if [ -n "$deployer_role_arn" ]; then
@@ -275,7 +279,8 @@ main() {
     work_dir=$(mktemp -d)
 
     log "fetching new template parameter schema via get-template-summary"
-    cfn get-template-summary \
+    # get-template-summary is read-only and does not accept --role-arn.
+    aws cloudformation get-template-summary \
         --template-url "$template_url" \
         --region "$region" \
         --query 'Parameters' \


### PR DESCRIPTION
## Summary

- `cfn()` wrapper unconditionally appends `--role-arn`, but `get-template-summary` is a read-only call that doesn't accept it
- Every run with `--deployer-role-arn` failed at the very first AWS call before creating any change set
- Fix: call `aws cloudformation get-template-summary` directly; document the wrapper rule

Verified by re-running the script against the live `cardinal-lakerunner` stack with the deployer role; change set was created cleanly.

## Test plan

- [x] `make test-unit` (92 passed, shellcheck clean)
- [x] `sh scripts/upgrade-lakerunner.sh --no-execute` against live stack with `--deployer-role-arn` reaches the change-set summary stage