### PR TITLE
teardown: fix nested-stack logical IDs (Storage→StorageStack etc)

### DIFF
--- a/scripts/teardown-lakerunner.sh
+++ b/scripts/teardown-lakerunner.sh
@@ -194,9 +194,9 @@ get_stack_output() {
 # ---------------------------------------------------------------------------
 capture_state() {
     log "discovering nested stacks under $stack_name"
-    storage_stack=$(get_nested_stack_id "$stack_name" "Storage")
-    database_stack=$(get_nested_stack_id "$stack_name" "Database")
-    config_stack=$(get_nested_stack_id "$stack_name" "Config")
+    storage_stack=$(get_nested_stack_id "$stack_name" "StorageStack")
+    database_stack=$(get_nested_stack_id "$stack_name" "DatabaseStack")
+    config_stack=$(get_nested_stack_id "$stack_name" "ConfigStack")
 
     install_id_long=$(get_stack_output "$stack_name" "InstallIdLong")
 

--- a/tests/unit/test_teardown_lakerunner_lint.py
+++ b/tests/unit/test_teardown_lakerunner_lint.py
@@ -87,6 +87,38 @@ def test_yes_flag_required_for_destruction():
 # / secretsmanager / rds calls would fail twice over.  Guard it.
 # ---------------------------------------------------------------------------
 
+def test_nested_stack_logical_ids_match_root_template():
+    """The script discovers retained-resource state by looking up nested
+    stacks under the root by logical id (`get_nested_stack_id ROOT
+    LOGICAL_ID`).  If a logical id in the script does not exist in the
+    generated root template the lookup silently returns empty and
+    cleanup skips every retained resource — exactly the bug fixed in
+    this commit.  Pin the logical ids the script depends on against
+    what `cardinal_cfn.root.build()` actually emits."""
+    import re
+
+    # Build the root template fresh so the test never lies about what's in
+    # generated-templates/.
+    from cardinal_cfn.root import build as build_root
+
+    root = build_root()
+    nested_ids = {
+        name
+        for name, res in root.resources.items()
+        if res.resource_type == "AWS::CloudFormation::Stack"
+    }
+    assert {"StorageStack", "DatabaseStack", "ConfigStack"}.issubset(nested_ids), (
+        f"expected StorageStack/DatabaseStack/ConfigStack in root nested ids, got {sorted(nested_ids)}"
+    )
+
+    raw = SCRIPT.read_text()
+    referenced = set(re.findall(r'get_nested_stack_id\s+"\$stack_name"\s+"([^"]+)"', raw))
+    missing = referenced - nested_ids
+    assert not missing, (
+        f"teardown script references nested logical ids that do not exist in the root template: {sorted(missing)}"
+    )
+
+
 def test_role_arn_only_passed_to_cloudformation_calls():
     """Collapse backslash-continued lines first, then check that every
     `--role-arn` occurrence is either docs, a variable assignment, the arg


### PR DESCRIPTION
## Summary
The teardown script looked up `Storage` / `Database` / `Config` as nested-stack logical IDs under the root, but `cardinal_cfn.root.build()` actually emits them as `StorageStack` / `DatabaseStack` / `ConfigStack`. `get_nested_stack_id` quietly returned empty, so `capture_state` wrote a state.json with all retained-resource fields blank. Result: `--yes` would have deleted the stack and skipped cleanup of the ingest bucket, all three retained secrets, and the RDS final snapshot.

## How discovered
e2e test plan, Phase 3 dry-run before any destructive call. With the fix, the dry-run reports all five retained resources correctly.

## Regression guard
Add `test_nested_stack_logical_ids_match_root_template`: parses the script for `get_nested_stack_id "$stack_name" "<id>"` calls and asserts every id exists as an `AWS::CloudFormation::Stack` resource in the freshly-built root template. Catches future logical-id renames that would otherwise silently break teardown.

## Test plan
- [x] `make test` (330 passed, 1 skipped — was 329)
- [x] Manual dry-run against a live stack: all 5 retained-resource fields populated
- [ ] Tag, run end-to-end, verify Phase 3 cleanly removes bucket / secrets / snapshot