### PR TITLE
upgrade-lakerunner: rename cfn() wrapper to cfntool()

### DIFF
--- a/scripts/upgrade-lakerunner.sh
+++ b/scripts/upgrade-lakerunner.sh
@@ -189,7 +189,7 @@ EOF
 # and must invoke `aws cloudformation` directly.  Tests/test_upgrade_lakerunner_lint.py
 # enforces this — keep it that way.
 # ---------------------------------------------------------------------------
-cfn() {
+cfntool() {
     if [ -n "$deployer_role_arn" ]; then
         aws cloudformation "$@" --role-arn "$deployer_role_arn"
     else
@@ -326,7 +326,7 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name"
-    cfn create-change-set \
+    cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type UPDATE \

--- a/tests/unit/test_upgrade_lakerunner_lint.py
+++ b/tests/unit/test_upgrade_lakerunner_lint.py
@@ -51,15 +51,15 @@ def test_runs_with_no_args_and_fails_loudly():
 
 # ---------------------------------------------------------------------------
 # AWS CLI accepts --role-arn only on create-change-set in this script.  Wrapping
-# any other subcommand in `cfn ...` causes the AWS CLI to error out with
+# any other subcommand in `cfntool ...` causes the AWS CLI to error out with
 # "Unknown options: --role-arn".  This regression bit us twice: once on
 # get-template-summary, once on execute-change-set.  Guard it.
 # ---------------------------------------------------------------------------
 
-ALLOWED_CFN_WRAPPED_SUBCOMMANDS = {"create-change-set"}
+ALLOWED_CFNTOOL_WRAPPED_SUBCOMMANDS = {"create-change-set"}
 
 
-def test_cfn_wrapper_only_wraps_role_capable_subcommands():
+def test_cfntool_wrapper_only_wraps_role_capable_subcommands():
     text = SCRIPT.read_text().splitlines()
     offenders = []
     for i, line in enumerate(text, 1):
@@ -67,17 +67,17 @@ def test_cfn_wrapper_only_wraps_role_capable_subcommands():
         # Skip comments, the function definition itself, and the inline help.
         if stripped.startswith("#"):
             continue
-        if not stripped.startswith("cfn "):
+        if not stripped.startswith("cfntool "):
             continue
-        # Extract the first token after `cfn `.
+        # Extract the first token after `cfntool `.
         token = stripped.split()[1] if len(stripped.split()) > 1 else ""
         # Skip lines that aren't actually CFN subcommands (e.g. nothing).
         if not token:
             continue
-        if token not in ALLOWED_CFN_WRAPPED_SUBCOMMANDS:
+        if token not in ALLOWED_CFNTOOL_WRAPPED_SUBCOMMANDS:
             offenders.append((i, stripped))
     assert not offenders, (
-        "cfn() wrapper used on subcommand(s) that don't accept --role-arn:\n"
+        "cfntool() wrapper used on subcommand(s) that don't accept --role-arn:\n"
         + "\n".join(f"  {i}: {ln}" for i, ln in offenders)
-        + f"\nAllowed: {sorted(ALLOWED_CFN_WRAPPED_SUBCOMMANDS)}"
+        + f"\nAllowed: {sorted(ALLOWED_CFNTOOL_WRAPPED_SUBCOMMANDS)}"
     )


### PR DESCRIPTION
## Summary
- Rename the `cfn()` shell wrapper in `scripts/upgrade-lakerunner.sh` to `cfntool()` so the name reflects what it does (inject `--role-arn` for the AWS CLI calls that accept it).
- Update the matching lint test (`tests/unit/test_upgrade_lakerunner_lint.py`) — function name, constant, and the `cfntool ` prefix it greps for.

## Test plan
- [x] `make test-unit` (`105 passed, 1 skipped`)