### PR TITLE
data-setup: take a single full s3:// URL for the Lambda zip

### DIFF
--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -54,11 +54,25 @@ The `cardinal-data-setup.yaml` template takes:
 | `BucketLifecycleDays` | Optional | S3 ingest object expiry (default `7`). |
 | `DbInstanceClass` | Optional | RDS class (default `db.t3.medium`). |
 | `DbAllocatedStorage` | Optional | RDS GiB (default `100`). |
-| `LambdaCodeS3Bucket` | Optional | Default `cardinal-cfn`. |
-| `LambdaCodeS3Key` | Optional | Default `lakerunner/dev/cardinal-data-setup-lambda.zip`; override to match `<VERSION>` for a release install. |
+| `LambdaCodeS3Url` | Optional | Full `s3://<bucket>/<prefix>/<version>/<file>.zip` URL of the data-setup Lambda zip. Must point at a bucket in the **same region** as this stack. Default targets us-east-2; override for any other region. See "Lambda code URL by region" below. |
 
 There are **no DEX or OIDC parameters** on this stack -- those flow
 only into the lakerunner stack.
+
+### Lambda code URL by region
+
+The data-setup Lambda's code zip must live in an S3 bucket in the
+same region as the Lambda function. The published artifact is
+mirrored to one regional bucket per supported region:
+
+| Region | Default `LambdaCodeS3Url` |
+|---|---|
+| `us-east-1` | `s3://cardinal-cfn-us-east-1/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip` |
+| `us-east-2` | `s3://cardinal-cfn-us-east-2/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip` (template default) |
+
+Air-gapped mirrors must preserve the same key shape -- exactly three
+slash-separated segments after the bucket -- because the template
+parses `LambdaCodeS3Url` with a fixed-depth `Fn::Split`.
 
 ## Step 2: published template URL
 
@@ -87,7 +101,7 @@ cat > /tmp/data-setup-params.json <<EOF
   {"ParameterKey": "PrivateSubnets",         "ParameterValue": "subnet-aaaa,subnet-bbbb,subnet-cccc"},
   {"ParameterKey": "DbSgId",                 "ParameterValue": "sg-..."},
   {"ParameterKey": "LicenseData",            "ParameterValue": "${LICENSE_DATA}"},
-  {"ParameterKey": "LambdaCodeS3Key",        "ParameterValue": "lakerunner/<VERSION>/cardinal-data-setup-lambda.zip"}
+  {"ParameterKey": "LambdaCodeS3Url",        "ParameterValue": "s3://cardinal-cfn-<REGION>/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip"}
 ]
 EOF
 

--- a/src/cardinal_cfn/data_setup_lambda/template.py
+++ b/src/cardinal_cfn/data_setup_lambda/template.py
@@ -31,9 +31,12 @@ import os
 
 from troposphere import (
     GetAtt,
+    Join,
     Output,
     Parameter,
     Ref,
+    Select,
+    Split,
     Tags,
     Template,
 )
@@ -42,8 +45,10 @@ from troposphere.awslambda import Code, Function
 
 
 VERSION = os.environ.get("CARDINAL_VERSION", "dev")
-DEFAULT_BUCKET = os.environ.get("CARDINAL_BUCKET_NAME", "cardinal-cfn")
-DEFAULT_LAMBDA_KEY = f"lakerunner/{VERSION}/cardinal-data-setup-lambda.zip"
+DEFAULT_BUCKET = os.environ.get("CARDINAL_BUCKET_NAME", "cardinal-cfn-us-east-2")
+DEFAULT_LAMBDA_URL = (
+    f"s3://{DEFAULT_BUCKET}/lakerunner/{VERSION}/cardinal-data-setup-lambda.zip"
+)
 
 
 def build_template() -> Template:
@@ -108,16 +113,21 @@ def build_template() -> Template:
         Description="S3 ingest bucket object expiration in days.",
     ))
     t.add_parameter(Parameter(
-        "LambdaCodeS3Bucket",
+        "LambdaCodeS3Url",
         Type="String",
-        Default=DEFAULT_BUCKET,
-        Description="S3 bucket containing the Lambda zip.",
-    ))
-    t.add_parameter(Parameter(
-        "LambdaCodeS3Key",
-        Type="String",
-        Default=DEFAULT_LAMBDA_KEY,
-        Description="S3 key of the Lambda zip within the bucket.",
+        Default=DEFAULT_LAMBDA_URL,
+        AllowedPattern=r"^s3://[^/]+/[^/]+/[^/]+/[^/]+\.zip$",
+        ConstraintDescription=(
+            "LambdaCodeS3Url must be an s3://<bucket>/<prefix>/<version>/<file>.zip URL "
+            "(exactly three slash-separated path segments). The bucket must be in the same "
+            "region as this stack."
+        ),
+        Description=(
+            "Full s3:// URL of the data-setup Lambda zip. The bucket must be in the same "
+            "region as this stack. Default targets the published bucket in us-east-2; "
+            "override for other regions or air-gapped mirrors. Example: "
+            "s3://cardinal-cfn-us-east-1/lakerunner/v0.0.42/cardinal-data-setup-lambda.zip."
+        ),
     ))
 
     # ---- Lambda function ---------------------------------------------------
@@ -133,9 +143,16 @@ def build_template() -> Template:
         # skip already-completed steps.
         Timeout=900,
         MemorySize=512,
+        # Parse LambdaCodeS3Url (s3://bucket/prefix/version/file.zip) into the
+        # S3Bucket + S3Key pair the Lambda CFN resource requires. AllowedPattern
+        # on the parameter enforces the three-segment shape this parsing assumes.
         Code=Code(
-            S3Bucket=Ref("LambdaCodeS3Bucket"),
-            S3Key=Ref("LambdaCodeS3Key"),
+            S3Bucket=Select(2, Split("/", Ref("LambdaCodeS3Url"))),
+            S3Key=Join("/", [
+                Select(3, Split("/", Ref("LambdaCodeS3Url"))),
+                Select(4, Split("/", Ref("LambdaCodeS3Url"))),
+                Select(5, Split("/", Ref("LambdaCodeS3Url"))),
+            ]),
         ),
         Description="Cardinal lakerunner data-setup: idempotent ensure_* over RDS, S3, SQS, Secrets, SSM.",
         Tags=Tags(

--- a/tests/templates/test_data_setup_lambda_template.py
+++ b/tests/templates/test_data_setup_lambda_template.py
@@ -28,10 +28,17 @@ def test_required_parameters_declared(template_dict):
         "DbInstanceClass",
         "DbAllocatedStorage",
         "BucketLifecycleDays",
-        "LambdaCodeS3Bucket",
-        "LambdaCodeS3Key",
+        "LambdaCodeS3Url",
     }
     assert required <= set(template_dict["Parameters"])
+
+
+def test_split_lambda_code_params_are_gone(template_dict):
+    """The previous LambdaCodeS3Bucket / LambdaCodeS3Key pair was replaced
+    by a single full-URL parameter; make sure nothing reintroduces them."""
+    params = set(template_dict["Parameters"])
+    assert "LambdaCodeS3Bucket" not in params
+    assert "LambdaCodeS3Key" not in params
 
 
 def test_secret_parameters_marked_no_echo(template_dict):
@@ -83,8 +90,29 @@ def test_naming_contract_lambda_function_name_is_stable(template_dict):
     assert fn["FunctionName"] == "cardinal-data-setup"
 
 
-def test_default_lambda_code_path_uses_published_bucket(template_dict):
-    bucket_default = template_dict["Parameters"]["LambdaCodeS3Bucket"]["Default"]
-    key_default = template_dict["Parameters"]["LambdaCodeS3Key"]["Default"]
-    assert bucket_default == "cardinal-cfn"
-    assert key_default.startswith("lakerunner/") and key_default.endswith("/cardinal-data-setup-lambda.zip")
+def test_default_lambda_code_url_targets_published_bucket(template_dict):
+    """Default LambdaCodeS3Url points at the published regional bucket; pattern
+    must match the AllowedPattern regex so the default is always self-validating."""
+    import re
+
+    p = template_dict["Parameters"]["LambdaCodeS3Url"]
+    assert re.match(p["AllowedPattern"], p["Default"]), p["Default"]
+    assert p["Default"].startswith("s3://cardinal-cfn")
+    assert p["Default"].endswith("/cardinal-data-setup-lambda.zip")
+    # Three slash-separated key segments (prefix/version/file).
+    key = p["Default"].split("/", 3)[3]
+    assert key.count("/") == 2
+
+
+def test_lambda_code_property_parses_url_into_bucket_and_key(template_dict):
+    """The Code.S3Bucket / Code.S3Key pair is derived from LambdaCodeS3Url
+    via Fn::Split + Fn::Select + Fn::Join. Element indices encode the
+    three-segment key shape that AllowedPattern enforces."""
+    code = template_dict["Resources"]["DataSetupFunction"]["Properties"]["Code"]
+    expected_split = {"Fn::Split": ["/", {"Ref": "LambdaCodeS3Url"}]}
+    assert code["S3Bucket"] == {"Fn::Select": [2, expected_split]}
+    assert code["S3Key"] == {"Fn::Join": ["/", [
+        {"Fn::Select": [3, expected_split]},
+        {"Fn::Select": [4, expected_split]},
+        {"Fn::Select": [5, expected_split]},
+    ]]}


### PR DESCRIPTION
## Summary

Replaces the data-setup stack's \`LambdaCodeS3Bucket\` + \`LambdaCodeS3Key\` parameter pair with a single \`LambdaCodeS3Url\`. The published artifact is mirrored to per-region buckets (\`cardinal-cfn-us-east-1\`, \`cardinal-cfn-us-east-2\`); operators paste the URL matching their deploy region instead of keeping bucket + key in lockstep.

## Operator-facing diff

\`\`\`diff
- {\"ParameterKey\": \"LambdaCodeS3Bucket\", \"ParameterValue\": \"cardinal-cfn\"},
- {\"ParameterKey\": \"LambdaCodeS3Key\",    \"ParameterValue\": \"lakerunner/v0.0.42/cardinal-data-setup-lambda.zip\"}
+ {\"ParameterKey\": \"LambdaCodeS3Url\",    \"ParameterValue\": \"s3://cardinal-cfn-us-east-1/lakerunner/v0.0.42/cardinal-data-setup-lambda.zip\"}
\`\`\`

Default targets \`cardinal-cfn-us-east-2\` to match the bucket \`release.yml\` writes to. Customers in other regions or running air-gapped mirrors paste their own URL.

## Implementation

- \`AllowedPattern: ^s3://[^/]+/[^/]+/[^/]+/[^/]+\\.zip$\` rejects malformed URLs at stack-create.
- Lambda's CFN resource still wants \`Code.S3Bucket\` + \`Code.S3Key\` separately; the template parses the URL with \`Fn::Split\` + \`Fn::Select\` + \`Fn::Join\`. Fixed three-segment key depth, matching the AllowedPattern.
- Air-gapped mirrors must preserve the three-segment key shape (\`<prefix>/<version>/<file>.zip\`).

## Test plan

- [x] \`make check\` (370 passed)
- [ ] After tag + publish, deploy v0.0.42 in the test account using the new \`LambdaCodeS3Url\` parameter