### PR TITLE
data-setup.sh + switch CI publishing to cardinal-cfn-us-east-1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     env:
-      AWS_REGION: us-east-2
-      CARDINAL_BUCKET_NAME: cardinal-cfn
-      CARDINAL_BUCKET_REGION: us-east-2
+      # us-east-1 is the source-of-truth publishing bucket. Replication
+      # populates cardinal-cfn-us-east-2 (and any other regional mirror)
+      # at the S3 level, out of band from this workflow.
+      AWS_REGION: us-east-1
+      CARDINAL_BUCKET_NAME: cardinal-cfn-us-east-1
+      CARDINAL_BUCKET_REGION: us-east-1
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ only -- production installs always bring their own VPC.
 
 ## Published templates
 
-Per release tag at `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<VERSION>/`:
+Per release tag at `https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<VERSION>/`:
 
 - `cardinal-data-setup.yaml` (+ `cardinal-data-setup-lambda.zip`)
 - `cardinal-lakerunner.yaml` (+ nested children under `cardinal-lakerunner/`)

--- a/docs/operations/deploying.md
+++ b/docs/operations/deploying.md
@@ -20,7 +20,7 @@ exactly the AWS APIs the lakerunner templates touch. Operators only need
 aws cloudformation create-stack \
   --stack-name cardinal-cfn-deployer \
   --region us-east-1 \
-  --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/cardinal-deployer-role.yaml \
+  --template-url https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<version>/cardinal-deployer-role.yaml \
   --capabilities CAPABILITY_NAMED_IAM
 
 # 2. Grab the ARN.
@@ -34,7 +34,7 @@ aws cloudformation update-stack \
   --stack-name cardinal-lakerunner \
   --region us-east-1 \
   --role-arn "$ROLE_ARN" \
-  --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/cardinal-lakerunner.yaml \
+  --template-url https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<version>/cardinal-lakerunner.yaml \
   --use-previous-parameters \
   --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND
 ```

--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -119,6 +119,32 @@ The stack does not create IAM; no `CAPABILITY_*` flag is needed. Stack
 create completes when the Lambda finishes its first invocation (10-20
 minutes on a cold install -- RDS provisioning dominates).
 
+## Alternative: skip the Lambda, run the steps directly
+
+`scripts/data-setup.sh` is a POSIX-shell, AWS-CLI-only driver that is
+functionally equivalent to the data-setup Lambda. Use it when you want
+to drive the data layer from Jenkins (or any CI runner) without
+deploying the wrapper CFN stack at all. Parameters are at the top of
+the script as env-overridable variables; outputs land on stdout as a
+JSON document with the same 13 keys the data-setup stack emits.
+
+```sh
+REGION=us-east-2 \
+VPC_ID=vpc-... \
+PRIVATE_SUBNETS=subnet-aaaa,subnet-bbbb \
+DB_SG_ID=sg-... \
+LICENSE_DATA_FILE=/path/to/license.token \
+    scripts/data-setup.sh > /tmp/data-setup-outputs.json
+```
+
+The script is idempotent (each step does describe-then-act on the same
+deterministic resource names the Lambda uses) so re-running after a
+partial failure converges. The caller's identity needs the same
+permissions the data-setup Lambda's role has -- see
+[`required-roles.md`](required-roles.md), `cardinal-data-setup-lambda-role`.
+
+If you use this path, skip step 3 above. Continue to step 4.
+
 ## Step 4: harvest outputs
 
 These outputs are 1:1 with the `cardinal-lakerunner` data-layer

--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -54,7 +54,7 @@ The `cardinal-data-setup.yaml` template takes:
 | `BucketLifecycleDays` | Optional | S3 ingest object expiry (default `7`). |
 | `DbInstanceClass` | Optional | RDS class (default `db.t3.medium`). |
 | `DbAllocatedStorage` | Optional | RDS GiB (default `100`). |
-| `LambdaCodeS3Url` | Optional | Full `s3://<bucket>/<prefix>/<version>/<file>.zip` URL of the data-setup Lambda zip. Must point at a bucket in the **same region** as this stack. Default targets us-east-2; override for any other region. See "Lambda code URL by region" below. |
+| `LambdaCodeS3Url` | Optional | Full `s3://<bucket>/<prefix>/<version>/<file>.zip` URL of the data-setup Lambda zip. Must point at a bucket in the **same region** as this stack. Default targets us-east-1 (the publishing source of truth); override for any other region. See "Lambda code URL by region" below. |
 
 There are **no DEX or OIDC parameters** on this stack -- those flow
 only into the lakerunner stack.
@@ -62,13 +62,14 @@ only into the lakerunner stack.
 ### Lambda code URL by region
 
 The data-setup Lambda's code zip must live in an S3 bucket in the
-same region as the Lambda function. The published artifact is
-mirrored to one regional bucket per supported region:
+same region as the Lambda function. The release workflow publishes
+to `cardinal-cfn-us-east-1` (the source of truth); S3 bucket
+replication populates `cardinal-cfn-us-east-2` as a regional mirror.
 
-| Region | Default `LambdaCodeS3Url` |
+| Region | `LambdaCodeS3Url` |
 |---|---|
-| `us-east-1` | `s3://cardinal-cfn-us-east-1/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip` |
-| `us-east-2` | `s3://cardinal-cfn-us-east-2/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip` (template default) |
+| `us-east-1` | `s3://cardinal-cfn-us-east-1/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip` (template default) |
+| `us-east-2` | `s3://cardinal-cfn-us-east-2/lakerunner/<VERSION>/cardinal-data-setup-lambda.zip` |
 
 Air-gapped mirrors must preserve the same key shape -- exactly three
 slash-separated segments after the bucket -- because the template
@@ -79,7 +80,7 @@ parses `LambdaCodeS3Url` with a fixed-depth `Fn::Split`.
 Templates are published per release tag at:
 
 ```
-https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<VERSION>/<template>.yaml
+https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<VERSION>/<template>.yaml
 ```
 
 Replace `<VERSION>` with the explicit release tag (e.g. `v0.0.41`).
@@ -108,7 +109,7 @@ EOF
 aws cloudformation create-stack \
     --region <REGION> \
     --stack-name cardinal-data-setup \
-    --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<VERSION>/cardinal-data-setup.yaml \
+    --template-url https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<VERSION>/cardinal-data-setup.yaml \
     --parameters file:///tmp/data-setup-params.json
 
 aws cloudformation wait stack-create-complete \

--- a/docs/operations/install-lakerunner.md
+++ b/docs/operations/install-lakerunner.md
@@ -82,7 +82,7 @@ params += [
     {"ParameterKey": "DexAdminEmail",          "ParameterValue": "admin@example.com"},
     {"ParameterKey": "DexAdminPasswordHash",   "ParameterValue": hash_text},
     {"ParameterKey": "OidcSuperadminEmails",   "ParameterValue": "admin@example.com"},
-    {"ParameterKey": "TemplateBaseUrl",        "ParameterValue": "https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<VERSION>/cardinal-lakerunner/"},
+    {"ParameterKey": "TemplateBaseUrl",        "ParameterValue": "https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<VERSION>/cardinal-lakerunner/"},
 ]
 print(json.dumps(params, indent=2))
 PY
@@ -108,7 +108,7 @@ have sensible defaults; override only the ones you need to change.
 aws cloudformation create-stack \
     --region <REGION> \
     --stack-name cardinal-lakerunner \
-    --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<VERSION>/cardinal-lakerunner.yaml \
+    --template-url https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<VERSION>/cardinal-lakerunner.yaml \
     --parameters file:///tmp/lakerunner-params.json
 
 aws cloudformation wait stack-create-complete \
@@ -152,7 +152,7 @@ update the infrastructure stack) and run `update-stack`:
 ```sh
 aws cloudformation update-stack \
     --region <REGION> --stack-name cardinal-lakerunner \
-    --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<NEW_VERSION>/cardinal-lakerunner.yaml \
+    --template-url https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<NEW_VERSION>/cardinal-lakerunner.yaml \
     --parameters file:///tmp/lakerunner-params.json
 ```
 

--- a/docs/operations/jenkins-deploy.md
+++ b/docs/operations/jenkins-deploy.md
@@ -71,7 +71,7 @@ For multiple installs, repeat for each — one job per install. After install, t
 |---|---|---|
 | `StackName` | `cardinal-lakerunner` | Edit per install |
 | `Region` | `us-east-2` | Edit per install |
-| `TemplateBaseUrl` | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` | Override for air-gapped customers |
+| `TemplateBaseUrl` | `https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner` | Override for air-gapped customers |
 | `Version` | (empty -- required) | Published template tag, e.g. `v0.0.38` |
 | `DeployerRoleArn` | (empty) | Strongly recommended; see `docs/operations/deploying.md` |
 | `AutoApprove` | `true` | When `false`, the pipeline pauses for manual approval after the change set is described |
@@ -102,7 +102,7 @@ The default uses the Jenkins AWS Credentials plugin (recommended). Two alternati
 
 ## Air-gapped variant
 
-Mirror `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/` to a private bucket (or any HTTPS-reachable location). Set the `TemplateBaseUrl` parameter on the Jenkins job to point at your mirror. Override per-image parameters via your stack defaults so customer images come from your private registry rather than `public.ecr.aws/...`.
+Mirror `https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner/<version>/` to a private bucket (or any HTTPS-reachable location). Set the `TemplateBaseUrl` parameter on the Jenkins job to point at your mirror. Override per-image parameters via your stack defaults so customer images come from your private registry rather than `public.ecr.aws/...`.
 
 ## Reading the change set summary
 

--- a/scripts/data-setup.sh
+++ b/scripts/data-setup.sh
@@ -1,0 +1,447 @@
+#!/bin/sh
+# Cardinal lakerunner data-setup driver, in raw AWS CLI.
+#
+# Functional drop-in for the cardinal-data-setup Lambda
+# (src/cardinal_cfn/data_setup_lambda/handler.py): creates RDS, S3 ingest,
+# SQS, the five `cardinal-*` Secrets Manager secrets, and the two SSM
+# parameters the lakerunner stack expects to find.
+#
+# Idempotent. Each step does describe-then-act on the deterministic
+# names below; re-running after a partial failure converges. The script
+# can be re-run safely against a partially-created install.
+#
+# Output: a JSON document on stdout with the 13 keys that
+# cardinal-lakerunner takes as parameters. Output keys are 1:1 with the
+# cardinal-data-setup stack outputs and the lakerunner stack parameters.
+#
+# Dependencies: POSIX shell, AWS CLI v2, jq, openssl.
+
+set -eu
+
+# ============================================================================
+#  PARAMETERS  --  edit these (or set as env vars before invocation)
+# ============================================================================
+
+# Required.
+: "${REGION:=us-east-2}"
+: "${VPC_ID:=vpc-xxxxxxxx}"
+: "${PRIVATE_SUBNETS:=subnet-aaaaaaaa,subnet-bbbbbbbb}"   # CSV, >=2 subnets in distinct AZs
+: "${DB_SG_ID:=sg-xxxxxxxx}"                              # cardinal-db-sg
+: "${LICENSE_DATA_FILE:=}"                                # path to z64:... license token
+
+# Optional sizing (defaults match the Lambda).
+: "${DB_INSTANCE_CLASS:=db.t3.medium}"
+: "${DB_ALLOCATED_STORAGE:=100}"
+: "${BUCKET_LIFECYCLE_DAYS:=7}"
+
+# ============================================================================
+#  CONSTANTS  --  these names are the contract with the lakerunner stack
+#                  (mirrors handler.py constants; do not change)
+# ============================================================================
+
+DB_IDENTIFIER="cardinal-db"
+DB_SUBNET_GROUP_NAME="cardinal-db-subnet-group"
+DB_NAME="lakerunner"
+DB_USERNAME="lakerunner"
+DB_PORT=5432
+
+SQS_QUEUE_NAME="cardinal-ingest"
+
+SECRET_DB_MASTER="cardinal-db-master"
+SECRET_LICENSE="cardinal-license"
+SECRET_INTERNAL_KEYS="cardinal-internal-keys"
+SECRET_ADMIN_KEY="cardinal-admin-key"
+SECRET_MAESTRO_DB="cardinal-maestro-db"
+
+SSM_STORAGE_PROFILES="/cardinal/storage-profiles"
+SSM_API_KEYS="/cardinal/api-keys"
+
+PROJECT="cardinal"
+APPLICATION="cardinal-lakerunner"
+MANAGED_BY="cardinal-data-setup-script"
+
+# ============================================================================
+#  HELPERS
+# ============================================================================
+
+log()  { printf '[data-setup] %s\n' "$*" >&2; }
+fail() { printf '[data-setup] ERROR: %s\n' "$*" >&2; exit 1; }
+
+for tool in aws jq openssl; do
+    command -v "$tool" >/dev/null 2>&1 || fail "$tool is required on PATH"
+done
+
+[ -n "${LICENSE_DATA_FILE}" ] || fail "LICENSE_DATA_FILE must point at the cardinal license token (z64:...)"
+[ -r "${LICENSE_DATA_FILE}" ] || fail "license file not readable: ${LICENSE_DATA_FILE}"
+
+aws_cli() { aws --region "$REGION" "$@"; }
+
+ACCOUNT_ID=$(aws_cli sts get-caller-identity --query Account --output text)
+BUCKET="cardinal-ingest-${ACCOUNT_ID}-${REGION}"
+QUEUE_ARN="arn:aws:sqs:${REGION}:${ACCOUNT_ID}:${SQS_QUEUE_NAME}"
+
+# 40-char password using the alphabet the Lambda uses (no shell-troublesome
+# punctuation; openssl rand for cryptographic strength).
+gen_password() {
+    openssl rand -base64 64 \
+        | tr -dc 'A-HJ-NP-Za-km-z2-9' \
+        | head -c 40
+}
+
+# 32-byte hex (64 chars) -- matches handler._random_hex(32).
+gen_hex32() { openssl rand -hex 32; }
+
+# Returns a JSON array of {Key,Value} suitable for the --tags option of
+# RDS / Secrets Manager / SSM (all of which accept JSON shorthand for --tags).
+tags_json_array() {
+    component="$1"
+    jq -nc \
+        --arg app "$APPLICATION" --arg proj "$PROJECT" \
+        --arg mgd "$MANAGED_BY" --arg comp "$component" \
+        '[
+            {Key:"Application",Value:$app},
+            {Key:"Project",Value:$proj},
+            {Key:"ManagedBy",Value:$mgd},
+            {Key:"Component",Value:$comp},
+            {Key:"Name",Value:("cardinal-"+$comp)}
+         ]'
+}
+
+# Returns "Key1=Value1,Key2=Value2" suitable for the --tags option of
+# SQS create-queue (which uses a flat map shorthand, not the JSON array).
+tags_sqs_map() {
+    component="$1"
+    printf 'Application=%s,Project=%s,ManagedBy=%s,Component=%s,Name=cardinal-%s' \
+        "$APPLICATION" "$PROJECT" "$MANAGED_BY" "$component" "$component"
+}
+
+# Returns the JSON {"TagSet": [...]} envelope S3 put-bucket-tagging wants.
+tags_s3_envelope() {
+    component="$1"
+    jq -nc --argjson set "$(tags_json_array "$component")" '{TagSet:$set}'
+}
+
+# ============================================================================
+#  STORAGE  --  SQS queue, S3 bucket + lifecycle + BPA, queue policy, S3 -> SQS
+# ============================================================================
+
+ensure_sqs_queue() {
+    log "ensuring SQS queue $SQS_QUEUE_NAME"
+    if url=$(aws_cli sqs get-queue-url --queue-name "$SQS_QUEUE_NAME" \
+                --query QueueUrl --output text 2>/dev/null); then
+        printf '%s' "$url"
+        return
+    fi
+    aws_cli sqs create-queue \
+        --queue-name "$SQS_QUEUE_NAME" \
+        --tags "$(tags_sqs_map ingest-queue)" \
+        --query QueueUrl --output text
+}
+
+ensure_s3_bucket() {
+    log "ensuring S3 bucket $BUCKET"
+    if aws_cli s3api head-bucket --bucket "$BUCKET" >/dev/null 2>&1; then
+        return
+    fi
+    if [ "$REGION" = "us-east-1" ]; then
+        aws_cli s3api create-bucket --bucket "$BUCKET" >/dev/null
+    else
+        aws_cli s3api create-bucket \
+            --bucket "$BUCKET" \
+            --create-bucket-configuration "LocationConstraint=$REGION" >/dev/null
+    fi
+    aws_cli s3api put-bucket-tagging \
+        --bucket "$BUCKET" \
+        --tagging "$(tags_s3_envelope ingest-bucket)" >/dev/null
+}
+
+ensure_s3_block_public_access() {
+    log "applying block-public-access to $BUCKET"
+    aws_cli s3api put-public-access-block \
+        --bucket "$BUCKET" \
+        --public-access-block-configuration \
+            BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+}
+
+ensure_s3_lifecycle() {
+    log "applying lifecycle (expire after $BUCKET_LIFECYCLE_DAYS days) to $BUCKET"
+    cfg=$(jq -nc --argjson d "$BUCKET_LIFECYCLE_DAYS" '{
+        Rules: [{
+            ID: "cardinal-ingest-expire",
+            Filter: {Prefix: ""},
+            Status: "Enabled",
+            Expiration: {Days: $d},
+            AbortIncompleteMultipartUpload: {DaysAfterInitiation: 1}
+        }]
+    }')
+    aws_cli s3api put-bucket-lifecycle-configuration \
+        --bucket "$BUCKET" --lifecycle-configuration "$cfg"
+}
+
+ensure_sqs_policy() {
+    queue_url="$1"
+    log "applying SQS policy on $queue_url (S3 sourced from $BUCKET)"
+    policy=$(jq -nc \
+        --arg arn "$QUEUE_ARN" \
+        --arg account "$ACCOUNT_ID" \
+        --arg bucket "$BUCKET" \
+        '{
+            Version: "2012-10-17",
+            Statement: [{
+                Effect: "Allow",
+                Principal: {Service: "s3.amazonaws.com"},
+                Action: ["sqs:SendMessage","sqs:GetQueueAttributes","sqs:GetQueueUrl"],
+                Resource: $arn,
+                Condition: {
+                    StringEquals: {"aws:SourceAccount": $account},
+                    ArnLike: {"aws:SourceArn": ("arn:aws:s3:::"+$bucket)}
+                }
+            }]
+        }')
+    aws_cli sqs set-queue-attributes \
+        --queue-url "$queue_url" \
+        --attributes "$(jq -nc --arg p "$policy" '{Policy:$p}')"
+}
+
+ensure_s3_notification() {
+    log "applying S3 -> SQS notification on $BUCKET"
+    cfg=$(jq -nc --arg arn "$QUEUE_ARN" '{
+        QueueConfigurations: [{
+            Id: "cardinal-ingest-to-sqs",
+            QueueArn: $arn,
+            Events: ["s3:ObjectCreated:*"]
+        }]
+    }')
+    aws_cli s3api put-bucket-notification-configuration \
+        --bucket "$BUCKET" --notification-configuration "$cfg"
+}
+
+# ============================================================================
+#  DATABASE  --  subnet group, master secret, RDS instance, conn-JSON rewrite
+# ============================================================================
+
+ensure_db_subnet_group() {
+    log "ensuring DB subnet group $DB_SUBNET_GROUP_NAME"
+    if aws_cli rds describe-db-subnet-groups \
+            --db-subnet-group-name "$DB_SUBNET_GROUP_NAME" >/dev/null 2>&1; then
+        return
+    fi
+    # SubnetIds expects multiple values; expand the CSV.
+    # shellcheck disable=SC2086
+    aws_cli rds create-db-subnet-group \
+        --db-subnet-group-name "$DB_SUBNET_GROUP_NAME" \
+        --db-subnet-group-description "Cardinal lakerunner DB subnet group" \
+        --subnet-ids $(printf '%s' "$PRIVATE_SUBNETS" | tr ',' ' ') \
+        --tags "$(tags_json_array db-subnet-group)" >/dev/null
+}
+
+# Returns "ARN<TAB>password" on stdout. Reuses the existing secret's password
+# on a partial re-run so the RDS create call can match what the secret holds.
+ensure_db_master_secret() {
+    log "ensuring secret $SECRET_DB_MASTER"
+    if existing_arn=$(aws_cli secretsmanager describe-secret \
+            --secret-id "$SECRET_DB_MASTER" --query ARN --output text 2>/dev/null); then
+        raw=$(aws_cli secretsmanager get-secret-value \
+                --secret-id "$existing_arn" --query SecretString --output text)
+        existing_password=$(printf '%s' "$raw" | jq -r '.password // empty')
+        [ -n "$existing_password" ] || \
+            fail "secret $SECRET_DB_MASTER exists but has no password field"
+        printf '%s\t%s' "$existing_arn" "$existing_password"
+        return
+    fi
+    password=$(gen_password)
+    placeholder=$(jq -nc --arg u "$DB_USERNAME" --arg p "$password" \
+                    '{username:$u, password:$p}')
+    arn=$(aws_cli secretsmanager create-secret \
+            --name "$SECRET_DB_MASTER" \
+            --description "Cardinal RDS master credentials (placeholder; rewritten with full conn JSON post-DB-create)" \
+            --secret-string "$placeholder" \
+            --tags "$(tags_json_array db-master)" \
+            --query ARN --output text)
+    printf '%s\t%s' "$arn" "$password"
+}
+
+ensure_db_instance() {
+    password="$1"
+    if aws_cli rds describe-db-instances \
+            --db-instance-identifier "$DB_IDENTIFIER" >/dev/null 2>&1; then
+        log "RDS instance $DB_IDENTIFIER already exists; skipping create"
+        return
+    fi
+    log "creating RDS instance $DB_IDENTIFIER (this can take 10+ minutes)"
+    aws_cli rds create-db-instance \
+        --db-instance-identifier "$DB_IDENTIFIER" \
+        --db-instance-class "$DB_INSTANCE_CLASS" \
+        --engine postgres \
+        --master-username "$DB_USERNAME" \
+        --master-user-password "$password" \
+        --allocated-storage "$DB_ALLOCATED_STORAGE" \
+        --storage-type gp3 \
+        --storage-encrypted \
+        --db-name "$DB_NAME" \
+        --port "$DB_PORT" \
+        --db-subnet-group-name "$DB_SUBNET_GROUP_NAME" \
+        --vpc-security-group-ids "$DB_SG_ID" \
+        --no-publicly-accessible \
+        --backup-retention-period 7 \
+        --deletion-protection \
+        --tags "$(tags_json_array db)" >/dev/null
+}
+
+wait_db_available() {
+    log "waiting for $DB_IDENTIFIER to become available"
+    aws_cli rds wait db-instance-available --db-instance-identifier "$DB_IDENTIFIER"
+}
+
+# Rewrites the master secret with full connection JSON (what the lakerunner
+# task containers parse). Idempotent: skip if host/port/dbname already present.
+update_db_master_secret() {
+    arn="$1"; password="$2"; endpoint="$3"; port="$4"
+    raw=$(aws_cli secretsmanager get-secret-value \
+            --secret-id "$arn" --query SecretString --output text)
+    if printf '%s' "$raw" | jq -e 'has("host") and has("port") and has("dbname")' \
+            >/dev/null 2>&1; then
+        log "secret $SECRET_DB_MASTER already has connection JSON; skipping rewrite"
+        return
+    fi
+    log "writing connection JSON into $SECRET_DB_MASTER"
+    new=$(jq -nc \
+        --arg u "$DB_USERNAME" --arg p "$password" \
+        --arg h "$endpoint" --argjson port "$port" \
+        --arg db "$DB_NAME" \
+        '{username:$u, password:$p, engine:"postgres", host:$h, port:$port, dbname:$db}')
+    aws_cli secretsmanager put-secret-value \
+        --secret-id "$arn" --secret-string "$new" >/dev/null
+}
+
+# ============================================================================
+#  SECRETS  --  license, internal-keys, admin-key, maestro-db
+#                Each is create-only: never overwrite on re-run.
+# ============================================================================
+
+ensure_secret_with_value() {
+    name="$1"; value="$2"; description="$3"; component="$4"
+    if existing=$(aws_cli secretsmanager describe-secret \
+            --secret-id "$name" --query ARN --output text 2>/dev/null); then
+        log "secret $name exists; reusing"
+        printf '%s' "$existing"
+        return
+    fi
+    log "creating secret $name"
+    aws_cli secretsmanager create-secret \
+        --name "$name" \
+        --description "$description" \
+        --secret-string "$value" \
+        --tags "$(tags_json_array "$component")" \
+        --query ARN --output text
+}
+
+# ============================================================================
+#  SSM  --  storage-profiles, api-keys (operator-managed JSON, default {})
+# ============================================================================
+
+ensure_ssm_parameter() {
+    name="$1"; value="$2"; description="$3"
+    if aws_cli ssm get-parameter --name "$name" >/dev/null 2>&1; then
+        log "ssm parameter $name exists"
+        return
+    fi
+    log "creating ssm parameter $name"
+    aws_cli ssm put-parameter \
+        --name "$name" --type String --value "$value" \
+        --description "$description" \
+        --tags "$(tags_json_array ssm-parameter)" >/dev/null
+}
+
+# ============================================================================
+#  ORCHESTRATION  --  matches handler.py run() ordering
+# ============================================================================
+
+main() {
+    log "account=$ACCOUNT_ID region=$REGION"
+    log "vpc=$VPC_ID  subnets=$PRIVATE_SUBNETS  db-sg=$DB_SG_ID"
+
+    # ---- storage ----------------------------------------------------------
+    queue_url=$(ensure_sqs_queue)
+    ensure_s3_bucket
+    ensure_s3_block_public_access
+    ensure_s3_lifecycle
+    ensure_sqs_policy "$queue_url"
+    ensure_s3_notification
+
+    # ---- database ---------------------------------------------------------
+    ensure_db_subnet_group
+    master=$(ensure_db_master_secret)
+    db_master_secret_arn=$(printf '%s' "$master" | cut -f1)
+    db_master_password=$(printf '%s' "$master" | cut -f2)
+    ensure_db_instance "$db_master_password"
+    wait_db_available
+    db_endpoint=$(aws_cli rds describe-db-instances \
+        --db-instance-identifier "$DB_IDENTIFIER" \
+        --query 'DBInstances[0].Endpoint.Address' --output text)
+    db_port=$(aws_cli rds describe-db-instances \
+        --db-instance-identifier "$DB_IDENTIFIER" \
+        --query 'DBInstances[0].Endpoint.Port' --output text)
+    update_db_master_secret \
+        "$db_master_secret_arn" "$db_master_password" "$db_endpoint" "$db_port"
+
+    # ---- secrets ----------------------------------------------------------
+    license_arn=$(ensure_secret_with_value "$SECRET_LICENSE" \
+        "$(cat "$LICENSE_DATA_FILE")" \
+        "Cardinal lakerunner license" \
+        license)
+    internal_keys_arn=$(ensure_secret_with_value "$SECRET_INTERNAL_KEYS" \
+        "$(gen_hex32)" \
+        "Internal service keys (random 32-byte hex)" \
+        internal-keys)
+    # admin-key is JSON {"key": "..."} so the ECS secret pointer ":key::"
+    # resolves at task launch.
+    admin_key_arn=$(ensure_secret_with_value "$SECRET_ADMIN_KEY" \
+        "$(jq -nc --arg k "$(gen_hex32)" '{key:$k}')" \
+        "First-boot admin API key (rotated by admin-api)." \
+        admin-key)
+    maestro_db_arn=$(ensure_secret_with_value "$SECRET_MAESTRO_DB" \
+        "$(jq -nc --arg p "$(gen_password)" '{username:"maestro", password:$p}')" \
+        "Maestro app DB credential (username/password JSON)." \
+        maestro-db)
+
+    # ---- SSM --------------------------------------------------------------
+    ensure_ssm_parameter "$SSM_STORAGE_PROFILES" "{}" \
+        "Cardinal storage profiles (operator-managed JSON)"
+    ensure_ssm_parameter "$SSM_API_KEYS" "{}" \
+        "Cardinal external API keys (operator-managed JSON)"
+
+    log "done; emitting outputs JSON to stdout"
+
+    # ---- output -----------------------------------------------------------
+    # 1:1 with the cardinal-data-setup stack outputs and the
+    # cardinal-lakerunner data-layer parameters.
+    jq -nc \
+        --arg DbEndpoint "$db_endpoint" \
+        --arg DbPort "$db_port" \
+        --arg DbName "$DB_NAME" \
+        --arg DbMasterSecretArn "$db_master_secret_arn" \
+        --arg MaestroDbSecretArn "$maestro_db_arn" \
+        --arg IngestBucketName "$BUCKET" \
+        --arg IngestQueueUrl "$queue_url" \
+        --arg IngestQueueArn "$QUEUE_ARN" \
+        --arg LicenseSecretArn "$license_arn" \
+        --arg InternalKeysSecretArn "$internal_keys_arn" \
+        --arg AdminKeySecretArn "$admin_key_arn" \
+        --arg StorageProfilesParamName "$SSM_STORAGE_PROFILES" \
+        --arg ApiKeysParamName "$SSM_API_KEYS" \
+        '{
+            DbEndpoint:$DbEndpoint, DbPort:$DbPort, DbName:$DbName,
+            DbMasterSecretArn:$DbMasterSecretArn,
+            MaestroDbSecretArn:$MaestroDbSecretArn,
+            IngestBucketName:$IngestBucketName,
+            IngestQueueUrl:$IngestQueueUrl, IngestQueueArn:$IngestQueueArn,
+            LicenseSecretArn:$LicenseSecretArn,
+            InternalKeysSecretArn:$InternalKeysSecretArn,
+            AdminKeySecretArn:$AdminKeySecretArn,
+            StorageProfilesParamName:$StorageProfilesParamName,
+            ApiKeysParamName:$ApiKeysParamName
+        }'
+}
+
+main "$@"

--- a/src/cardinal_cfn/data_setup_lambda/template.py
+++ b/src/cardinal_cfn/data_setup_lambda/template.py
@@ -45,7 +45,10 @@ from troposphere.awslambda import Code, Function
 
 
 VERSION = os.environ.get("CARDINAL_VERSION", "dev")
-DEFAULT_BUCKET = os.environ.get("CARDINAL_BUCKET_NAME", "cardinal-cfn-us-east-2")
+# us-east-1 is the publishing source-of-truth; cardinal-cfn-us-east-2 is
+# populated via S3 bucket replication. Override CARDINAL_BUCKET_NAME for
+# air-gapped builds that target a customer-owned mirror.
+DEFAULT_BUCKET = os.environ.get("CARDINAL_BUCKET_NAME", "cardinal-cfn-us-east-1")
 DEFAULT_LAMBDA_URL = (
     f"s3://{DEFAULT_BUCKET}/lakerunner/{VERSION}/cardinal-data-setup-lambda.zip"
 )

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -30,8 +30,11 @@ from cardinal_cfn.defaults import load_defaults
 
 
 VERSION = os.environ.get("CARDINAL_VERSION", "dev")
-DEFAULT_BUCKET_REGION = os.environ.get("CARDINAL_BUCKET_REGION", "us-east-2")
-DEFAULT_BUCKET_NAME = os.environ.get("CARDINAL_BUCKET_NAME", "cardinal-cfn")
+# us-east-1 is the publishing source of truth; us-east-2 is populated via
+# S3 bucket replication. Override CARDINAL_BUCKET_NAME / CARDINAL_BUCKET_REGION
+# for air-gapped builds that target a customer-owned mirror.
+DEFAULT_BUCKET_REGION = os.environ.get("CARDINAL_BUCKET_REGION", "us-east-1")
+DEFAULT_BUCKET_NAME = os.environ.get("CARDINAL_BUCKET_NAME", "cardinal-cfn-us-east-1")
 DEFAULT_TEMPLATE_BASE_URL = (
     f"https://{DEFAULT_BUCKET_NAME}.s3.{DEFAULT_BUCKET_REGION}.amazonaws.com"
     f"/lakerunner/{VERSION}/cardinal-lakerunner/"


### PR DESCRIPTION
## Summary

Two related changes — feel free to split if you'd rather review separately.

### 1. \`scripts/data-setup.sh\` — raw AWS-CLI driver for the data layer

Functional drop-in for the cardinal-data-setup Lambda. Same resource names, same idempotent describe-then-act pattern, same 13 outputs on stdout. Use it from Jenkins (or any CI runner) to drive the data layer without deploying the wrapper CFN stack.

\`\`\`sh
REGION=us-east-2 \\
VPC_ID=vpc-... \\
PRIVATE_SUBNETS=subnet-aaaa,subnet-bbbb \\
DB_SG_ID=sg-... \\
LICENSE_DATA_FILE=/path/to/license.token \\
    scripts/data-setup.sh > /tmp/data-setup-outputs.json
\`\`\`

\`install-infrastructure.md\` adds an "Alternative: skip the Lambda" section pointing at it.

### 2. CI publishing source-of-truth → \`cardinal-cfn-us-east-1\`

us-east-1 is now the canonical publishing bucket; \`cardinal-cfn-us-east-2\` is populated via S3 bucket replication, out of band from this workflow.

- \`.github/workflows/release.yml\` AWS_REGION / CARDINAL_BUCKET_NAME / CARDINAL_BUCKET_REGION point at us-east-1.
- \`src/cardinal_cfn/root.py\` and \`src/cardinal_cfn/data_setup_lambda/template.py\` default to us-east-1 when \`CARDINAL_BUCKET_*\` env vars are unset.
- README, install-infrastructure, install-lakerunner, deploying, jenkins-deploy URLs all updated. install-infrastructure's per-region table is reordered with us-east-1 marked as the template default.
- \`end-to-end-test-plan.md\` is pre-pivot and intentionally left as legacy.

## Test plan

- [x] \`make check\` (370 passed, 3 skipped)
- [ ] Tag a release to confirm v0.0.43 lands at \`cardinal-cfn-us-east-1\` and replication populates \`cardinal-cfn-us-east-2\`