### PR TITLE
monitoring: drop --grpc-port flag (removed in v1.19.2)

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -143,7 +143,7 @@ services:
 
   lakerunner-monitoring:
     signal_type: common
-    command: ["/app/bin/lakerunner", "monitoring", "serve", "--grpc-port=9090"]
+    command: ["/app/bin/lakerunner", "monitoring", "serve"]
     cpu: 256
     memory_mib: 512
     replicas: 1


### PR DESCRIPTION
## Summary

Lakerunner v1.19.2 removed the \`--grpc-port\` flag from \`lakerunner monitoring serve\`. The container exits with \`Error: unknown flag: --grpc-port\` on startup, the ECS deployment circuit breaker triggers, and CFN rolls the whole stack back. Caught in a live upgrade attempt against the test cluster.

## Test plan

- [x] \`make build\` clean
- [x] \`make test\` (314 passed)
- [ ] After tag, re-run the upgrade script against the live stack — expect green