### PR TITLE
teardown-lakerunner: docs + script for retained-resource cleanup

### DIFF
--- a/docs/operations/deploying.md
+++ b/docs/operations/deploying.md
@@ -92,3 +92,11 @@ resource type, update `_POLICY_STATEMENTS` in `cardinal_deployer.py` so
 customers running the template get the new permission. The drift test in
 `tests/templates/test_cardinal_deployer.py` will fail if the template adds a
 resource type that isn't represented in the policy.
+
+## Tearing down
+
+`delete-stack` does not remove every resource — the ingest bucket, the
+license / admin-api-key / db-master secrets, and the RDS final snapshot are
+intentionally retained. See [`tearing-down.md`](tearing-down.md) for the
+full survivor list and a companion script
+(`scripts/teardown-lakerunner.sh`) that handles the cleanup pass.

--- a/docs/operations/tearing-down.md
+++ b/docs/operations/tearing-down.md
@@ -1,0 +1,169 @@
+# Tearing down a lakerunner stack
+
+`aws cloudformation delete-stack` is *not* the end of the story. Several
+resources are intentionally retained so that a misclick or bad upgrade does
+not destroy customer data. This page lists every survivor, why it was
+retained, and how to clean it up when the install is really being
+decommissioned.
+
+The retention list is the policy table in
+[`src/cardinal_cfn/policies.py`](../../src/cardinal_cfn/policies.py); this
+page is the operator-facing companion.
+
+## TL;DR
+
+Use the companion script:
+
+```sh
+scripts/teardown-lakerunner.sh \
+  --stack-name cardinal-lakerunner \
+  --region us-east-2 \
+  --deployer-role-arn arn:aws:iam::<acct>:role/cardinal-cfn-deployer \
+  --yes
+```
+
+Without `--yes`, the script prints what it would delete and exits without
+touching anything. With `--yes`, it deletes the stack, waits for
+`DELETE_COMPLETE`, then drains the ingest bucket, force-deletes the retained
+secrets, and deletes the RDS final snapshot.
+
+## What survives `delete-stack`
+
+| Resource | Why retained | How to delete |
+|---|---|---|
+| `cardinal-ingest-<account>-<region>-<InstallIdLong>` (S3 bucket) | `DeletionPolicy: Retain` — bucket holds ingested telemetry; deleting it is destructive and irreversible. | Drain object versions + delete markers, then `s3api delete-bucket`. |
+| `cardinal/<InstallIdLong>/license` (Secrets Manager) | `DeletionPolicy: Retain` — vendor-issued license value, painful to re-fetch. | `secretsmanager delete-secret --force-delete-without-recovery`. |
+| `cardinal/<InstallIdLong>/admin-api-key` (Secrets Manager) | `DeletionPolicy: Retain` — auto-generated admin API key; redeploying the stack would issue a different value. | `secretsmanager delete-secret --force-delete-without-recovery`. |
+| `DbMasterSecret` (Secrets Manager, auto-named, tag `Name=cardinal-db-master-<InstallIdShort>`) | `DeletionPolicy: Retain` — paired with the snapshot so the snapshot can be restored later. | `secretsmanager delete-secret --force-delete-without-recovery`. |
+| RDS final snapshot (CFN-named `<stack>-Db-<random>` after a `Snapshot`-policy delete) | `DeletionPolicy: Snapshot` — last-line defence against accidental delete-stack. | `rds describe-db-snapshots --db-instance-identifier <id>` then `rds delete-db-snapshot`. |
+
+`internal-service-keys`, the SSM parameters, all log groups, the SQS queue,
+the ALB, the ECS cluster, and the RDS DB instance itself are *not* retained —
+`delete-stack` removes them. Orphan log groups can occasionally show up if a
+service held one open at delete time; they will roll off via their retention
+policy on their own.
+
+## Why secrets need `--force-delete-without-recovery`
+
+Secrets Manager normally schedules deletion 7-30 days out so that a
+mistakenly deleted secret can be restored. For a real tear-down that
+recovery window is just billing for nothing. `--force-delete-without-recovery`
+removes the secret immediately and skips the window.
+
+If you want the recovery window (the install might come back), drop the flag
+and pass `--recovery-window-in-days N` instead.
+
+## Permissions model
+
+The `cardinal-cfn-deployer` role's trust policy only allows
+`cloudformation.amazonaws.com` to assume it. The deployer role is therefore
+only useful on the `delete-stack` call itself; the post-stack cleanup
+(bucket drain, secret force-delete, snapshot delete) runs as the calling
+identity.
+
+The deployer role *itself* needs `rds:CreateDBSnapshot` /
+`rds:DescribeDBSnapshots` so that CloudFormation can take the final RDS
+snapshot during stack deletion (issue #62, fixed in PR #65). Without those
+permissions the stack lands in `DELETE_FAILED` and recovery requires admin
+credentials.
+
+## Manual procedure (without the script)
+
+If you cannot run the script (air-gapped, custom IAM, etc.), the same flow
+in raw AWS CLI:
+
+```sh
+STACK=cardinal-lakerunner
+REGION=us-east-2
+ROLE=arn:aws:iam::111122223333:role/cardinal-cfn-deployer
+
+# 1. Capture identifiers BEFORE deleting — they are not recoverable afterward.
+INSTALL_ID_LONG=$(aws cloudformation describe-stacks \
+  --stack-name "$STACK" --region "$REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`InstallIdLong`].OutputValue' \
+  --output text)
+
+STORAGE_STACK=$(aws cloudformation describe-stack-resource \
+  --stack-name "$STACK" --logical-resource-id Storage \
+  --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text)
+BUCKET=$(aws cloudformation describe-stacks \
+  --stack-name "$STORAGE_STACK" --region "$REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`BucketName`].OutputValue' \
+  --output text)
+
+DATABASE_STACK=$(aws cloudformation describe-stack-resource \
+  --stack-name "$STACK" --logical-resource-id Database \
+  --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text)
+DB_ID=$(aws cloudformation describe-stack-resource \
+  --stack-name "$DATABASE_STACK" --logical-resource-id Db \
+  --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text)
+DB_SECRET=$(aws cloudformation describe-stacks \
+  --stack-name "$DATABASE_STACK" --region "$REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`DbSecretArn`].OutputValue' \
+  --output text)
+
+CONFIG_STACK=$(aws cloudformation describe-stack-resource \
+  --stack-name "$STACK" --logical-resource-id Config \
+  --region "$REGION" \
+  --query 'StackResourceDetail.PhysicalResourceId' --output text)
+LICENSE_SECRET=$(aws cloudformation describe-stacks \
+  --stack-name "$CONFIG_STACK" --region "$REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`LicenseSecretArn`].OutputValue' \
+  --output text)
+ADMIN_SECRET=$(aws cloudformation describe-stacks \
+  --stack-name "$CONFIG_STACK" --region "$REGION" \
+  --query 'Stacks[0].Outputs[?OutputKey==`AdminApiKeySecretArn`].OutputValue' \
+  --output text)
+
+# 2. Delete the stack.
+aws cloudformation delete-stack \
+  --stack-name "$STACK" --region "$REGION" --role-arn "$ROLE"
+aws cloudformation wait stack-delete-complete \
+  --stack-name "$STACK" --region "$REGION"
+
+# 3. Drain + delete the bucket (handles versioned objects).
+aws s3api list-object-versions --bucket "$BUCKET" --region "$REGION" \
+  --query '{Objects: (Versions || `[]`) + (DeleteMarkers || `[]`) | [*].{Key:Key,VersionId:VersionId}}' \
+  --output json > /tmp/del.json
+aws s3api delete-objects --bucket "$BUCKET" --region "$REGION" \
+  --delete file:///tmp/del.json
+aws s3api delete-bucket --bucket "$BUCKET" --region "$REGION"
+
+# 4. Force-delete the three retained secrets.
+for ARN in "$LICENSE_SECRET" "$ADMIN_SECRET" "$DB_SECRET"; do
+  aws secretsmanager delete-secret --secret-id "$ARN" \
+    --region "$REGION" --force-delete-without-recovery
+done
+
+# 5. Delete the RDS final snapshot.
+for SNAP in $(aws rds describe-db-snapshots \
+                --db-instance-identifier "$DB_ID" \
+                --snapshot-type manual --region "$REGION" \
+                --query 'DBSnapshots[*].DBSnapshotIdentifier' \
+                --output text); do
+  aws rds delete-db-snapshot --db-snapshot-identifier "$SNAP" --region "$REGION"
+done
+```
+
+The bucket-drain step in (3) only handles a single page of object versions.
+For populated buckets, loop until `list-object-versions` returns an empty
+list. The script handles this automatically.
+
+## What if the stack is already in `DELETE_FAILED`?
+
+`DELETE_FAILED` after a `delete-stack` typically means CloudFormation could
+not delete some resource it owns (most often the RDS instance, because the
+deployer role lacked `rds:CreateDBSnapshot`). Recovery:
+
+1. Update the deployer role from the latest template (PR #65 added the
+   missing snapshot perms). See [`deploying.md`](deploying.md) for the
+   `update-stack` flow.
+2. Re-run `delete-stack` with the updated role; it will retry the failing
+   resource.
+
+If a specific resource can't be deleted at all (e.g., a manually-modified
+SG), use `delete-stack --retain-resources <LogicalId>` to drop it from the
+stack and clean it up by hand afterwards.

--- a/scripts/teardown-lakerunner.sh
+++ b/scripts/teardown-lakerunner.sh
@@ -1,0 +1,494 @@
+#!/bin/sh
+# Tear down a deployed cardinal-lakerunner CloudFormation stack and clean up
+# the resources it intentionally retains: the ingest S3 bucket, the license /
+# admin-api-key / db-master secrets, and the RDS final snapshot.
+#
+# Companion to scripts/upgrade-lakerunner.sh.  Self-contained: depends only on
+# a POSIX shell, the AWS CLI v2, and jq.
+#
+# Resources retained by design (see src/cardinal_cfn/policies.py):
+#   - cardinal-ingest-<account>-<region>-<InstallIdLong>   (S3, Retain)
+#   - cardinal/<InstallIdLong>/license                      (Secrets, Retain)
+#   - cardinal/<InstallIdLong>/admin-api-key                (Secrets, Retain)
+#   - DbMasterSecret (auto-named, tagged db-master)         (Secrets, Retain)
+#   - <stack>-Db-* final snapshot                           (RDS, Snapshot)
+#
+# The deployer role (cardinal-cfn-deployer) is only assumable by
+# cloudformation.amazonaws.com, so --deployer-role-arn is passed only to
+# `delete-stack`.  The post-stack cleanup AWS CLI calls (s3api, secretsmanager,
+# rds) run as the calling identity.
+
+set -eu
+
+stack_name=""
+region=""
+deployer_role_arn=""
+yes="false"
+keep_data="false"
+keep_bucket="false"
+keep_secrets="false"
+keep_snapshot="false"
+
+# Internal-only test hooks (pure data transforms, no AWS calls).
+internal_format_plan=""
+internal_check_yes=""
+
+# State held across stages for the abort handler.
+work_dir=""
+
+usage() {
+    cat <<'EOF'
+Usage: teardown-lakerunner.sh [options]
+
+Required:
+  --stack-name NAME           Existing stack to tear down (root cardinal-lakerunner stack).
+  --region REGION             AWS region of the stack.
+  --yes                       Confirm destructive operation.  Without this the
+                              script prints the plan and exits.
+
+Optional:
+  --deployer-role-arn ARN     Role ARN for the delete-stack call.  All other
+                              cleanup AWS calls run as the calling identity.
+  --keep-data                 Skip ALL post-delete cleanup (bucket, secrets, snapshot).
+  --keep-bucket               Skip ingest-bucket drain + delete.
+  --keep-secrets              Skip force-delete of retained secrets.
+  --keep-snapshot             Skip RDS final snapshot delete.
+
+Exit codes:
+  0  success
+  1  generic / AWS / cleanup failure
+  2  pre-flight / input validation failure
+EOF
+}
+
+log() {
+    printf '[%s] %s\n' "teardown-lakerunner" "$*" >&2
+}
+
+fail() {
+    code="$1"
+    shift
+    printf '[teardown-lakerunner] ERROR: %s\n' "$*" >&2
+    exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: render the human-readable cleanup plan from a captured-state JSON
+# blob.  Used by --internal-format-plan for tests and by the main pipeline.
+#
+# Input shape (stdin or $1):
+#   { "InstallIdLong": "...", "BucketName": "...",
+#     "LicenseSecretArn": "...", "AdminApiKeySecretArn": "...",
+#     "DbSecretArn": "...", "DbInstanceIdentifier": "..." }
+# ---------------------------------------------------------------------------
+format_plan() {
+    state_file="$1"
+    keep_bucket_flag="$2"
+    keep_secrets_flag="$3"
+    keep_snapshot_flag="$4"
+
+    if [ ! -r "$state_file" ]; then
+        fail 2 "cannot read state file: $state_file"
+    fi
+
+    jq -r \
+        --arg keep_bucket "$keep_bucket_flag" \
+        --arg keep_secrets "$keep_secrets_flag" \
+        --arg keep_snapshot "$keep_snapshot_flag" \
+        '
+        def fmt(name; value): if (value // "") == "" then "  - " + name + ": (not found)" else "  - " + name + ": " + value end;
+        [
+          "Resources scheduled for cleanup AFTER the stack is deleted:",
+          (if $keep_bucket == "true" then "  (S3 ingest bucket: SKIPPED via --keep-bucket)" else fmt("S3 ingest bucket"; .BucketName) end),
+          (if $keep_secrets == "true" then "  (Retained secrets: SKIPPED via --keep-secrets)" else
+            ([
+              fmt("Secret (license)"; .LicenseSecretArn),
+              fmt("Secret (admin-api-key)"; .AdminApiKeySecretArn),
+              fmt("Secret (db-master)"; .DbSecretArn)
+            ] | join("\n")) end),
+          (if $keep_snapshot == "true" then "  (RDS final snapshot: SKIPPED via --keep-snapshot)" else
+            "  - RDS final snapshot(s) for DB instance: " + (if (.DbInstanceIdentifier // "") == "" then "(not found)" else .DbInstanceIdentifier end) end)
+        ] | join("\n")
+        ' "$state_file"
+}
+
+# ---------------------------------------------------------------------------
+# Internal: returns "ok" if --yes was supplied alongside an otherwise valid
+# arg set.  Returns "missing-yes" otherwise.  Used by --internal-check-yes.
+# ---------------------------------------------------------------------------
+check_yes() {
+    if [ "$yes" = "true" ]; then
+        printf 'ok\n'
+    else
+        printf 'missing-yes\n'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight tool check.
+# ---------------------------------------------------------------------------
+preflight() {
+    missing=""
+    for tool in aws jq; do
+        if ! command -v "$tool" >/dev/null 2>&1; then
+            missing="$missing $tool"
+        fi
+    done
+    if [ -n "$missing" ]; then
+        cat >&2 <<EOF
+[teardown-lakerunner] ERROR: required tool(s) not found:$missing
+Install hints:
+  Debian/Ubuntu : sudo apt-get install -y awscli jq
+  Amazon Linux  : sudo yum install -y aws-cli jq
+  Alpine        : sudo apk add aws-cli jq
+  macOS (brew)  : brew install awscli jq
+EOF
+        exit 2
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Best-effort cleanup on abort.
+# ---------------------------------------------------------------------------
+cleanup() {
+    rc=$?
+    if [ -n "$work_dir" ] && [ -d "$work_dir" ]; then
+        rm -rf "$work_dir"
+    fi
+    exit "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Look up the physical ID (nested-stack ARN) of a child stack by its logical
+# ID under the root stack.  Returns empty string if the child does not exist.
+# ---------------------------------------------------------------------------
+get_nested_stack_id() {
+    parent="$1"
+    logical_id="$2"
+    aws cloudformation describe-stack-resource \
+        --stack-name "$parent" \
+        --logical-resource-id "$logical_id" \
+        --region "$region" \
+        --query 'StackResourceDetail.PhysicalResourceId' \
+        --output text 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Look up a single output value from a stack.  Empty string if missing.
+# ---------------------------------------------------------------------------
+get_stack_output() {
+    stack="$1"
+    key="$2"
+    aws cloudformation describe-stacks \
+        --stack-name "$stack" \
+        --region "$region" \
+        --query "Stacks[0].Outputs[?OutputKey=='$key'].OutputValue | [0]" \
+        --output text 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# Capture the survivors' identifiers from the running stack, write them to
+# $work_dir/state.json.  Must run BEFORE delete-stack — once the stack is
+# gone the nested stacks are too, and we lose the ability to discover the
+# physical IDs.
+# ---------------------------------------------------------------------------
+capture_state() {
+    log "discovering nested stacks under $stack_name"
+    storage_stack=$(get_nested_stack_id "$stack_name" "Storage")
+    database_stack=$(get_nested_stack_id "$stack_name" "Database")
+    config_stack=$(get_nested_stack_id "$stack_name" "Config")
+
+    install_id_long=$(get_stack_output "$stack_name" "InstallIdLong")
+
+    bucket_name=""
+    if [ -n "$storage_stack" ] && [ "$storage_stack" != "None" ]; then
+        bucket_name=$(get_stack_output "$storage_stack" "BucketName")
+    fi
+
+    db_secret_arn=""
+    db_instance_id=""
+    if [ -n "$database_stack" ] && [ "$database_stack" != "None" ]; then
+        db_secret_arn=$(get_stack_output "$database_stack" "DbSecretArn")
+        db_instance_id=$(aws cloudformation describe-stack-resource \
+            --stack-name "$database_stack" \
+            --logical-resource-id "Db" \
+            --region "$region" \
+            --query 'StackResourceDetail.PhysicalResourceId' \
+            --output text 2>/dev/null || true)
+    fi
+
+    license_secret_arn=""
+    admin_secret_arn=""
+    if [ -n "$config_stack" ] && [ "$config_stack" != "None" ]; then
+        license_secret_arn=$(get_stack_output "$config_stack" "LicenseSecretArn")
+        admin_secret_arn=$(get_stack_output "$config_stack" "AdminApiKeySecretArn")
+    fi
+
+    # Normalize "None" (returned by the CLI when a query yields no value) to "".
+    [ "$install_id_long" = "None" ] && install_id_long=""
+    [ "$bucket_name" = "None" ] && bucket_name=""
+    [ "$db_secret_arn" = "None" ] && db_secret_arn=""
+    [ "$db_instance_id" = "None" ] && db_instance_id=""
+    [ "$license_secret_arn" = "None" ] && license_secret_arn=""
+    [ "$admin_secret_arn" = "None" ] && admin_secret_arn=""
+
+    jq -n \
+        --arg install_id_long "$install_id_long" \
+        --arg bucket "$bucket_name" \
+        --arg db_secret "$db_secret_arn" \
+        --arg db_id "$db_instance_id" \
+        --arg license "$license_secret_arn" \
+        --arg admin "$admin_secret_arn" \
+        '{
+          InstallIdLong: $install_id_long,
+          BucketName: $bucket,
+          DbSecretArn: $db_secret,
+          DbInstanceIdentifier: $db_id,
+          LicenseSecretArn: $license,
+          AdminApiKeySecretArn: $admin
+        }' >"$work_dir/state.json"
+}
+
+# ---------------------------------------------------------------------------
+# Drain and delete the retained ingest bucket.  Handles versioned buckets
+# (the lifecycle rules can leave delete markers and noncurrent versions).
+# ---------------------------------------------------------------------------
+drain_and_delete_bucket() {
+    bucket="$1"
+    if [ -z "$bucket" ]; then
+        log "no bucket name captured; skipping bucket cleanup"
+        return 0
+    fi
+
+    if ! aws s3api head-bucket --bucket "$bucket" --region "$region" >/dev/null 2>&1; then
+        log "bucket $bucket already gone; skipping"
+        return 0
+    fi
+
+    log "draining bucket $bucket (object versions + delete markers)"
+    while :; do
+        payload=$(aws s3api list-object-versions \
+            --bucket "$bucket" \
+            --region "$region" \
+            --max-items 1000 \
+            --output json 2>/dev/null || printf '{}\n')
+        objects=$(printf '%s\n' "$payload" | jq -c '
+            {Objects: ((.Versions // []) + (.DeleteMarkers // []))
+              | map({Key: .Key, VersionId: .VersionId})}
+        ')
+        count=$(printf '%s\n' "$objects" | jq '.Objects | length')
+        if [ "$count" = "0" ]; then
+            break
+        fi
+        log "  deleting batch of $count object version(s)"
+        printf '%s\n' "$objects" >"$work_dir/delete-batch.json"
+        aws s3api delete-objects \
+            --bucket "$bucket" \
+            --region "$region" \
+            --delete "file://$work_dir/delete-batch.json" \
+            >/dev/null
+    done
+
+    log "deleting bucket $bucket"
+    aws s3api delete-bucket --bucket "$bucket" --region "$region"
+}
+
+# ---------------------------------------------------------------------------
+# Force-delete a Secrets Manager secret with no recovery window.  Tolerates
+# the secret already being absent.
+# ---------------------------------------------------------------------------
+force_delete_secret() {
+    arn="$1"
+    label="$2"
+    if [ -z "$arn" ]; then
+        log "no $label secret captured; skipping"
+        return 0
+    fi
+    if ! aws secretsmanager describe-secret \
+            --secret-id "$arn" \
+            --region "$region" >/dev/null 2>&1; then
+        log "$label secret $arn already gone; skipping"
+        return 0
+    fi
+    log "force-deleting $label secret: $arn"
+    aws secretsmanager delete-secret \
+        --secret-id "$arn" \
+        --region "$region" \
+        --force-delete-without-recovery >/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Find and delete every manual snapshot for the captured DB instance.
+# DeletionPolicy: Snapshot creates exactly one final snapshot, but a
+# customer or rotation could have created others — delete them all.
+# ---------------------------------------------------------------------------
+delete_db_snapshots() {
+    db_id="$1"
+    if [ -z "$db_id" ]; then
+        log "no DB instance identifier captured; skipping snapshot cleanup"
+        return 0
+    fi
+    log "looking up manual snapshots for DB instance $db_id"
+    snapshots=$(aws rds describe-db-snapshots \
+        --db-instance-identifier "$db_id" \
+        --snapshot-type manual \
+        --region "$region" \
+        --query 'DBSnapshots[*].DBSnapshotIdentifier' \
+        --output text 2>/dev/null || true)
+    if [ -z "$snapshots" ] || [ "$snapshots" = "None" ]; then
+        log "no manual snapshots found for $db_id"
+        return 0
+    fi
+    for snap in $snapshots; do
+        log "deleting RDS snapshot $snap"
+        aws rds delete-db-snapshot \
+            --db-snapshot-identifier "$snap" \
+            --region "$region" >/dev/null
+    done
+}
+
+# ---------------------------------------------------------------------------
+# Main pipeline.
+# ---------------------------------------------------------------------------
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --stack-name) stack_name="$2"; shift 2 ;;
+            --region) region="$2"; shift 2 ;;
+            --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
+            --yes) yes="true"; shift ;;
+            --keep-data) keep_data="true"; shift ;;
+            --keep-bucket) keep_bucket="true"; shift ;;
+            --keep-secrets) keep_secrets="true"; shift ;;
+            --keep-snapshot) keep_snapshot="true"; shift ;;
+            --internal-format-plan)
+                internal_format_plan="$2"
+                shift 2
+                ;;
+            --internal-check-yes)
+                internal_check_yes="true"
+                shift
+                ;;
+            -h|--help) usage; exit 0 ;;
+            *) fail 2 "unknown argument: $1" ;;
+        esac
+    done
+
+    if [ "$keep_data" = "true" ]; then
+        keep_bucket="true"
+        keep_secrets="true"
+        keep_snapshot="true"
+    fi
+}
+
+main() {
+    parse_args "$@"
+
+    # Internal test hooks bypass AWS entirely.
+    if [ -n "$internal_format_plan" ]; then
+        if ! command -v jq >/dev/null 2>&1; then
+            fail 2 "jq is required for --internal-format-plan"
+        fi
+        format_plan \
+            "$internal_format_plan" \
+            "$keep_bucket" \
+            "$keep_secrets" \
+            "$keep_snapshot"
+        return 0
+    fi
+    if [ "$internal_check_yes" = "true" ]; then
+        check_yes
+        return 0
+    fi
+
+    preflight
+
+    if [ -z "$stack_name" ] || [ -z "$region" ]; then
+        usage >&2
+        fail 2 "--stack-name and --region are required"
+    fi
+
+    log "verifying stack $stack_name exists in $region"
+    if ! aws cloudformation describe-stacks \
+            --stack-name "$stack_name" \
+            --region "$region" >/dev/null 2>&1; then
+        fail 2 "stack '$stack_name' not found in region '$region'"
+    fi
+
+    account_id=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || echo "unknown")
+    log "AWS account: $account_id  region: $region  stack: $stack_name"
+
+    work_dir=$(mktemp -d)
+
+    capture_state
+
+    log "captured state:"
+    cat "$work_dir/state.json" >&2
+
+    plan=$(format_plan "$work_dir/state.json" "$keep_bucket" "$keep_secrets" "$keep_snapshot")
+    printf '%s\n' "$plan" >&2
+
+    if [ "$yes" != "true" ]; then
+        log "DRY RUN: pass --yes to delete the stack and clean up the resources above."
+        return 0
+    fi
+
+    log "deleting stack $stack_name"
+    if [ -n "$deployer_role_arn" ]; then
+        aws cloudformation delete-stack \
+            --stack-name "$stack_name" \
+            --region "$region" \
+            --role-arn "$deployer_role_arn"
+    else
+        aws cloudformation delete-stack \
+            --stack-name "$stack_name" \
+            --region "$region"
+    fi
+
+    log "waiting for stack-delete-complete (this can take 10+ minutes)"
+    if ! aws cloudformation wait stack-delete-complete \
+            --stack-name "$stack_name" \
+            --region "$region"; then
+        final_status=$(aws cloudformation describe-stacks \
+            --stack-name "$stack_name" \
+            --region "$region" \
+            --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "DELETED")
+        if [ "$final_status" != "DELETED" ] && [ "$final_status" != "DELETE_COMPLETE" ]; then
+            fail 1 "stack did not reach DELETE_COMPLETE; final status: $final_status"
+        fi
+    fi
+    log "stack deleted"
+
+    bucket=$(jq -r '.BucketName // ""' "$work_dir/state.json")
+    license_arn=$(jq -r '.LicenseSecretArn // ""' "$work_dir/state.json")
+    admin_arn=$(jq -r '.AdminApiKeySecretArn // ""' "$work_dir/state.json")
+    db_secret_arn=$(jq -r '.DbSecretArn // ""' "$work_dir/state.json")
+    db_id=$(jq -r '.DbInstanceIdentifier // ""' "$work_dir/state.json")
+
+    if [ "$keep_bucket" = "true" ]; then
+        log "skipping bucket cleanup (--keep-bucket / --keep-data)"
+    else
+        drain_and_delete_bucket "$bucket"
+    fi
+
+    if [ "$keep_secrets" = "true" ]; then
+        log "skipping secret force-delete (--keep-secrets / --keep-data)"
+    else
+        force_delete_secret "$license_arn" "license"
+        force_delete_secret "$admin_arn" "admin-api-key"
+        force_delete_secret "$db_secret_arn" "db-master"
+    fi
+
+    if [ "$keep_snapshot" = "true" ]; then
+        log "skipping RDS snapshot delete (--keep-snapshot / --keep-data)"
+    else
+        delete_db_snapshots "$db_id"
+    fi
+
+    log "tear-down complete"
+    return 0
+}
+
+trap cleanup EXIT INT TERM HUP
+
+main "$@"

--- a/tests/unit/test_teardown_lakerunner.py
+++ b/tests/unit/test_teardown_lakerunner.py
@@ -1,0 +1,140 @@
+"""Tests for the standalone teardown-lakerunner.sh script.
+
+The script is shell + jq + AWS CLI.  To keep the pure-data parts testable
+without AWS, the script exposes:
+
+- --internal-format-plan <state.json>
+- --internal-check-yes
+
+Both run pure data transforms with no AWS calls and no side effects.
+"""
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "teardown-lakerunner.sh"
+
+
+def _require_jq():
+    if shutil.which("jq") is None:
+        pytest.skip("jq not installed on this runner")
+
+
+@pytest.fixture(autouse=True)
+def _script_exists():
+    if not SCRIPT.exists():
+        pytest.fail(
+            f"Script missing: {SCRIPT}. Implement it before running these tests."
+        )
+
+
+@pytest.fixture
+def state_file(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({
+        "InstallIdLong": "abc123def456",
+        "BucketName": "cardinal-ingest-111122223333-us-east-2-abc123def456",
+        "DbSecretArn": "arn:aws:secretsmanager:us-east-2:111122223333:secret:cardinal-database-DbMasterSecret-XYZ-AbCdEf",
+        "DbInstanceIdentifier": "cardinal-lakerunner-db-1abc2def",
+        "LicenseSecretArn": "arn:aws:secretsmanager:us-east-2:111122223333:secret:cardinal/abc123def456/license-AbCdEf",
+        "AdminApiKeySecretArn": "arn:aws:secretsmanager:us-east-2:111122223333:secret:cardinal/abc123def456/admin-api-key-AbCdEf",
+    }))
+    return path
+
+
+def _run_format(state_path, *extra):
+    return subprocess.run(
+        ["sh", str(SCRIPT), "--internal-format-plan", str(state_path), *extra],
+        capture_output=True, text=True,
+    )
+
+
+def test_format_plan_lists_every_survivor(state_file):
+    _require_jq()
+    result = _run_format(state_file)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "S3 ingest bucket: cardinal-ingest-111122223333-us-east-2-abc123def456" in out
+    assert "Secret (license)" in out
+    assert "Secret (admin-api-key)" in out
+    assert "Secret (db-master)" in out
+    assert "RDS final snapshot(s) for DB instance: cardinal-lakerunner-db-1abc2def" in out
+
+
+def test_format_plan_marks_skipped_with_keep_bucket(state_file):
+    _require_jq()
+    result = _run_format(state_file, "--keep-bucket")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "S3 ingest bucket: SKIPPED via --keep-bucket" in out
+    # Other survivors are still listed.
+    assert "Secret (license)" in out
+    assert "RDS final snapshot(s) for DB instance" in out
+
+
+def test_format_plan_marks_skipped_with_keep_secrets(state_file):
+    _require_jq()
+    result = _run_format(state_file, "--keep-secrets")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "Retained secrets: SKIPPED via --keep-secrets" in out
+    assert "S3 ingest bucket: cardinal-ingest" in out
+
+
+def test_format_plan_marks_skipped_with_keep_snapshot(state_file):
+    _require_jq()
+    result = _run_format(state_file, "--keep-snapshot")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "RDS final snapshot: SKIPPED via --keep-snapshot" in out
+    assert "S3 ingest bucket: cardinal-ingest" in out
+
+
+def test_format_plan_marks_skipped_with_keep_data(state_file):
+    """--keep-data is shorthand for all three keep-* flags."""
+    _require_jq()
+    result = _run_format(state_file, "--keep-data")
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "S3 ingest bucket: SKIPPED" in out
+    assert "Retained secrets: SKIPPED" in out
+    assert "RDS final snapshot: SKIPPED" in out
+
+
+def test_format_plan_handles_missing_state_fields(tmp_path):
+    """If the script could not discover (e.g.) the bucket name, the plan
+    should still render with a clear (not found) marker rather than an empty
+    line that the operator might miss."""
+    _require_jq()
+    state = tmp_path / "partial.json"
+    state.write_text(json.dumps({
+        "InstallIdLong": "abc123def456",
+        "BucketName": "",
+        "LicenseSecretArn": "",
+        "AdminApiKeySecretArn": "",
+        "DbSecretArn": "",
+        "DbInstanceIdentifier": "",
+    }))
+    result = _run_format(state)
+    assert result.returncode == 0, result.stderr
+    out = result.stdout
+    assert "S3 ingest bucket: (not found)" in out
+    assert "Secret (license): (not found)" in out
+    assert "RDS final snapshot(s) for DB instance: (not found)" in out
+
+
+def test_format_plan_fails_on_missing_state_file(tmp_path):
+    _require_jq()
+    missing = tmp_path / "nope.json"
+    result = subprocess.run(
+        ["sh", str(SCRIPT), "--internal-format-plan", str(missing)],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}: {result.stderr}"
+    )

--- a/tests/unit/test_teardown_lakerunner_lint.py
+++ b/tests/unit/test_teardown_lakerunner_lint.py
@@ -1,0 +1,116 @@
+"""Lint tests for the teardown-lakerunner.sh script.
+
+Mirrors test_upgrade_lakerunner_lint.py: shellcheck-clean, parses, fails
+loudly without required args.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "teardown-lakerunner.sh"
+
+
+def test_script_is_executable():
+    assert SCRIPT.exists(), f"missing {SCRIPT}"
+    assert SCRIPT.stat().st_mode & 0o111, "script should be executable"
+
+
+def test_shellcheck_clean():
+    if shutil.which("shellcheck") is None:
+        pytest.skip("shellcheck not installed on this runner")
+    result = subprocess.run(
+        ["shellcheck", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"shellcheck reported issues:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_runs_with_no_args_and_fails_loudly():
+    """A bare invocation should hit the validation branch and exit code 2,
+    not blow up with a syntax error."""
+    result = subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"},
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}: {result.stderr}"
+    )
+
+
+def test_help_flag_prints_usage_and_exits_zero():
+    result = subprocess.run(
+        ["sh", str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout
+    assert "--yes" in result.stdout
+    assert "--keep-data" in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# Safety: --yes is required to actually destroy anything.  The script's
+# pure-data --internal-check-yes hook reports whether --yes was passed; use
+# it to confirm the gate exists in the parsed-args layer.
+# ---------------------------------------------------------------------------
+
+def test_yes_flag_required_for_destruction():
+    no_yes = subprocess.run(
+        ["sh", str(SCRIPT), "--internal-check-yes"],
+        capture_output=True, text=True,
+    )
+    assert no_yes.returncode == 0, no_yes.stderr
+    assert no_yes.stdout.strip() == "missing-yes"
+
+    with_yes = subprocess.run(
+        ["sh", str(SCRIPT), "--internal-check-yes", "--yes"],
+        capture_output=True, text=True,
+    )
+    assert with_yes.returncode == 0, with_yes.stderr
+    assert with_yes.stdout.strip() == "ok"
+
+
+# ---------------------------------------------------------------------------
+# AWS CLI accepts --role-arn only on cloudformation subcommands in this
+# script — and the deployer role's trust policy only allows
+# cloudformation.amazonaws.com to assume it, so passing --role-arn to s3api
+# / secretsmanager / rds calls would fail twice over.  Guard it.
+# ---------------------------------------------------------------------------
+
+def test_role_arn_only_passed_to_cloudformation_calls():
+    """Collapse backslash-continued lines first, then check that every
+    `--role-arn` occurrence is either docs, a variable assignment, the arg
+    parser, or a real `aws cloudformation ...` invocation."""
+    raw = SCRIPT.read_text()
+    # Join shell line-continuations so multi-line AWS calls become one logical line.
+    joined = raw.replace("\\\n", " ")
+    offenders = []
+    for i, line in enumerate(joined.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            continue
+        if "--role-arn" not in stripped:
+            continue
+        if "aws cloudformation" in stripped:
+            continue
+        if (
+            "deployer_role_arn=" in stripped
+            or '"--deployer-role-arn"' in stripped
+            or "Role ARN" in stripped
+        ):
+            continue
+        offenders.append((i, stripped))
+    assert not offenders, (
+        "--role-arn appears on a non-cloudformation AWS CLI call:\n"
+        + "\n".join(f"  {i}: {ln}" for i, ln in offenders)
+    )


### PR DESCRIPTION
Closes #64.

## Summary

- `docs/operations/tearing-down.md` (new): operator-facing tear-down guide. Lists every retained resource (ingest bucket, license / admin-api-key / db-master secrets, RDS final snapshot) with name pattern, why retained, and how to delete it. Includes a manual AWS-CLI fallback procedure for air-gapped customers, a permissions-model section noting that the deployer role's CFN-only trust policy means post-stack cleanup must run as the operator, and a `DELETE_FAILED` recovery note.
- `docs/operations/deploying.md`: short pointer to the new tear-down doc.
- `scripts/teardown-lakerunner.sh` (new): POSIX shell + jq + AWS CLI v2, mirrors `upgrade-lakerunner.sh` style. Captures retained-resource identifiers from the running stack, then `delete-stack` with the deployer role, waits for `DELETE_COMPLETE`, drains the bucket (handles versioned objects + delete markers), force-deletes the three secrets, and deletes the RDS final snapshot. Defaults to dry-run; requires `--yes` to actually delete. Supports `--keep-data` / `--keep-bucket` / `--keep-secrets` / `--keep-snapshot` for partial tear-downs.
- `tests/unit/test_teardown_lakerunner{,_lint}.py` (new): 13 tests via the script's pure-data internal hooks (`--internal-format-plan`, `--internal-check-yes`). Covers shellcheck, parses, fails loudly without args, `--yes` is required for destruction, every keep-flag, missing-state-fields rendering, and a guard that `--role-arn` is never passed to a non-`aws cloudformation` call.

Builds on PR #65 (deployer-role tear-down perms — RDS snapshot + S3 object), which #64 listed as a prerequisite.

## Test plan

- [x] `make build` clean
- [x] `make test` (329 passed, 1 skipped — all pre-existing tests still green; 13 new tests added)
- [x] `shellcheck scripts/teardown-lakerunner.sh` clean
- [ ] **Live tear-down verification deferred** — needs a throwaway lakerunner stack to confirm the end-to-end flow reaches `DELETE_COMPLETE` and cleans up the bucket / secrets / snapshot via the deployer role + operator identity. Same caveat as PR #65's verification step.