### PR TITLE
deployer-role: grant tear-down perms (RDS snapshot + S3 object)

### DIFF
--- a/src/cardinal_cfn/cardinal_deployer.py
+++ b/src/cardinal_cfn/cardinal_deployer.py
@@ -161,6 +161,12 @@ _POLICY_STATEMENTS = [
             "rds:DeleteDBSubnetGroup",
             "rds:DescribeDBSubnetGroups",
             "rds:ModifyDBSubnetGroup",
+            # Snapshot verbs are required for stack delete: the database has
+            # DeletionPolicy: Snapshot, so CFN takes a final snapshot during
+            # delete-stack. Without these, delete-stack fails with AccessDenied.
+            "rds:CreateDBSnapshot",
+            "rds:DescribeDBSnapshots",
+            "rds:DeleteDBSnapshot",
             "rds:AddTagsToResource",
             "rds:RemoveTagsFromResource",
             "rds:ListTagsForResource",
@@ -176,6 +182,7 @@ _POLICY_STATEMENTS = [
             "s3:GetBucketLocation",
             "s3:GetBucketTagging",
             "s3:PutBucketTagging",
+            "s3:GetBucketVersioning",
             "s3:GetBucketPolicy",
             "s3:PutBucketPolicy",
             "s3:DeleteBucketPolicy",
@@ -189,6 +196,18 @@ _POLICY_STATEMENTS = [
             "s3:PutLifecycleConfiguration",
             "s3:GetBucketPublicAccessBlock",
             "s3:PutBucketPublicAccessBlock",
+            # Object-level verbs are required so an operator using this role
+            # can drain the retained ingest bucket post-stack-delete.  Without
+            # them DeleteBucket fails because S3 will not delete a non-empty
+            # bucket and the role can't list/remove objects to empty it.
+            "s3:ListBucket",
+            "s3:ListBucketVersions",
+            "s3:GetObject",
+            "s3:GetObjectVersion",
+            "s3:DeleteObject",
+            "s3:DeleteObjectVersion",
+            "s3:AbortMultipartUpload",
+            "s3:ListMultipartUploadParts",
         ],
         "Resource": "*",
     },

--- a/tests/templates/test_cardinal_deployer.py
+++ b/tests/templates/test_cardinal_deployer.py
@@ -96,3 +96,27 @@ def test_policy_covers_resource_types_used_by_lakerunner(td):
 def test_policy_includes_passrole(td):
     """ECS/Lambda task roles get attached at deploy time -> iam:PassRole required."""
     assert "iam:PassRole" in _all_actions(td)
+
+
+def test_policy_can_take_rds_final_snapshot_on_delete(td):
+    """The database has DeletionPolicy: Snapshot, so delete-stack triggers a
+    final snapshot. Without CreateDBSnapshot the stack lands in DELETE_FAILED
+    and the customer is wedged. Describe + Delete are needed for cleanup."""
+    actions = set(_all_actions(td))
+    for a in ("rds:CreateDBSnapshot", "rds:DescribeDBSnapshots", "rds:DeleteDBSnapshot"):
+        assert a in actions, f"deployer role must allow {a} so stack delete can finish"
+
+
+def test_policy_can_drain_and_delete_retained_bucket(td):
+    """The ingest bucket has DeletionPolicy: Retain. Post-stack-delete cleanup
+    via this role requires draining objects (and any versions/markers) before
+    DeleteBucket — bucket-level perms alone aren't enough."""
+    actions = set(_all_actions(td))
+    for a in (
+        "s3:ListBucket",
+        "s3:ListBucketVersions",
+        "s3:DeleteObject",
+        "s3:DeleteObjectVersion",
+        "s3:GetBucketVersioning",
+    ):
+        assert a in actions, f"deployer role must allow {a} to clean up retained ingest bucket"


### PR DESCRIPTION
Closes #62, closes #63.

## Summary

Two related deployer-role gaps that block stack tear-down:

1. \`delete-stack\` tries to take a final RDS snapshot (DeletionPolicy: Snapshot) — the role lacked \`rds:CreateDBSnapshot\` and the stack lands in DELETE_FAILED. Hit live during teardown of the test cluster today.
2. Post-stack-delete the ingest bucket is retained, and the role had no way to drain it for actual deletion: bucket-level perms only, no \`s3:ListBucket\` / \`DeleteObject\` / \`DeleteObjectVersion\`. \`DeleteBucket\` fails on any non-empty bucket.

## Changes

- \`cardinal_deployer.py\`: add \`rds:CreateDBSnapshot\`, \`rds:DescribeDBSnapshots\`, \`rds:DeleteDBSnapshot\` to the RDS statement. Add \`s3:ListBucket\`, \`s3:ListBucketVersions\`, \`s3:GetObject\`, \`s3:GetObjectVersion\`, \`s3:DeleteObject\`, \`s3:DeleteObjectVersion\`, \`s3:GetBucketVersioning\`, \`s3:AbortMultipartUpload\`, \`s3:ListMultipartUploadParts\` to the S3 statement.
- \`tests/templates/test_cardinal_deployer.py\`: two new tests — one for the RDS snapshot trio, one for the S3-bucket-drain set — so this doesn't regress silently.

## Test plan

- [x] \`make build\` clean
- [x] \`make test\` (316 passed)
- [ ] **Not deploying yet** per request — once we have a fresh test cluster, we'll redeploy the deployer-role stack from the new template and verify \`delete-stack --role-arn\` reaches DELETE_COMPLETE end-to-end (final snapshot + bucket cleanup) without falling back to admin creds. Tracked as the verification step on issue #64.