### PR TITLE
upgrade-lakerunner: drop --role-arn from execute-change-set

### DIFF
--- a/scripts/upgrade-lakerunner.sh
+++ b/scripts/upgrade-lakerunner.sh
@@ -173,9 +173,12 @@ EOF
 # ---------------------------------------------------------------------------
 # CFN call wrapper that adds --role-arn when configured.
 #
-# Only use for stack-mutation calls (create/update/delete stack, create/execute
-# change set).  Read-only calls (get-template-summary, describe-*, wait, ...)
-# do not accept --role-arn and must invoke `aws cloudformation` directly.
+# In this script the only call that accepts --role-arn is create-change-set:
+# CFN attaches the role to the change set itself, then uses that role during
+# execute-change-set automatically.  All other AWS CLI calls (including
+# execute-change-set, get-template-summary, describe-*, wait) reject --role-arn
+# and must invoke `aws cloudformation` directly.  Tests/test_upgrade_lakerunner_lint.py
+# enforces this — keep it that way.
 # ---------------------------------------------------------------------------
 cfn() {
     if [ -n "$deployer_role_arn" ]; then
@@ -368,7 +371,9 @@ main() {
     fi
 
     log "executing change set"
-    cfn execute-change-set \
+    # execute-change-set does not accept --role-arn; the role attached to the
+    # change set at create time is used automatically during execution.
+    aws cloudformation execute-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --region "$region" >/dev/null

--- a/tests/unit/test_upgrade_lakerunner_lint.py
+++ b/tests/unit/test_upgrade_lakerunner_lint.py
@@ -47,3 +47,37 @@ def test_runs_with_no_args_and_fails_loudly():
     assert result.returncode == 2, (
         f"expected exit 2, got {result.returncode}: {result.stderr}"
     )
+
+
+# ---------------------------------------------------------------------------
+# AWS CLI accepts --role-arn only on create-change-set in this script.  Wrapping
+# any other subcommand in `cfn ...` causes the AWS CLI to error out with
+# "Unknown options: --role-arn".  This regression bit us twice: once on
+# get-template-summary, once on execute-change-set.  Guard it.
+# ---------------------------------------------------------------------------
+
+ALLOWED_CFN_WRAPPED_SUBCOMMANDS = {"create-change-set"}
+
+
+def test_cfn_wrapper_only_wraps_role_capable_subcommands():
+    text = SCRIPT.read_text().splitlines()
+    offenders = []
+    for i, line in enumerate(text, 1):
+        stripped = line.strip()
+        # Skip comments, the function definition itself, and the inline help.
+        if stripped.startswith("#"):
+            continue
+        if not stripped.startswith("cfn "):
+            continue
+        # Extract the first token after `cfn `.
+        token = stripped.split()[1] if len(stripped.split()) > 1 else ""
+        # Skip lines that aren't actually CFN subcommands (e.g. nothing).
+        if not token:
+            continue
+        if token not in ALLOWED_CFN_WRAPPED_SUBCOMMANDS:
+            offenders.append((i, stripped))
+    assert not offenders, (
+        "cfn() wrapper used on subcommand(s) that don't accept --role-arn:\n"
+        + "\n".join(f"  {i}: {ln}" for i, ln in offenders)
+        + f"\nAllowed: {sorted(ALLOWED_CFN_WRAPPED_SUBCOMMANDS)}"
+    )


### PR DESCRIPTION
## Summary

- Same class of bug as #56 — `cfn` wrapper added `--role-arn` to `execute-change-set`, which AWS CLI rejects
- Hit on the first real apply against the live cluster; the cleanup trap deleted the change set so no stack damage
- Fix: call `aws cloudformation execute-change-set` directly. The role attached at `create-change-set` time is what CFN uses during execution, automatically
- Add a regression-guard test that fails if `cfn` is ever wrapped around any subcommand other than `create-change-set`

## Test plan

- [x] `make test-unit` — new test passes; whole suite green