### PR TITLE
deployer-role: grant secretsmanager:GetRandomPassword

### DIFF
--- a/src/cardinal_cfn/cardinal_deployer.py
+++ b/src/cardinal_cfn/cardinal_deployer.py
@@ -239,6 +239,7 @@ _POLICY_STATEMENTS = [
             "secretsmanager:UpdateSecret",
             "secretsmanager:GetSecretValue",
             "secretsmanager:PutSecretValue",
+            "secretsmanager:GetRandomPassword",
             "secretsmanager:TagResource",
             "secretsmanager:UntagResource",
         ],


### PR DESCRIPTION
## Summary
- Adds `secretsmanager:GetRandomPassword` to the deployer role's `Secrets` Sid.
- Without this, `cardinal-cfn-deployer` cannot create the auto-generated `InternalServiceKeysSecret` / `AdminApiKeySecret` in `config.yaml`; create-stack rolls back at first child.

## How discovered
End-to-end test plan run (docs/operations/end-to-end-test-plan.md). Phase 1 create-stack with `--role-arn $DEPLOYER_ROLE_ARN` failed within 10s; ConfigStack reported `User: cardinal-cfn-deployer is not authorized to perform: secretsmanager:GetRandomPassword`. The action only takes `Resource: "*"` so it lives in the existing wildcard Sid.

## Test plan
- [x] `make build` regenerates `cardinal-deployer-role.yaml` with the new action
- [x] `make test` (329 passed, 1 skipped)
- [ ] Tag a release; deploy the regenerated role; rerun Phase 1 of the e2e test plan