### PR TITLE
migration: unify on LakerunnerImage; drop MigrationImage/Digest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Pre-allocated, registered in `src/cardinal_cfn/listener_priorities.py`. Each ser
 Lambda-backed, runs the lakerunner migrator as a one-shot ECS task. Behavior:
 
 - Stable `PhysicalResourceId`: `cardinal-migration-<InstallIdLong>`.
-- Trigger: `MigrationVersion` property = lakerunner image **digest** (`sha256:...`). Tags are rejected.
+- Trigger: `MigrationVersion` property = `LakerunnerImage` value. The migrator runs from the same image as the lakerunner service tasks (single `LakerunnerImage` parameter), so any image change reruns migrations and the two cannot drift. Customers who want digest pinning use `image@sha256:...` as the `LakerunnerImage` value. Mutable tags like `:latest` are not supported.
 - Create runs the migrator. Update reruns only if `MigrationVersion` changed. Delete is a no-op.
 
 ### Service tier rule (B → C safe)

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -29,8 +29,8 @@ storage_profiles:
 
 # ---------------------------------------------------------------------------
 # Container images. Each can be overridden via *Image parameters on the root.
-# MigrationImageDigest is mandatory and digest-pinned (sha256:...) — that's a
-# root-template concern, not a default here.
+# The migrator runs from the same image as the lakerunner tasks (LakerunnerImage)
+# so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
@@ -39,7 +39,6 @@ images:
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
-  migration:  "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
 
 # ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is

--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -50,13 +50,16 @@ def build() -> Template:
     t.add_parameter(Parameter("DbName", Type="String", Default="lakerunner", Description="Database name."))
     t.add_parameter(Parameter("DbSecretArn", Type="String", Description="ARN of the DB master secret."))
 
-    # Image parameters
+    # Image parameters.  The migrator uses the same image as the lakerunner
+    # service tasks (LakerunnerImage) so the two cannot drift.  The custom
+    # resource keys its trigger off this same value, so any change to
+    # LakerunnerImage reruns migrations.
     t.add_parameter(
         Parameter(
-            "MigrationImage",
+            "LakerunnerImage",
             Type="String",
-            Default=defaults["images"]["migration"],
-            Description="Container image for the DB migrator.",
+            Default=defaults["images"]["lakerunner"],
+            Description="Container image used for both lakerunner tasks and the DB migrator.",
         )
     )
     t.add_parameter(
@@ -65,15 +68,6 @@ def build() -> Template:
             Type="String",
             Default=defaults["images"]["db_init"],
             Description="Image used by the configdb-init container (must include psql).",
-        )
-    )
-    t.add_parameter(
-        Parameter(
-            "MigrationImageDigest",
-            Type="String",
-            AllowedPattern=r"^sha256:[0-9a-f]{64}$",
-            ConstraintDescription="Must be a sha256 image digest (sha256:<64 hex chars>).",
-            Description="Image digest (sha256:...) used to trigger re-runs on upgrade.",
         )
     )
 
@@ -190,7 +184,7 @@ def build() -> Template:
 
     migrator_container = ContainerDefinition(
         Name="migrator",
-        Image=Ref("MigrationImage"),
+        Image=Ref("LakerunnerImage"),
         Command=["/app/bin/lakerunner", "migrate", "--databases=lrdb,configdb"],
         Essential=True,
         DependsOn=[ContainerDependency(ContainerName="configdb-init", Condition="COMPLETE")],
@@ -321,7 +315,7 @@ def build() -> Template:
         CustomResource(
             "MigrationRunner",
             ServiceToken=GetAtt(migration_fn, "Arn"),
-            MigrationVersion=Ref("MigrationImageDigest"),
+            MigrationVersion=Ref("LakerunnerImage"),
             InstallIdLong=Ref("InstallIdLong"),
             ClusterArn=Ref("ClusterArn"),
             TaskDefinitionArn=Ref(task_def),

--- a/src/cardinal_cfn/children/migration_lambda.py
+++ b/src/cardinal_cfn/children/migration_lambda.py
@@ -2,7 +2,10 @@
 
 Embedded in migration.yaml as Code.ZipFile. Behavior contract:
 - PhysicalResourceId is stable: cardinal-migration-<InstallIdLong>.
-- Trigger property MigrationVersion: image digest (sha256:<64 hex>). Tags are rejected.
+- Trigger property MigrationVersion: the LakerunnerImage value (tag or
+  image@sha256:...). Any change reruns the migrator. Mutable tags like :latest
+  are not supported by Cardinal policy and the Lambda treats them like any
+  other string — equal value, no rerun.
 - Create runs the migrator ECS task; success on exit-code 0.
 - Update reruns the migrator only if MigrationVersion changed.
 - Delete is a no-op.
@@ -13,7 +16,6 @@ Embedded in migration.yaml as Code.ZipFile. Behavior contract:
 SOURCE = '''\
 import json
 import os
-import re
 import time
 import traceback
 import urllib.request
@@ -24,7 +26,6 @@ import boto3
 ecs = boto3.client("ecs")
 
 MAX_REASON_LEN = 1000
-DIGEST_RE = re.compile(r"^sha256:[0-9a-f]{64}$")
 
 
 def _send(event, context, status, reason="", physical_id=None, data=None):
@@ -49,13 +50,6 @@ def _send(event, context, status, reason="", physical_id=None, data=None):
 def _physical_id(event):
     install_id_long = event["ResourceProperties"]["InstallIdLong"]
     return f"cardinal-migration-{install_id_long}"
-
-
-def _validate_digest(value):
-    if not value or not DIGEST_RE.match(value):
-        raise ValueError(
-            f"MigrationVersion must be a sha256 image digest (sha256:<64 hex>); got {value!r}"
-        )
 
 
 def _run_migration(event):
@@ -125,7 +119,8 @@ def lambda_handler(event, context):
             _send(event, context, "SUCCESS", physical_id=physical_id)
             return
         new = event["ResourceProperties"].get("MigrationVersion")
-        _validate_digest(new)
+        if not new:
+            raise ValueError("MigrationVersion property is required")
         if event["RequestType"] == "Update":
             old = event.get("OldResourceProperties", {}).get("MigrationVersion")
             if old == new:

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -271,21 +271,6 @@ def build() -> Template:
         t, name="DexInitImage",
         default=defaults["images"]["dex_init"],
         description="BusyBox-style image used to render the dex config.yaml.")
-    add_image_override(
-        t, name="MigrationImage",
-        default=defaults["images"]["migration"],
-        description="DB migrator container image.")
-    t.add_parameter(Parameter(
-        "MigrationImageDigest",
-        Type="String",
-        AllowedPattern=r"^sha256:[0-9a-f]{64}$",
-        ConstraintDescription="Must be a sha256 image digest (sha256:<64 hex chars>).",
-        Description=(
-            "Image digest (sha256:...) for the migrator. Required; tags are "
-            "not accepted. Changing this triggers a re-run of migrations."
-        ),
-    ))
-
     image_param_names = [
         "LakerunnerImage",
         "MaestroImage",
@@ -293,8 +278,6 @@ def build() -> Template:
         "DexImage",
         "DbInitImage",
         "DexInitImage",
-        "MigrationImage",
-        "MigrationImageDigest",
     ]
 
     # ---------------------------------------------------------------------
@@ -398,8 +381,7 @@ def build() -> Template:
         "DbPort": GetAtt(database_stack, "Outputs.DbPort"),
         "DbName": GetAtt(database_stack, "Outputs.DbName"),
         "DbSecretArn": GetAtt(database_stack, "Outputs.DbSecretArn"),
-        "MigrationImage": Ref("MigrationImage"),
-        "MigrationImageDigest": Ref("MigrationImageDigest"),
+        "LakerunnerImage": lakerunner_image,
         "DbInitImage": Ref("DbInitImage"),
     })
 

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -15,16 +15,16 @@ def template_dict():
 def test_required_parameters(template_dict):
     for n in ("InstallIdShort", "InstallIdLong", "ClusterArn", "ClusterName",
               "TaskSecurityGroupId", "ExecutionRoleArn", "PrivateSubnetsCsv",
-              "DbEndpoint", "DbSecretArn", "MigrationImage", "MigrationImageDigest"):
+              "DbEndpoint", "DbSecretArn", "LakerunnerImage"):
         assert n in template_dict["Parameters"], f"missing parameter: {n}"
 
 
-def test_migration_image_digest_pattern_rejects_tags(template_dict):
-    """Spec: tags must be rejected; only sha256:<64 hex> digests are valid."""
-    p = template_dict["Parameters"]["MigrationImageDigest"]
-    assert p.get("AllowedPattern") == r"^sha256:[0-9a-f]{64}$", (
-        f"MigrationImageDigest needs AllowedPattern to reject tags; got {p.get('AllowedPattern')!r}"
-    )
+def test_migration_image_params_are_unified(template_dict):
+    """Spec: migrator and lakerunner tasks share LakerunnerImage; the legacy
+    MigrationImage / MigrationImageDigest parameters must not reappear."""
+    params = template_dict["Parameters"]
+    assert "MigrationImage" not in params
+    assert "MigrationImageDigest" not in params
 
 
 def test_creates_lambda_and_custom_resource(template_dict):
@@ -39,15 +39,30 @@ def test_creates_task_definition(template_dict):
     assert "AWS::ECS::TaskDefinition" in types
 
 
-def test_custom_resource_uses_image_digest_as_trigger(template_dict):
-    """MigrationVersion must be wired to the digest parameter (not the mutable image tag)."""
+def test_custom_resource_uses_lakerunner_image_as_trigger(template_dict):
+    """MigrationVersion must be wired to LakerunnerImage so any image change
+    reruns the migrator and the migrator can never drift from the tasks."""
     cr = next(
         r for r in template_dict["Resources"].values()
         if r["Type"] == "AWS::CloudFormation::CustomResource" or r["Type"] == "Custom::MigrationRunner"
     )
     mv = cr["Properties"].get("MigrationVersion")
-    assert mv == {"Ref": "MigrationImageDigest"}, (
-        f"MigrationVersion must be Ref(MigrationImageDigest); got {mv!r}"
+    assert mv == {"Ref": "LakerunnerImage"}, (
+        f"MigrationVersion must be Ref(LakerunnerImage); got {mv!r}"
+    )
+
+
+def test_migrator_container_uses_lakerunner_image(template_dict):
+    """The migrator container must run the same image as the lakerunner tasks."""
+    task_def = next(
+        r for r in template_dict["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
+    )
+    container = next(
+        c for c in task_def["Properties"]["ContainerDefinitions"]
+        if c["Name"] == "migrator"
+    )
+    assert container["Image"] == {"Ref": "LakerunnerImage"}, (
+        f"migrator container must use Ref(LakerunnerImage); got {container['Image']!r}"
     )
 
 

--- a/tests/unit/test_migration_lambda.py
+++ b/tests/unit/test_migration_lambda.py
@@ -7,7 +7,7 @@ CloudFormation events to verify the behavior contract:
 
 - Delete is a no-op SUCCESS.
 - Update with unchanged MigrationVersion skips run_task and returns SUCCESS.
-- Create with a non-digest MigrationVersion fails.
+- Create with an empty MigrationVersion fails (any non-empty image string is fine).
 - Container exitCode != 0 fails (treated as migration failure).
 - Container exitCode is None (e.g. ECS killed the task before the container ran) fails.
 - run_task failures array (non-empty) fails.
@@ -25,8 +25,8 @@ import pytest
 from cardinal_cfn.children import migration_lambda
 
 
-VALID_DIGEST = "sha256:" + "a" * 64
-ANOTHER_DIGEST = "sha256:" + "b" * 64
+VALID_VERSION = "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
+ANOTHER_VERSION = "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.3"
 
 
 @pytest.fixture
@@ -51,7 +51,7 @@ def lambda_module():
             sys.modules["boto3"] = saved
 
 
-def _event(request_type, *, install_id_long="abcdef012345", migration_version=VALID_DIGEST,
+def _event(request_type, *, install_id_long="abcdef012345", migration_version=VALID_VERSION,
            old_version=None):
     event = {
         "RequestType": request_type,
@@ -104,7 +104,7 @@ def test_delete_is_noop_success(lambda_module):
 
 def test_update_unchanged_skips_run_task(lambda_module):
     lambda_module["lambda_handler"](
-        _event("Update", migration_version=VALID_DIGEST, old_version=VALID_DIGEST),
+        _event("Update", migration_version=VALID_VERSION, old_version=VALID_VERSION),
         _context(),
     )
     body = _last_response_payload(lambda_module)
@@ -130,7 +130,7 @@ def test_update_changed_runs_migration(lambda_module):
         }],
     }
     lambda_module["lambda_handler"](
-        _event("Update", migration_version=ANOTHER_DIGEST, old_version=VALID_DIGEST),
+        _event("Update", migration_version=ANOTHER_VERSION, old_version=VALID_VERSION),
         _context(),
     )
     body = _last_response_payload(lambda_module)
@@ -139,18 +139,19 @@ def test_update_changed_runs_migration(lambda_module):
 
 
 # ---------------------------------------------------------------------------
-# Digest validation — non-digest values must fail.
+# MigrationVersion is required (any non-empty string is acceptable; the
+# template enforces no-:latest as a deployment policy, not in the Lambda).
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("bad", ["", "v1.2.3", ":latest", "latest", "sha256:short", None])
-def test_create_rejects_non_digest_migration_version(lambda_module, bad):
+@pytest.mark.parametrize("bad", ["", None])
+def test_create_rejects_empty_migration_version(lambda_module, bad):
     lambda_module["lambda_handler"](
         _event("Create", migration_version=bad),
         _context(),
     )
     body = _last_response_payload(lambda_module)
     assert body["Status"] == "FAILED"
-    assert "sha256" in body["Reason"]
+    assert "MigrationVersion" in body["Reason"]
     assert not lambda_module["ecs"].run_task.called
 
 
@@ -240,7 +241,7 @@ def test_polling_deadline_is_under_lambda_timeout():
 def test_physical_id_is_stable_across_request_types(lambda_module):
     for rt in ("Delete", "Update"):
         lambda_module["lambda_handler"](
-            _event(rt, migration_version=VALID_DIGEST, old_version=VALID_DIGEST),
+            _event(rt, migration_version=VALID_VERSION, old_version=VALID_VERSION),
             _context(),
         )
         body = _last_response_payload(lambda_module)


### PR DESCRIPTION
## Summary

- Migrator now uses the same image as the lakerunner service tasks (single `LakerunnerImage` parameter)
- Custom resource trigger is the `LakerunnerImage` value, so any image change reruns migrations
- Drop `MigrationImage` and `MigrationImageDigest` parameters from root and the migration child
- Drop the sha256 regex validation in the embedded Lambda — it's no longer required because tag-based references are valid (Cardinal disallows mutable tags like `:latest` as policy, not template constraint)
- Update CLAUDE.md and `cardinal-defaults.yaml` to reflect the new contract

## Backward compat

- Existing deployed stacks have `MigrationImage`/`MigrationImageDigest` parameters set. CFN drops parameters that no longer exist in the new template on update — verified against the live `cardinal-lakerunner` stack via the upgrade script
- The first upgrade onto this template will rerun migrations because `LakerunnerImage` is also bumping (`v1.19.0` -> `v1.19.2`)

## Test plan

- [x] `make test` (311 passed, 1 skipped, cfn-lint clean)
- [x] `make build` produces clean templates with `LakerunnerImage` as the migrator image and trigger
- [ ] After tag, run `scripts/upgrade-lakerunner.sh --no-execute` against the live stack and confirm the change set drops the legacy parameters and reruns the migration