### PR TITLE
alb: drop PublicSubnets/AlbScheme; auto-recover ROLLBACK_COMPLETE

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The stack creates RDS, S3, SQS, ALB, all ECS services, runs the migration, and o
 
 ## Quick start (you need a VPC)
 
-Deploy `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/latest/cardinal-vpc.yaml` first, then use its `VpcId`, `PrivateSubnetsCsv`, and `PublicSubnetsCsv` outputs as inputs to the `cardinal-lakerunner.yaml` deploy.
+Deploy `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/latest/cardinal-vpc.yaml` first, then use its `VpcId` and `PrivateSubnetsCsv` outputs as inputs to the `cardinal-lakerunner.yaml` deploy. The application stack runs entirely in private subnets behind an internal ALB; the VPC's `PublicSubnetsCsv` output is exposed for completeness but is not required by the application stack.
 
 ## Versioned URLs
 

--- a/docs/operations/end-to-end-test-plan.md
+++ b/docs/operations/end-to-end-test-plan.md
@@ -40,7 +40,7 @@ Capture the account ID and the IAM identity (user or assumed role) the Jenkins A
 
 Either:
 
-- **Use an existing VPC** in the account. Capture VpcId and at least two private subnet IDs in distinct AZs. For an internet-facing ALB, also capture at least two public subnet IDs.
+- **Use an existing VPC** in the account. Capture VpcId and at least two private subnet IDs in distinct AZs. The application stack runs entirely in private subnets behind an internal ALB; public subnets are not used by this stack.
 - **Or deploy the Cardinal VPC stack once** via the AWS Console or CLI (this stack survives all subsequent trials):
 
     ```sh
@@ -56,14 +56,11 @@ Either:
         --query 'Stacks[0].Outputs' --output table
     ```
 
-    Note `VpcId`, `PublicSubnetsCsv`, `PrivateSubnetsCsv` from the outputs.
+    Note `VpcId` and `PrivateSubnetsCsv` from the outputs. (`PublicSubnetsCsv` is also exposed but is not used by the lakerunner application stack.)
 
-### C. ALB scheme decision
+### C. ALB reachability
 
-Pick **one** for the test; the spec assumes internet-facing because there is no DNS / VPN / bastion in the test environment and we need to curl the ALB from the operator's laptop:
-
-- **`internet-facing`** (recommended for this test). Requires `PublicSubnets` to be set. ALB gets a public DNS that is reachable from anywhere.
-- `internal`. Cheaper, more secure, but requires a way to reach the ALB from inside the VPC (e.g. SSM Session Manager into an EC2 in a private subnet, then `curl` from there). Not the default for this spec.
+The lakerunner ALB is always **internal** -- the application stack does not provision or attach to public subnets. To reach the ALB from outside the VPC during testing you need a route in: SSM Session Manager into an EC2 instance in a private subnet, a bastion host, a VPN, Direct Connect, or VPC peering. The simplest path for a one-off test account is `aws ssm start-session` into a small Amazon Linux EC2 in one of the private subnets and `curl -k https://<alb-dns>/...` from there.
 
 ### D. Self-signed TLS cert
 
@@ -121,8 +118,6 @@ Copy `jenkins/Jenkinsfile.lakerunner` into a Jenkins **Pipeline** job (inline or
 | `AwsCredentialsId` | the binding for the test account |
 | `VpcId` | from B |
 | `PrivateSubnets` | comma-separated IDs from B |
-| `PublicSubnets` | comma-separated IDs from B |
-| `AlbScheme` | `internet-facing` |
 | `CertificateArn` | leave empty (we are importing PEMs) |
 | `LicenseData` | paste the JSON from F |
 | `DexAdminEmail` | from E (e.g. `admin@cardinal.test`) |

--- a/docs/operations/jenkins-deploy.md
+++ b/docs/operations/jenkins-deploy.md
@@ -53,7 +53,7 @@ In your AWS account: a CloudFormation deployer role created from `cardinal-deplo
     - `AwsCredentialsId` — the Jenkins credential binding ID with permission to run CloudFormation against this account.
     - `DeployerRoleArn` — the ARN of the deployer role for this account.
 3. **For new installs**, also fill in:
-    - `VpcId`, `PrivateSubnets`, `PublicSubnets` (latter required only when `AlbScheme=internet-facing`)
+    - `VpcId`, `PrivateSubnets` (the application stack runs entirely in private subnets behind an internal ALB)
     - `LicenseData` — paste the license JSON. Visible in the build UI on purpose so you can verify it before running.
     - `DexAdminEmail`, `OidcSuperadminEmails`
     - `DexAdminPasswordHashCredentialId` — the ID of a Jenkins **Secret Text** credential containing the bcrypt hash. **Required.**
@@ -83,9 +83,7 @@ For multiple installs, repeat for each — one job per install. After install, t
 | Parameter | Notes |
 |---|---|
 | `VpcId` | Required for install |
-| `PrivateSubnets` | Required for install. Comma-separated subnet IDs |
-| `PublicSubnets` | Required if `AlbScheme=internet-facing` |
-| `AlbScheme` | `internal` or `internet-facing` |
+| `PrivateSubnets` | Required for install. Comma-separated subnet IDs. The ALB is internal-only and lives in these subnets |
 | `CertificateArn` | Existing ACM cert. Alternative to PEM import below. See `docs/operations/certificates.md` for how to obtain one |
 | `LicenseData` | License JSON. **Visible** in the build UI for verification |
 | `DexAdminEmail` | DEX admin login email |
@@ -129,12 +127,12 @@ When `AutoApprove=false`, the pipeline pauses here and waits for an operator to 
 
 ## Recovery
 
-If the deploy lands the stack in `UPDATE_FAILED`, `UPDATE_ROLLBACK_COMPLETE`, `CREATE_FAILED`, or `ROLLBACK_COMPLETE`, the build is red. For upgrades, the stack has either applied nothing or fully rolled back automatically. For installs, a `ROLLBACK_COMPLETE` stack must be deleted before retrying. Re-run the job once the underlying issue is fixed:
+If the deploy lands the stack in `UPDATE_FAILED`, `UPDATE_ROLLBACK_COMPLETE`, `CREATE_FAILED`, or `ROLLBACK_COMPLETE`, the build is red. For upgrades, the stack has either applied nothing or fully rolled back automatically. Re-run the job once the underlying issue is fixed:
 
 - **Bad image tag** → publish a fixed image, re-run.
 - **Parameter without default required** → the script prints the parameter name; supply it on the next run (currently via the script's flags or by adding it as a job parameter).
 - **AWS API throttling / transient error** → re-run.
-- **Install rolled back** → `aws cloudformation delete-stack`, then re-run. CloudFormation does not allow updating a `ROLLBACK_COMPLETE` stack.
+- **Install rolled back (`ROLLBACK_COMPLETE`)** → just re-run the job. The script auto-deletes the empty `ROLLBACK_COMPLETE` stack and re-enters CREATE mode (same recovery path as `REVIEW_IN_PROGRESS`).
 
 If the stack lands in `UPDATE_ROLLBACK_FAILED`, you are in the IAM-rollback wedge described in `docs/operations/deploying.md`. The fix is to ensure all upgrades use a deployer role; see that document for one-time recovery steps.
 

--- a/docs/superpowers/specs/2026-04-28-cardinal-cfn-refactor-design.md
+++ b/docs/superpowers/specs/2026-04-28-cardinal-cfn-refactor-design.md
@@ -102,7 +102,6 @@ The install suffix is computed from `AWS::StackId`, which is fixed for the lifet
 The root template `cardinal-lakerunner.yaml` is an orchestrator. It contains:
 
 - Customer-facing parameters and `Metadata` for console parameter groups
-- Conditions (e.g. `HasPublicSubnets`)
 - The `InstallId` derivation
 - One `AWS::CloudFormation::Stack` resource per nested child, with `TemplateURL` pointing at the vendor S3 bucket and parameters threaded through
 - Top-level `Outputs` (ALB DNS name, Maestro URL, query API URL)
@@ -156,7 +155,7 @@ CloudFormation does not allow sibling nested stacks to reference each other dire
 
 Root template generator code centralizes this wiring so that adding a new dependency between children is a one-line change.
 
-**List-typed parameters and nested stacks.** CloudFormation passes nested-stack parameters as strings. List parameters such as `PrivateSubnets` and `PublicSubnets` cannot be reliably forwarded as `List<AWS::EC2::Subnet::Id>` from root → child; the conversion is unstable and AWS warns against it. The convention is: every child template that needs a subnet list declares the parameter as `String` (a comma-separated list), and the child uses `Fn::Split(",", ...)` internally. The root template joins lists with `Fn::Join(",", ...)` before passing.
+**List-typed parameters and nested stacks.** CloudFormation passes nested-stack parameters as strings. A list parameter such as `PrivateSubnets` cannot be reliably forwarded as `List<AWS::EC2::Subnet::Id>` from root → child; the conversion is unstable and AWS warns against it. The convention is: every child template that needs a subnet list declares the parameter as `String` (a comma-separated list), and the child uses `Fn::Split(",", ...)` internally. The root template joins lists with `Fn::Join(",", ...)` before passing.
 
 ### Service tier model
 
@@ -216,8 +215,7 @@ Each priority is hard-coded into the per-service ListenerRule in its current tie
 
 ### Networking
 
-- `PublicSubnets` (List<AWS::EC2::Subnet::Id>, default empty — required only if `AlbScheme=internet-facing`)
-- `AlbScheme` — `internal` (default) or `internet-facing`
+The application stack runs entirely in private subnets behind an **internal** ALB. The ALB scheme is hard-coded — there is no `PublicSubnets` or `AlbScheme` parameter on the root template. Customers who need to expose the ALB externally must do so out-of-band (e.g. an upstream NLB/ALB, API Gateway, VPN, or peering). The standalone `cardinal-vpc.yaml` template still creates public subnets for its own NAT gateway, but those subnets are not consumed by the application stack.
 
 ### Sizing (with defaults from `lakerunner-stack-defaults.yaml`)
 

--- a/jenkins/Jenkinsfile.lakerunner
+++ b/jenkins/Jenkinsfile.lakerunner
@@ -69,16 +69,6 @@ pipeline {
             description: 'INSTALL: comma-separated private subnet IDs.  Required for new installs.'
         )
         string(
-            name: 'PublicSubnets',
-            defaultValue: '',
-            description: 'INSTALL: comma-separated public subnet IDs.  Required if AlbScheme=internet-facing.'
-        )
-        string(
-            name: 'AlbScheme',
-            defaultValue: 'internal',
-            description: 'INSTALL: ALB scheme (internal or internet-facing).'
-        )
-        string(
             name: 'CertificateArn',
             defaultValue: '',
             description: 'INSTALL: existing ACM cert ARN.  Leave empty to import PEMs via the credential bindings below.'
@@ -246,8 +236,6 @@ def runDeploy(boolean planOnly) {
 
         if (params.VpcId?.trim())               args << "--vpc-id '${params.VpcId}'"
         if (params.PrivateSubnets?.trim())      args << "--private-subnets '${params.PrivateSubnets}'"
-        if (params.PublicSubnets?.trim())       args << "--public-subnets '${params.PublicSubnets}'"
-        if (params.AlbScheme?.trim())           args << "--alb-scheme '${params.AlbScheme}'"
         if (params.CertificateArn?.trim())      args << "--certificate-arn '${params.CertificateArn}'"
         if (params.DexAdminEmail?.trim())       args << "--dex-admin-email '${params.DexAdminEmail}'"
         if (params.OidcSuperadminEmails?.trim()) args << "--oidc-superadmin-emails '${params.OidcSuperadminEmails}'"

--- a/scripts/deploy-lakerunner.sh
+++ b/scripts/deploy-lakerunner.sh
@@ -31,8 +31,6 @@ no_execute="false"
 # Install-only flags.  Ignored on UPDATE.
 cli_vpc_id=""
 cli_private_subnets=""
-cli_public_subnets=""
-cli_alb_scheme=""
 cli_certificate_arn=""
 cli_dex_admin_email=""
 cli_dex_admin_password_hash=""
@@ -73,8 +71,6 @@ Optional (both modes):
 Install-only (used when the stack does not yet exist; ignored on UPDATE):
   --vpc-id VPC                Required for install.
   --private-subnets CSV       Required for install (comma-separated subnet IDs).
-  --public-subnets CSV        Required when --alb-scheme=internet-facing.
-  --alb-scheme SCHEME         internal | internet-facing
   --certificate-arn ARN       Existing ACM cert (alternative to PEM import).
   --certificate-body-file PATH         PEM cert (used when --certificate-arn empty).
   --certificate-private-key-file PATH  PEM private key (used when --certificate-arn empty).
@@ -314,8 +310,6 @@ parse_args() {
             --no-execute) no_execute="true"; shift ;;
             --vpc-id) cli_vpc_id="$2"; shift 2 ;;
             --private-subnets) cli_private_subnets="$2"; shift 2 ;;
-            --public-subnets) cli_public_subnets="$2"; shift 2 ;;
-            --alb-scheme) cli_alb_scheme="$2"; shift 2 ;;
             --certificate-arn) cli_certificate_arn="$2"; shift 2 ;;
             --certificate-body-file) cli_certificate_body_file="$2"; shift 2 ;;
             --certificate-private-key-file) cli_certificate_private_key_file="$2"; shift 2 ;;
@@ -376,8 +370,6 @@ build_create_overrides() {
     jq -n \
         --arg vpc_id "$cli_vpc_id" \
         --arg private_subnets "$cli_private_subnets" \
-        --arg public_subnets "$cli_public_subnets" \
-        --arg alb_scheme "$cli_alb_scheme" \
         --arg cert_arn "$cli_certificate_arn" \
         --arg cert_body "$cert_body" \
         --arg cert_pkey "$cert_pkey" \
@@ -390,8 +382,6 @@ build_create_overrides() {
         '{
             VpcId: $vpc_id,
             PrivateSubnets: $private_subnets,
-            PublicSubnets: $public_subnets,
-            AlbScheme: $alb_scheme,
             CertificateArn: $cert_arn,
             CertificateBody: $cert_body,
             CertificatePrivateKey: $cert_pkey,
@@ -442,28 +432,33 @@ main() {
     fi
 
     log "checking whether stack $stack_name exists in $region"
-    # REVIEW_IN_PROGRESS is the state CloudFormation puts a stack in after
-    # a CREATE-type change set has been described but never executed (i.e.
-    # `--no-execute` was used and either the change set is still pending
-    # or was deleted manually).  No real resources exist yet; the stack
-    # must be deleted before a new CREATE can be issued, and treating it
-    # as UPDATE would fail because UsePreviousValue cannot supply install-
-    # only parameters.  We auto-recover by deleting it and treating the
-    # stack as nonexistent for mode selection.
+    # REVIEW_IN_PROGRESS and ROLLBACK_COMPLETE both indicate a stack record
+    # with no live resources:
+    #   - REVIEW_IN_PROGRESS: a CREATE-type change set was described but
+    #     never executed (`--no-execute` followed by no Apply, or a manual
+    #     change-set delete).
+    #   - ROLLBACK_COMPLETE: the initial CREATE failed and CloudFormation
+    #     rolled everything back; the empty stack record remains and CFN
+    #     refuses any further UPDATE against it.
+    # Both must be deleted before a fresh CREATE can succeed, and both are
+    # safe to delete (no surviving resources).  Treat the stack as
+    # nonexistent for mode selection.
     existing_status=$(aws cloudformation describe-stacks \
             --stack-name "$stack_name" \
             --region "$region" \
             --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "")
-    if [ "$existing_status" = "REVIEW_IN_PROGRESS" ]; then
-        log "found stale REVIEW_IN_PROGRESS stack; deleting before CREATE"
-        aws cloudformation delete-stack \
-            --stack-name "$stack_name" \
-            --region "$region" >/dev/null 2>&1 || true
-        aws cloudformation wait stack-delete-complete \
-            --stack-name "$stack_name" \
-            --region "$region" >/dev/null 2>&1 || true
-        existing_status=""
-    fi
+    case "$existing_status" in
+        REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE)
+            log "found stale $existing_status stack; deleting before CREATE"
+            aws cloudformation delete-stack \
+                --stack-name "$stack_name" \
+                --region "$region" >/dev/null 2>&1 || true
+            aws cloudformation wait stack-delete-complete \
+                --stack-name "$stack_name" \
+                --region "$region" >/dev/null 2>&1 || true
+            existing_status=""
+            ;;
+    esac
     if [ -n "$existing_status" ]; then
         mode="update"
         cs_type="UPDATE"

--- a/src/cardinal_cfn/children/alb.py
+++ b/src/cardinal_cfn/children/alb.py
@@ -7,8 +7,6 @@ from troposphere import (
     GetAtt,
     Output,
     Split,
-    If,
-    Equals,
 )
 from troposphere.elasticloadbalancingv2 import (
     LoadBalancer,
@@ -41,26 +39,9 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "PublicSubnetsCsv",
-            Type="String",
-            Default="",
-            Description="Comma-separated public subnet IDs. Required when AlbScheme is internet-facing.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
             "PrivateSubnetsCsv",
             Type="String",
             Description="Comma-separated private subnet IDs.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
-            "AlbScheme",
-            Type="String",
-            Default="internal",
-            AllowedValues=["internal", "internet-facing"],
-            Description="ALB scheme: internal (private subnets) or internet-facing (public subnets).",
         )
     )
     t.add_parameter(
@@ -77,9 +58,6 @@ def build() -> Template:
             Description="ACM certificate ARN for the HTTPS listener. Must be a valid certificate ARN.",
         )
     )
-
-    # Conditions
-    t.add_condition("IsInternetFacing", Equals(Ref("AlbScheme"), "internet-facing"))
 
     alb_sg = t.add_resource(
         SecurityGroup(
@@ -109,12 +87,8 @@ def build() -> Template:
     alb = t.add_resource(
         LoadBalancer(
             "Alb",
-            Scheme=Ref("AlbScheme"),
-            Subnets=If(
-                "IsInternetFacing",
-                Split(",", Ref("PublicSubnetsCsv")),
-                Split(",", Ref("PrivateSubnetsCsv")),
-            ),
+            Scheme="internal",
+            Subnets=Split(",", Ref("PrivateSubnetsCsv")),
             SecurityGroups=[Ref(alb_sg)],
             Type="application",
             Tags=cardinal_tags(component="networking", role="alb"),

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -12,9 +12,7 @@ from troposphere import (
     Parameter,
     Ref,
     GetAtt,
-    Equals,
     Join,
-    Not,
     Output,
     Sub,
 )
@@ -157,19 +155,6 @@ def build() -> Template:
         Description="Private subnet IDs (>=2 across different AZs).",
     ))
     t.add_parameter(Parameter(
-        "PublicSubnets",
-        Type="List<AWS::EC2::Subnet::Id>",
-        Default="",
-        Description="Public subnet IDs. Required only when AlbScheme=internet-facing.",
-    ))
-    t.add_parameter(Parameter(
-        "AlbScheme",
-        Type="String",
-        Default="internal",
-        AllowedValues=["internal", "internet-facing"],
-        Description="ALB scheme.",
-    ))
-    t.add_parameter(Parameter(
         "CertificateArn",
         Type="String",
         Default="",
@@ -281,20 +266,13 @@ def build() -> Template:
     ]
 
     # ---------------------------------------------------------------------
-    # Conditions
-    # ---------------------------------------------------------------------
-    t.add_condition("HasPublicSubnets",
-                    Not(Equals(Join(",", Ref("PublicSubnets")), "")))
-
-    # ---------------------------------------------------------------------
     # Console grouping
     # ---------------------------------------------------------------------
     add_parameter_group_metadata(
         t,
         groups=[
             {"label": "Networking",
-             "parameters": ["VpcId", "PrivateSubnets", "PublicSubnets",
-                            "AlbScheme", "CertificateArn",
+             "parameters": ["VpcId", "PrivateSubnets", "CertificateArn",
                             "CertificateBody", "CertificatePrivateKey",
                             "CertificateChain"]},
             {"label": "Sizing", "parameters": sizing_param_names},
@@ -314,7 +292,6 @@ def build() -> Template:
     install_short = install_id_short()
     install_long = install_id_long()
     private_subnets_csv = Join(",", Ref("PrivateSubnets"))
-    public_subnets_csv = Join(",", Ref("PublicSubnets"))
 
     # ---------------------------------------------------------------------
     # Nested children
@@ -362,9 +339,7 @@ def build() -> Template:
         "InstallIdShort": install_short,
         "InstallIdLong": install_long,
         "VpcId": Ref("VpcId"),
-        "PublicSubnetsCsv": public_subnets_csv,
         "PrivateSubnetsCsv": private_subnets_csv,
-        "AlbScheme": Ref("AlbScheme"),
         "TaskSecurityGroupId": GetAtt(cluster_stack, "Outputs.TaskSecurityGroupId"),
         "CertificateArn": GetAtt(cert_stack, "Outputs.EffectiveCertificateArn"),
     }, depends_on=["ClusterStack", "CertStack"])

--- a/tests/templates/test_alb.py
+++ b/tests/templates/test_alb.py
@@ -13,9 +13,26 @@ def template_dict():
 
 
 def test_required_parameters(template_dict):
-    for n in ("InstallIdShort", "InstallIdLong", "VpcId", "PublicSubnetsCsv",
-              "PrivateSubnetsCsv", "AlbScheme", "TaskSecurityGroupId"):
+    for n in ("InstallIdShort", "InstallIdLong", "VpcId",
+              "PrivateSubnetsCsv", "TaskSecurityGroupId"):
         assert n in template_dict["Parameters"], f"missing parameter: {n}"
+
+
+def test_no_public_subnet_or_alb_scheme_parameters(template_dict):
+    for n in ("PublicSubnetsCsv", "AlbScheme"):
+        assert n not in template_dict["Parameters"], (
+            f"parameter {n} should have been removed"
+        )
+
+
+def test_alb_is_internal(template_dict):
+    alb_def = next(
+        v for v in template_dict["Resources"].values()
+        if v["Type"] == "AWS::ElasticLoadBalancingV2::LoadBalancer"
+    )
+    assert alb_def["Properties"]["Scheme"] == "internal"
+    subnets = alb_def["Properties"]["Subnets"]
+    assert subnets == {"Fn::Split": [",", {"Ref": "PrivateSubnetsCsv"}]}
 
 
 def test_creates_load_balancer(template_dict):

--- a/tests/templates/test_root.py
+++ b/tests/templates/test_root.py
@@ -16,8 +16,6 @@ def test_required_parameters(td):
     for n in (
         "VpcId",
         "PrivateSubnets",
-        "PublicSubnets",
-        "AlbScheme",
         "CertificateArn",
         "LicenseData",
         "ApiKeysOverride",
@@ -25,6 +23,21 @@ def test_required_parameters(td):
         "TemplateBaseUrl",
     ):
         assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_no_public_subnet_or_alb_scheme_parameters(td):
+    for n in ("PublicSubnets", "AlbScheme"):
+        assert n not in td["Parameters"], (
+            f"parameter {n} should have been removed"
+        )
+
+
+def test_alb_stack_does_not_receive_public_subnets_or_scheme(td):
+    params = td["Resources"]["AlbStack"]["Properties"]["Parameters"]
+    for n in ("PublicSubnetsCsv", "AlbScheme"):
+        assert n not in params, (
+            f"AlbStack should no longer be passed {n}"
+        )
 
 
 def test_template_base_url_default_pattern(td):
@@ -157,5 +170,5 @@ def test_outputs(td):
         assert n in td["Outputs"], f"missing output: {n}"
 
 
-def test_has_public_subnets_condition(td):
-    assert "HasPublicSubnets" in td.get("Conditions", {})
+def test_no_public_subnets_condition(td):
+    assert "HasPublicSubnets" not in td.get("Conditions", {})

--- a/tests/unit/test_deploy_lakerunner.py
+++ b/tests/unit/test_deploy_lakerunner.py
@@ -369,8 +369,8 @@ def test_create_uses_template_default_when_no_override(tmp_path):
     _require_jq()
     new_template = [
         {
-            "ParameterKey": "AlbScheme",
-            "DefaultValue": "internal",
+            "ParameterKey": "DbInstanceClass",
+            "DefaultValue": "db.t4g.xlarge",
             "ParameterType": "String",
         },
     ]
@@ -378,7 +378,10 @@ def test_create_uses_template_default_when_no_override(tmp_path):
     result = _run_resolve_create(tmp_path, new_template, overrides)
     assert result.returncode == 0, result.stderr
     out = _by_key(json.loads(result.stdout))
-    assert out["AlbScheme"] == {"ParameterKey": "AlbScheme", "ParameterValue": "internal"}
+    assert out["DbInstanceClass"] == {
+        "ParameterKey": "DbInstanceClass",
+        "ParameterValue": "db.t4g.xlarge",
+    }
 
 
 def test_create_override_beats_template_default(tmp_path):
@@ -418,14 +421,14 @@ def test_create_required_param_missing_fails_loudly(tmp_path):
 
 def test_create_full_install_mix(tmp_path):
     """Realistic install: VpcId/Subnets/License from CLI overrides, *Image and
-    AlbScheme from template defaults, DexAdminEmail overridden by CLI."""
+    DbInstanceClass from template defaults, DexAdminEmail overridden by CLI."""
     _require_jq()
     new_template = [
         {"ParameterKey": "VpcId", "ParameterType": "AWS::EC2::VPC::Id"},
         {"ParameterKey": "PrivateSubnets", "ParameterType": "CommaDelimitedList"},
         {
-            "ParameterKey": "AlbScheme",
-            "DefaultValue": "internal",
+            "ParameterKey": "DbInstanceClass",
+            "DefaultValue": "db.t4g.xlarge",
             "ParameterType": "String",
         },
         {
@@ -459,7 +462,7 @@ def test_create_full_install_mix(tmp_path):
     out = _by_key(json.loads(result.stdout))
     assert out["VpcId"]["ParameterValue"] == "vpc-0abc123"
     assert out["PrivateSubnets"]["ParameterValue"] == "subnet-1,subnet-2"
-    assert out["AlbScheme"]["ParameterValue"] == "internal"  # template default
+    assert out["DbInstanceClass"]["ParameterValue"] == "db.t4g.xlarge"  # template default
     assert out["LakerunnerImage"]["ParameterValue"].endswith("1.20.0")
     assert out["DexAdminEmail"]["ParameterValue"] == "ops@example.com"  # CLI overrides default
     assert out["DexAdminPasswordHash"]["ParameterValue"].startswith("$2b$12$")

--- a/tests/unit/test_deploy_lakerunner_lint.py
+++ b/tests/unit/test_deploy_lakerunner_lint.py
@@ -65,6 +65,17 @@ def test_review_in_progress_handling_present():
     )
 
 
+def test_rollback_complete_handling_present():
+    """A failed initial CREATE leaves the stack in ROLLBACK_COMPLETE.
+    CloudFormation refuses any UPDATE against such a stack, so the deploy
+    script must auto-recover the same way it does for REVIEW_IN_PROGRESS:
+    delete the empty stack and re-enter CREATE mode."""
+    text = SCRIPT.read_text()
+    assert "ROLLBACK_COMPLETE" in text, (
+        "deploy script must handle ROLLBACK_COMPLETE state explicitly"
+    )
+
+
 # ---------------------------------------------------------------------------
 # AWS CLI accepts --role-arn only on create-change-set in this script.  Wrapping
 # any other subcommand in `cfntool ...` causes the AWS CLI to error out with


### PR DESCRIPTION
## Summary

- The application stack now runs entirely in private subnets behind an **internal** ALB. `PublicSubnets` and `AlbScheme` are removed from the root template, the `alb` child, the deploy script, and the Jenkinsfile. Customers needing external exposure handle it out-of-band (upstream NLB/ALB, API Gateway, VPN, peering).
- `cardinal-vpc.yaml` is unchanged -- it still creates public subnets for its NAT gateway, but the app stack no longer consumes them.
- `scripts/deploy-lakerunner.sh` now auto-recovers from `ROLLBACK_COMPLETE` the same way it does from `REVIEW_IN_PROGRESS`: delete the empty stack and re-enter CREATE mode. A failed initial install no longer requires a manual `delete-stack` before retrying.

## Test plan

- [x] `make build` — generates all templates, cfn-lint clean (only pre-existing W2001 warnings)
- [x] `make test` — 339 passed, 3 skipped, 0 failed
- [x] Verify generated `alb.yaml` has hard-coded `Scheme: internal` and no `PublicSubnetsCsv` / `AlbScheme` parameters
- [x] Verify generated root has no `PublicSubnets` / `AlbScheme` parameters and `AlbStack` no longer receives them
- [ ] On a test account, run a fresh install and confirm only `VpcId` + `PrivateSubnets` are required for networking
- [ ] On a test account, force a `ROLLBACK_COMPLETE` (e.g. invalid license) and confirm the next deploy run auto-recovers without a manual `delete-stack`