### PR TITLE
docs: split permissions into infrastructure + lakerunner

### DIFF
--- a/docs/operations/permissions-infrastructure.md
+++ b/docs/operations/permissions-infrastructure.md
@@ -1,0 +1,67 @@
+# Permissions — infrastructure (install-time)
+
+What the **deployer principal** (CI role, human, or service account that
+runs `cloudformation deploy` against the lakerunner templates) needs in
+order to create, update, and tear down the AWS resources the templates
+declare.
+
+This is the "what does your platform team need to provision?" half of the
+permissions story. Runtime permissions — the IAM roles assumed by the
+running tasks themselves — live in `permissions-lakerunner.md`.
+
+VPC is bring-your-own and intentionally excluded.
+
+## Scope assumptions
+
+- Resource ARNs match `cardinal-*` and `cardinal/${InstallIdLong}/*` where
+  the AWS API supports name-prefix scoping.
+- `iam:PassRole` is scoped to `arn:aws:iam::${account}:role/cardinal-*`.
+- No `kms:*` is required — the templates rely on AWS-managed keys for
+  RDS, Secrets Manager, and S3.
+- The deployer never touches running data planes — it only creates,
+  updates, and deletes infrastructure.
+
+## API actions by AWS service
+
+| Service | Why the deployer needs it | Minimum API actions |
+|---|---|---|
+| `cloudformation` | Create/update/delete the root stack and the 12 nested children; CFN reads the published S3 templates. | `CreateStack`, `UpdateStack`, `DeleteStack`, `DescribeStacks`, `DescribeStackEvents`, `DescribeStackResources`, `DescribeStackResource`, `GetTemplate`, `ListStacks`, `CreateChangeSet`, `DescribeChangeSet`, `ExecuteChangeSet`, `DeleteChangeSet` |
+| `iam` | Create/delete the ~14 task roles, the shared execution role, and the 2 Lambda roles; pass them to ECS and Lambda. | `CreateRole`, `DeleteRole`, `GetRole`, `UpdateRole`, `PutRolePolicy`, `GetRolePolicy`, `DeleteRolePolicy`, `AttachRolePolicy`, `DetachRolePolicy`, `ListRolePolicies`, `ListAttachedRolePolicies`, `TagRole`, `UntagRole`, `PassRole` |
+| `ecs` | Cluster, task definitions, services. | `CreateCluster`, `DeleteCluster`, `DescribeClusters`, `RegisterTaskDefinition`, `DeregisterTaskDefinition`, `DescribeTaskDefinition`, `CreateService`, `UpdateService`, `DeleteService`, `DescribeServices`, `ListServices`, `ListTasks`, `DescribeTasks`, `RunTask` (manual migrations only — CFN drives the install-time run via the migration Lambda), `TagResource` |
+| `rds` | Postgres instance + subnet group. | `CreateDBInstance`, `DeleteDBInstance`, `ModifyDBInstance`, `DescribeDBInstances`, `CreateDBSubnetGroup`, `DeleteDBSubnetGroup`, `DescribeDBSubnetGroups`, `AddTagsToResource`, `RemoveTagsFromResource`, `ListTagsForResource` |
+| `ec2` (security groups only) | Three SGs + their ingress rules. VPC, subnets, route tables are excluded. | `CreateSecurityGroup`, `DeleteSecurityGroup`, `DescribeSecurityGroups`, `AuthorizeSecurityGroupIngress`, `AuthorizeSecurityGroupEgress`, `RevokeSecurityGroupIngress`, `RevokeSecurityGroupEgress`, `CreateTags`, `DeleteTags`, `DescribeTags` |
+| `elasticloadbalancingv2` | ALB, two listeners, target groups, listener rules. | `CreateLoadBalancer`, `DeleteLoadBalancer`, `DescribeLoadBalancers`, `ModifyLoadBalancerAttributes`, `CreateListener`, `DeleteListener`, `ModifyListener`, `DescribeListeners`, `CreateTargetGroup`, `DeleteTargetGroup`, `DescribeTargetGroups`, `ModifyTargetGroup`, `CreateRule`, `DeleteRule`, `ModifyRule`, `DescribeRules`, `AddTags`, `RemoveTags`, `DescribeTags` |
+| `s3` | Ingest bucket + lifecycle + bucket-event notification. | `CreateBucket`, `DeleteBucket`, `PutBucketLifecycleConfiguration`, `GetBucketLifecycleConfiguration`, `PutBucketNotification`, `GetBucketNotification`, `PutBucketTagging`, `GetBucketTagging`, `GetBucketLocation`, `ListBucket` |
+| `sqs` | Ingest queue + its resource policy. | `CreateQueue`, `DeleteQueue`, `SetQueueAttributes`, `GetQueueAttributes`, `GetQueueUrl`, `ListQueues`, `TagQueue`, `UntagQueue`, `ListQueueTags` |
+| `secretsmanager` | DB master, maestro DB, license, internal-keys, admin-key. | `CreateSecret`, `DeleteSecret`, `UpdateSecret`, `DescribeSecret`, `GetRandomPassword`, `TagResource`, `UntagResource`, `ListSecrets` |
+| `ssm` | Two config parameters under `parameter/cardinal/${InstallIdLong}/*`. | `PutParameter`, `DeleteParameter`, `GetParameter`, `GetParameters`, `DescribeParameters`, `AddTagsToResource`, `RemoveTagsFromResource`, `ListTagsForResource` |
+| `logs` | Per-service log groups + retention. | `CreateLogGroup`, `DeleteLogGroup`, `PutRetentionPolicy`, `DescribeLogGroups`, `TagResource`, `UntagResource`, `ListTagsForResource` |
+| `lambda` | Migration Lambda (always); cert-import Lambda (only when importing PEM certs). | `CreateFunction`, `DeleteFunction`, `UpdateFunctionCode`, `UpdateFunctionConfiguration`, `GetFunction`, `GetFunctionConfiguration`, `InvokeFunction`, `TagResource`, `UntagResource`, `ListTags` |
+| `servicediscovery` | Cloud Map private DNS namespace + per-service entries. | `CreatePrivateDnsNamespace`, `DeleteNamespace`, `GetNamespace`, `ListNamespaces`, `CreateService`, `DeleteService`, `GetService`, `ListServices`, `GetOperation`, `TagResource`, `UntagResource`, `ListTagsForResource` |
+
+## What the deployer does **not** need
+
+- Anything under `ec2:*Vpc*`, `ec2:*Subnet*`, `ec2:*RouteTable*`,
+  `ec2:*InternetGateway*`, `ec2:*NatGateway*` — VPC is bring-your-own.
+- `kms:*` — no customer-managed keys are provisioned.
+- `bedrock:*` — Bedrock is runtime-only on the maestro task role.
+- `acm:*` — required only by the optional cert-import Lambda's own role,
+  not by the deployer.
+- Any `*:*` or account-wide read.
+- Any cross-account permissions.
+
+## Suggested grouping into managed policies
+
+If you can't grant a single broad role, three managed policies cover the
+install cleanly:
+
+1. **`cardinal-deploy-stack`** — `cloudformation:*` plus all `*:*Tag*` and
+   `*:Describe*`/`*:List*` actions across the services above.
+2. **`cardinal-deploy-iam`** — the `iam:*` actions, scoped to
+   `arn:aws:iam::${account}:role/cardinal-*`.
+3. **`cardinal-deploy-resources`** — the resource-creating actions on
+   ecs/rds/ec2-sg/elbv2/s3/sqs/secretsmanager/ssm/logs/lambda/servicediscovery,
+   scoped to `cardinal-*` ARNs where the AWS API supports prefixes.
+
+Splitting along those lines lets a security team approve the IAM grants
+separately from the resource grants if their policy requires it.

--- a/docs/operations/permissions-lakerunner.md
+++ b/docs/operations/permissions-lakerunner.md
@@ -1,48 +1,49 @@
-# Permissions
+# Permissions — lakerunner + maestro (runtime)
 
-Reference for security review of a Cardinal Lakerunner install. Lists every
-IAM role, resource policy, and security group the templates create, scoped
-to the install only — nothing here grants cross-account or cross-install
-access.
+What the **running application** has access to. Every role here is
+created and assumed inside the customer account at install time and
+deleted on stack teardown. ARN scopes use `${InstallIdLong}` (12 hex
+chars derived from the root stack ID) so multiple installs in one
+account stay isolated.
+
+This is the "what does the running software actually do?" half of the
+permissions story. The deployer / install-time permissions live in
+`permissions-infrastructure.md`.
 
 Source of truth: `src/cardinal_cfn/children/*.py`.
 
 ## IAM roles
 
-All roles below are created inside the customer account at install time and
-deleted on stack teardown. ARN scopes use `${InstallIdLong}` (12 hex chars
-derived from the root stack ID) so multiple installs in one account remain
-isolated.
+### Service-launch role (shared)
 
-### Service-launch roles
-
-| Role | Trust | Why it exists | Permissions (summary) |
+| Role | Trust | Why | Permissions |
 |---|---|---|---|
-| `ExecutionRole` (cluster) | `ecs-tasks.amazonaws.com` | ECS uses this at task launch on every Fargate task. | AWS-managed `AmazonECSTaskExecutionRolePolicy` (ECR pull, base logs) + `secretsmanager:GetSecretValue` on `cardinal/${InstallIdLong}/*`, `DbMasterSecret-*`, `MaestroDbSecret-*`, `InternalServiceKeysSecret-*` + `ssm:GetParameter*` on `parameter/cardinal/${InstallIdLong}/*`. |
+| `ExecutionRole` | `ecs-tasks.amazonaws.com` | ECS uses this at task launch on every Fargate task to pull the image, write the bootstrap log stream, and resolve `secrets:` blocks on container definitions. | AWS-managed `AmazonECSTaskExecutionRolePolicy` (ECR pull, base CW Logs) + `secretsmanager:GetSecretValue` on `cardinal/${InstallIdLong}/*`, `DbMasterSecret-*`, `MaestroDbSecret-*`, `InternalServiceKeysSecret-*` + `ssm:GetParameter*` on `parameter/cardinal/${InstallIdLong}/*`. |
 
 ### ECS task roles (application identities)
 
-One per service. All trust `ecs-tasks.amazonaws.com`. Base = S3 RW on the
-ingest bucket, SQS consume+send on the ingest queue, SSM read on the two
-config params, Secrets Manager read on `DbMasterSecret`, `LicenseSecret`,
-`InternalServiceKeysSecret`, and CW Logs writes to its own log group.
+One per service. All trust `ecs-tasks.amazonaws.com`. **Base** = S3 RW
+on the ingest bucket, SQS consume+send on the ingest queue, SSM read on
+the two config params, Secrets Manager read on `DbMasterSecret`,
+`LicenseSecret`, `InternalServiceKeysSecret`, and CW Logs writes to its
+own log group.
 
 | Role | Why | Deviation from base |
 |---|---|---|
 | `QueryWorkerTaskRole` | Runs query workers. | Base only. |
-| `QueryApiTaskRole` | Runs the query API; discovers live workers via ECS. | Base + `ecs:DescribeServices/ListTasks/DescribeTasks` (resource `*`, condition `ecs:cluster = ${ClusterArn}` — these actions don't accept ARN scopes). |
+| `QueryApiTaskRole` | Runs the query API; discovers live workers via the ECS API. | Base + `ecs:DescribeServices/ListTasks/DescribeTasks` (resource `*`, condition `ecs:cluster = ${ClusterArn}` — these actions don't accept ARN scopes). |
 | `ProcessLogsTaskRole`, `ProcessMetricsTaskRole`, `ProcessTracesTaskRole`, `PubsubSqsTaskRole` | Log/metric/trace ingest workers. | Base only. |
 | `SweeperTaskRole`, `AlertEvaluatorTaskRole` | Background control-plane jobs. | Base only. |
 | `MonitoringTaskRole` | Autoscales the three `process-*` services. | Base + `ecs:DescribeServices`, `ecs:UpdateService` scoped to the three process service ARNs. |
-| `AdminApiTaskRole` | Admin API service; needs to seed first admin key. | Base + extra ARN (`AdminApiKeySecretArn`) added to the existing Secrets Manager statement. |
+| `AdminApiTaskRole` | Admin API; needs to seed first admin key on first boot. | Base + extra ARN (`AdminApiKeySecretArn`) added to the existing Secrets Manager statement. |
 | `OtelTaskRole` | OTel collector; writes raw bytes to S3, no queue work. | S3 R/W/list + SSM + `LicenseSecret`/`InternalServiceKeysSecret` + own log group. **No SQS, no DB.** |
-| `MaestroTaskRole` | Maestro UI + bundled DEX; talks only to Postgres and Bedrock. | DB master + maestro DB + license + internal-keys secrets, two SSM params, four maestro log groups, plus `bedrock:InvokeModel(WithResponseStream)` on `arn:aws:bedrock:${AWS::Region}::foundation-model/*`. **No S3, no SQS.** |
-| `MigratorTaskRole` | One-shot DB migrator container. | `secretsmanager:GetSecretValue` on `DbMasterSecret` + `logs:*` on `*` (self-creates its log group). **No S3, no SQS, no app secrets.** |
+| `MaestroTaskRole` | Maestro UI + bundled DEX OIDC; talks only to Postgres and Bedrock. | DB master + maestro DB + license + internal-keys secrets, two SSM params, four maestro log groups, plus `bedrock:InvokeModel(WithResponseStream)` on `arn:aws:bedrock:${AWS::Region}::foundation-model/*`. **No S3, no SQS.** |
+| `MigratorTaskRole` | One-shot DB migrator container (runs at install/upgrade only). | `secretsmanager:GetSecretValue` on `DbMasterSecret` + `logs:*` on `*` (self-creates its log group). **No S3, no SQS, no app secrets.** |
 
 ### Lambda roles (CloudFormation custom resources)
 
-Both trust `lambda.amazonaws.com`. Logs are inline (not via the AWS-managed
-basic-execution policy) so scopes stay deliberate.
+Both trust `lambda.amazonaws.com`. Logs are inline (not via the
+AWS-managed basic-execution policy) so scopes stay deliberate.
 
 | Role | Why | Permissions |
 |---|---|---|


### PR DESCRIPTION
## Summary

- Replaces the single `permissions.md` (added in #81) with two files so customers can decide separately what install-time deploy perms vs. runtime perms they're comfortable with.
- `permissions-infrastructure.md`: APIs the deployer principal needs to call CloudFormation (IAM, ECS, RDS, S3, SQS, Secrets Manager, SSM, Logs, Lambda, ELBv2, Cloud Map). VPC excluded — bring-your-own.
- `permissions-lakerunner.md`: runtime IAM roles, resource policies, and security groups for the running services (lakerunner + maestro + the Lambda custom resources).

## Test plan
- [ ] Skim the rendered Markdown on the PR page to confirm both tables render.