### PR TITLE
drop NoEcho on cert PEMs and DEX admin password hash

### DIFF
--- a/src/cardinal_cfn/children/cert.py
+++ b/src/cardinal_cfn/children/cert.py
@@ -51,21 +51,18 @@ def build() -> Template:
         "CertificateBody",
         Type="String",
         Default="",
-        NoEcho=True,
         Description="PEM-encoded certificate. Required when CertificateArn is empty.",
     ))
     t.add_parameter(Parameter(
         "CertificatePrivateKey",
         Type="String",
         Default="",
-        NoEcho=True,
         Description="PEM-encoded private key. Required when CertificateArn is empty.",
     ))
     t.add_parameter(Parameter(
         "CertificateChain",
         Type="String",
         Default="",
-        NoEcho=True,
         Description="Optional PEM-encoded chain of intermediate certificates.",
     ))
 

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -52,7 +52,6 @@ from cardinal_cfn.images import add_image_override
 from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import (
     add_install_id_parameters,
-    add_no_echo_parameter,
     add_parameter_group_metadata,
 )
 
@@ -248,15 +247,16 @@ def build() -> Template:
             ),
         )
     )
-    add_no_echo_parameter(
-        t,
+    t.add_parameter(Parameter(
         "DexAdminPasswordHash",
-        description=(
+        Type="String",
+        Default="",
+        Description=(
             "Bcrypt hash of the DEX admin password. Generate with "
-            "`htpasswd -bnBC 10 \"\" 'your-password' | tr -d ':\\n' | sed 's/^/$/' | sed 's/2y/2a/'` "
-            "(or any bcrypt $2a$/$2b$/$2y$ hash). Required."
+            "`htpasswd -bnBC 10 \"\" 'your-password' | cut -d: -f2`. "
+            "Accepts $2a$/$2b$/$2y$. Required."
         ),
-    )
+    ))
 
     # ---------------------------------------------------------------------
     # Console parameter grouping

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -188,39 +188,47 @@ def build() -> Template:
                           description="Optional YAML override for API keys.")
     add_no_echo_parameter(t, "StorageProfilesOverride",
                           description="Optional YAML override for storage profiles.")
-    add_no_echo_parameter(
-        t, "CertificateBody",
-        description=(
+    t.add_parameter(Parameter(
+        "CertificateBody",
+        Type="String",
+        Default="",
+        Description=(
             "PEM-encoded certificate. Required when CertificateArn is empty; "
             "ignored otherwise."
         ),
-    )
-    add_no_echo_parameter(
-        t, "CertificatePrivateKey",
-        description=(
+    ))
+    t.add_parameter(Parameter(
+        "CertificatePrivateKey",
+        Type="String",
+        Default="",
+        Description=(
             "PEM-encoded private key. Required when CertificateArn is empty; "
             "ignored otherwise."
         ),
-    )
-    add_no_echo_parameter(
-        t, "CertificateChain",
-        description=(
+    ))
+    t.add_parameter(Parameter(
+        "CertificateChain",
+        Type="String",
+        Default="",
+        Description=(
             "Optional PEM-encoded chain of intermediate certificates. Used "
             "when CertificateArn is empty."
         ),
-    )
+    ))
     t.add_parameter(Parameter(
         "DexAdminEmail",
         Type="String",
         Default="admin@cardinal.local",
         Description="Email address for the DEX local-DB admin login.",
     ))
-    add_no_echo_parameter(
-        t, "DexAdminPasswordHash",
-        description=(
+    t.add_parameter(Parameter(
+        "DexAdminPasswordHash",
+        Type="String",
+        Default="",
+        Description=(
             "Bcrypt hash ($2a$/$2b$/$2y$) of the DEX admin password. Required."
         ),
-    )
+    ))
     t.add_parameter(Parameter(
         "OidcSuperadminEmails",
         Type="String",

--- a/tests/templates/test_cert.py
+++ b/tests/templates/test_cert.py
@@ -19,10 +19,10 @@ def test_required_parameters(template_dict):
         assert n in template_dict["Parameters"], f"missing parameter: {n}"
 
 
-def test_pem_parameters_are_no_echo(template_dict):
+def test_pem_parameters_not_no_echo(template_dict):
     for n in ("CertificateBody", "CertificatePrivateKey", "CertificateChain"):
-        assert template_dict["Parameters"][n].get("NoEcho") is True, (
-            f"{n} must be NoEcho=true"
+        assert "NoEcho" not in template_dict["Parameters"][n], (
+            f"{n} must be a plain text parameter, not NoEcho"
         )
 
 


### PR DESCRIPTION
## Summary

- Removes `NoEcho=True` from `CertificateBody`, `CertificatePrivateKey`, `CertificateChain` (root + cert child) and from `DexAdminPasswordHash` (root + maestro child).
- Console renders these as plain text fields so customers can paste PEMs and the bcrypt hash without the masked-password UI.
- Updates `tests/templates/test_cert.py` to assert the PEM params are NOT NoEcho.

## Caveat

The bcrypt hash is fine to expose (already a hash), but `CertificatePrivateKey` is a real secret. Without `NoEcho`, the private key will appear in CloudFormation events, `GetTemplateSummary` output, and the console parameter view. This is an intentional UX tradeoff — confirm before merging.

This change conflicts with the rule in `CLAUDE.md`: "Parameters carrying secrets ... declare `NoEcho: true`." If we land this, that doc line should be revisited.

## Test plan

- [x] `make build` (cfn-lint clean apart from pre-existing W2001)
- [x] `make test` (336 passed, 1 skipped)
- [ ] Spot-check CloudFormation console: confirm the four parameters render as text boxes, not masked password fields