### PR TITLE
deployer-role: grant route53 perms for PrivateDnsNamespace

### DIFF
--- a/src/cardinal_cfn/cardinal_deployer.py
+++ b/src/cardinal_cfn/cardinal_deployer.py
@@ -317,6 +317,30 @@ _POLICY_STATEMENTS = [
         "Resource": "*",
     },
     {
+        # AWS::ServiceDiscovery::PrivateDnsNamespace creates a Route 53 private
+        # hosted zone under the hood and associates it with the VPC. The
+        # deployer principal needs the matching route53 perms or namespace
+        # creation fails with AccessDenied on route53:CreateHostedZone.
+        "Sid": "Route53ForPrivateDns",
+        "Effect": "Allow",
+        "Action": [
+            "route53:CreateHostedZone",
+            "route53:DeleteHostedZone",
+            "route53:GetHostedZone",
+            "route53:GetChange",
+            "route53:ChangeResourceRecordSets",
+            "route53:AssociateVPCWithHostedZone",
+            "route53:DisassociateVPCFromHostedZone",
+            "route53:ListHostedZonesByName",
+            "route53:ListHostedZonesByVPC",
+            "route53:CreateVPCAssociationAuthorization",
+            "route53:DeleteVPCAssociationAuthorization",
+            "route53:ChangeTagsForResource",
+            "route53:ListTagsForResource",
+        ],
+        "Resource": "*",
+    },
+    {
         "Sid": "AcmForImportedCerts",
         "Effect": "Allow",
         "Action": [


### PR DESCRIPTION
## Summary
Adds a `Route53ForPrivateDns` Sid to `cardinal-cfn-deployer` covering create/delete/associate of private hosted zones.

`AWS::ServiceDiscovery::PrivateDnsNamespace` (used in `cluster.yaml` for the `cardinal-<install>.local` namespace) creates a Route 53 private hosted zone under the hood and associates it with the VPC. Without these actions, ClusterStack fails at create with `route53:CreateHostedZone` AccessDenied.

## How discovered
Same e2e run as #68; once the secretsmanager fix landed, the next iteration reached ClusterStack and surfaced this gap.

## Test plan
- [x] `make build` regenerates `cardinal-deployer-role.yaml` with the new Sid
- [x] `make test` (329 passed, 1 skipped)
- [ ] Tag, deploy regenerated role, rerun Phase 1 of e2e