### PR TITLE
upgrade-lakerunner: refresh TemplateBaseUrl on every upgrade

### DIFF
--- a/scripts/upgrade-lakerunner.sh
+++ b/scripts/upgrade-lakerunner.sh
@@ -24,6 +24,7 @@ refresh_image_defaults="true"
 no_execute="false"
 internal_resolve_params=""
 internal_resolve_params_arg2=""
+internal_resolve_params_tbu=""
 internal_classify_status=""
 internal_classify_reason=""
 
@@ -73,6 +74,10 @@ resolve_params() {
     new_template_file="$1"
     current_stack_file="$2"
     refresh_images="$3"
+    # Optional: an explicit value for the TemplateBaseUrl parameter.  Carried
+    # forward from the previous stack value would point nested children at the
+    # OLD version, so we always override here when provided.
+    explicit_template_base_url="${4:-}"
 
     if [ ! -r "$new_template_file" ]; then
         fail 2 "cannot read template-summary file: $new_template_file"
@@ -86,6 +91,7 @@ resolve_params() {
         --slurpfile newp "$new_template_file" \
         --slurpfile curp "$current_stack_file" \
         --arg refresh "$refresh_images" \
+        --arg tbu "$explicit_template_base_url" \
         '
         ($newp[0] // []) as $newparams
         | ($curp[0] // []) as $current
@@ -94,10 +100,13 @@ resolve_params() {
         | map(
             . as $p
             | $p.ParameterKey as $k
+            | (($k == "TemplateBaseUrl") and ($tbu != "")) as $rule_tbu_override
             | (($k | endswith("Image")) and ($refresh == "true") and (has("DefaultValue"))) as $rule_image_refresh
             | ($current_by_key | has($k)) as $rule_carry
             | (has("DefaultValue")) as $rule_new_default
-            | if $rule_image_refresh then
+            | if $rule_tbu_override then
+                {ParameterKey: $k, ParameterValue: $tbu}
+              elif $rule_image_refresh then
                 {ParameterKey: $k, ParameterValue: $p.DefaultValue}
               elif $rule_carry then
                 {ParameterKey: $k, UsePreviousValue: true}
@@ -225,6 +234,10 @@ parse_args() {
                 internal_resolve_params_arg2="$3"
                 shift 3
                 ;;
+            --internal-template-base-url)
+                internal_resolve_params_tbu="$2"
+                shift 2
+                ;;
             --internal-classify-changeset-status)
                 internal_classify_status="$2"
                 internal_classify_reason="$3"
@@ -248,7 +261,8 @@ main() {
         resolve_params \
             "$internal_resolve_params" \
             "$internal_resolve_params_arg2" \
-            "$refresh_image_defaults"
+            "$refresh_image_defaults" \
+            "$internal_resolve_params_tbu"
         return 0
     fi
     if [ -n "$internal_classify_status" ]; then
@@ -296,11 +310,18 @@ main() {
         --query 'Stacks[0].Parameters' \
         --output json >"$work_dir/current-params.json"
 
-    log "resolving parameters (refresh-image-defaults=$refresh_image_defaults)"
+    # The TemplateBaseUrl parameter encodes the version path nested children
+    # are loaded from.  It MUST track the version we're upgrading to, otherwise
+    # the new root will load the OLD nested templates and fail in confusing
+    # ways.  Compute it from the same flags used to fetch the root template.
+    effective_template_base_url="$template_base_url/$version/cardinal-lakerunner/"
+
+    log "resolving parameters (refresh-image-defaults=$refresh_image_defaults, TemplateBaseUrl=$effective_template_base_url)"
     resolve_params \
         "$work_dir/new-params.json" \
         "$work_dir/current-params.json" \
         "$refresh_image_defaults" \
+        "$effective_template_base_url" \
         >"$work_dir/parameters.json"
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"

--- a/tests/unit/test_upgrade_lakerunner.py
+++ b/tests/unit/test_upgrade_lakerunner.py
@@ -127,6 +127,62 @@ def test_non_image_param_carries_forward(tmp_path):
     assert out["VpcId"] == {"ParameterKey": "VpcId", "UsePreviousValue": True}
 
 
+def test_template_base_url_takes_explicit_override_not_carry_forward(tmp_path):
+    """TemplateBaseUrl drives nested-stack TemplateURL Subs and MUST track the
+    upgrade target's version path, even if the running stack has an older
+    value. Carrying it forward would point the new root at the OLD nested
+    templates and fail in confusing ways."""
+    _require_jq()
+    new_template = [
+        {
+            "ParameterKey": "TemplateBaseUrl",
+            "DefaultValue": "https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/v9.9.9/cardinal-lakerunner/",
+            "ParameterType": "String",
+        }
+    ]
+    current = [
+        {
+            "ParameterKey": "TemplateBaseUrl",
+            "ParameterValue": "https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/v0.0.29/cardinal-lakerunner/",
+        }
+    ]
+    explicit = "https://my-mirror.example.com/lakerunner/v9.9.9/cardinal-lakerunner/"
+    result = _run_resolve(
+        tmp_path, new_template, current,
+        "--internal-template-base-url", explicit,
+    )
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["TemplateBaseUrl"] == {
+        "ParameterKey": "TemplateBaseUrl",
+        "ParameterValue": explicit,
+    }
+
+
+def test_template_base_url_falls_back_to_template_default_when_no_override(tmp_path):
+    """If the script doesn't pass an explicit TemplateBaseUrl (e.g., a test
+    invoking resolve_params directly), the carry-forward rule still applies
+    when the param exists in the current stack."""
+    _require_jq()
+    new_template = [
+        {
+            "ParameterKey": "TemplateBaseUrl",
+            "DefaultValue": "https://example.com/v9.9.9/",
+            "ParameterType": "String",
+        }
+    ]
+    current = [
+        {"ParameterKey": "TemplateBaseUrl", "ParameterValue": "https://example.com/v0.0.29/"},
+    ]
+    result = _run_resolve(tmp_path, new_template, current)
+    assert result.returncode == 0, result.stderr
+    out = _by_key(json.loads(result.stdout))
+    assert out["TemplateBaseUrl"] == {
+        "ParameterKey": "TemplateBaseUrl",
+        "UsePreviousValue": True,
+    }
+
+
 def test_new_param_takes_template_default(tmp_path):
     _require_jq()
     new_template = [


### PR DESCRIPTION
## Summary

Live upgrade against the test cluster failed because the root template was updated to v0.0.32 but `TemplateBaseUrl` carried forward as the v0.0.29 path, so nested children still loaded v0.0.29 templates. The v0.0.29 MigrationStack template demanded `MigrationImageDigest`, which the new root no longer provides — CFN rolled back the whole stack.

The carry-forward rule in `resolve_params` is correct for things like VpcId or sizing, but wrong for `TemplateBaseUrl`: that parameter encodes the version path of nested children and MUST track whatever version is being deployed.

## Changes

- `scripts/upgrade-lakerunner.sh`: compute `effective_template_base_url = "${template_base_url}/${version}/cardinal-lakerunner/"` from the existing `--template-base-url` and `--version` flags, and pass it to `resolve_params` as an explicit override
- `resolve_params`: take an optional 4th positional arg; when set, always emit `TemplateBaseUrl=<that>` instead of carry-forward / new-default
- New internal flag `--internal-template-base-url` for tests
- Two new unit tests: explicit override is honored; absent override falls through to the existing rules

## Test plan

- [x] `make test-unit` (91 passed, 1 skipped)
- [ ] After tag, run upgrade against live `cardinal-lakerunner` stack and confirm `TemplateBaseUrl` is passed as the new value, change set executes, migrations rerun, all 12 children update cleanly