### PR TITLE
add cardinal-infrastructure: standalone stack for data-plane resources

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -9,3 +9,8 @@ ignore_checks:
   - W3005  # nested-stack DependsOn intentionally repeats the dependency
            # already implied by GetAtt(MigrationStack.Outputs.*) — keeping
            # both forms makes the ordering explicit at the root level
+  - E3005  # cardinal-infrastructure: IngestBucket DependsOn the conditional
+           # IngestQueuePolicy. In fresh-create mode the policy exists and
+           # the dependency prevents an S3-validates-by-posting race; in
+           # ImportMode=Yes neither resource is created, so DependsOn is a
+           # no-op per CFN docs.

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ check: test	## Pre-push gate (alias for test)
 lint:	## Run cfn-lint on every generated template
 	source $(VENV_DIR)/bin/activate && cfn-lint \
 	  generated-templates/cardinal-vpc.yaml \
+	  generated-templates/cardinal-infrastructure.yaml \
 	  generated-templates/cardinal-lakerunner.yaml \
 	  generated-templates/cardinal-lakerunner/*.yaml
 

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ export PYTHONPATH="$(pwd)/src${PYTHONPATH:+:$PYTHONPATH}"
 echo "Generating cardinal-vpc.yaml..."
 python3 -m cardinal_cfn.cardinal_vpc > generated-templates/cardinal-vpc.yaml
 
+echo "Generating cardinal-infrastructure.yaml..."
+python3 -m cardinal_cfn.cardinal_infrastructure > generated-templates/cardinal-infrastructure.yaml
+
 # ---------------------------------------------------------------------------
 # Lakerunner stack (root + 8 nested children). Children take role ARNs,
 # security-group IDs, and infra identifiers (cluster, RDS, S3, SQS, secrets,
@@ -39,6 +42,7 @@ done
 echo
 echo "Linting CFN templates..."
 cfn-lint generated-templates/cardinal-vpc.yaml \
+         generated-templates/cardinal-infrastructure.yaml \
          generated-templates/cardinal-lakerunner.yaml \
          generated-templates/cardinal-lakerunner/*.yaml || \
   echo "cfn-lint completed with warnings"

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -1,0 +1,677 @@
+"""cardinal-infrastructure: standalone data-plane template.
+
+Customer-deployable peer to ``cardinal-vpc``. Creates the resources that
+``cardinal-lakerunner`` needs as inputs but does not manage itself:
+
+- RDS PostgreSQL instance + DB subnet group + master secret
+- S3 ingest bucket + lifecycle policy + S3 -> SQS notification
+- SQS ingest queue + queue policy
+- License / internal-keys / admin-key / maestro-db secrets
+- /cardinal/storage-profiles and /cardinal/api-keys SSM parameters
+
+Conceptually a CloudFormation port of ``scripts/data-setup.sh``; the
+opinionated config (engine version, sizing, lifecycle days, password
+shape, secret JSON layout) mirrors the script 1:1.
+
+Outputs match the keys the script emits, so the lakerunner stack can
+consume either path identically.
+
+Recovery from a failed first create
+-----------------------------------
+
+Every resource has ``DeletionPolicy: Retain`` (RDS uses ``Snapshot``).
+A rollback after partial create therefore orphans whatever was already
+created. Resources with explicit physical names (the S3 ingest bucket,
+the two SSM parameters, the license + admin-key secrets) will then
+collide on retry. To recover:
+
+1. Delete the failed stack -- orphaned resources stay put.
+2. Either: (a) pass alternate values for ``IngestBucketName`` /
+   ``LicenseSecretName`` / ``AdminKeySecretName`` /
+   ``StorageProfilesParamName`` / ``ApiKeysParamName`` on retry, or
+   (b) manually delete the orphans via the console (note: Secrets
+   Manager imposes a 7-day minimum recovery window unless you call
+   ``delete-secret --force-delete-without-recovery``), then redeploy.
+
+Resources without explicit names (RDS, SQS, DB subnet group, the
+db-master / internal-keys / maestro-db secrets) are CFN-named and
+collide-free on retry.
+"""
+
+from troposphere import (
+    Equals,
+    GetAtt,
+    If,
+    Output,
+    Parameter,
+    Ref,
+    Sub,
+    Tags,
+    Template,
+)
+from troposphere.rds import DBInstance, DBSubnetGroup
+from troposphere.s3 import (
+    AbortIncompleteMultipartUpload,
+    Bucket,
+    LifecycleConfiguration,
+    LifecycleRule,
+    NotificationConfiguration,
+    QueueConfigurations,
+)
+from troposphere.secretsmanager import (
+    GenerateSecretString,
+    Secret,
+    SecretTargetAttachment,
+)
+from troposphere.sqs import Queue, QueuePolicy
+from troposphere.ssm import Parameter as SSMParameter
+
+from cardinal_cfn.parameters import add_no_echo_parameter, add_parameter_group_metadata
+
+
+MANAGED_BY = "cardinal-cfn-infrastructure"
+PROJECT = "cardinal"
+APPLICATION = "cardinal-lakerunner"
+
+
+def _tags(*, component: str) -> Tags:
+    """Tag set matching scripts/data-setup.sh's ``tags_json_array``."""
+
+    return Tags(
+        Application=APPLICATION,
+        Project=PROJECT,
+        ManagedBy=MANAGED_BY,
+        Component=component,
+        Name=f"cardinal-{component}",
+    )
+
+
+def _retain(resource):
+    resource.DeletionPolicy = "Retain"
+    resource.UpdateReplacePolicy = "Retain"
+    return resource
+
+
+def _snapshot(resource):
+    resource.DeletionPolicy = "Snapshot"
+    resource.UpdateReplacePolicy = "Snapshot"
+    return resource
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal infrastructure: RDS, S3 ingest bucket, SQS ingest queue, "
+        "secrets, and SSM parameters consumed by the cardinal-lakerunner stack. "
+        "All resources retain on stack delete (RDS snapshots) so customer data "
+        "survives rollback or stack tear-down."
+    )
+
+    # -----------------------------------------------------------------------
+    # Parameters
+    # -----------------------------------------------------------------------
+
+    private_subnets = t.add_parameter(
+        Parameter(
+            "PrivateSubnets",
+            Type="List<AWS::EC2::Subnet::Id>",
+            Description=(
+                "Two or more private subnets in distinct AZs for the RDS "
+                "subnet group."
+            ),
+        )
+    )
+    db_sg_id = t.add_parameter(
+        Parameter(
+            "DBSecurityGroupId",
+            Type="AWS::EC2::SecurityGroup::Id",
+            Description=(
+                "Security group attached to the RDS instance. The customer "
+                "creates this and grants the lakerunner ECS tasks ingress."
+            ),
+        )
+    )
+    db_engine_version = t.add_parameter(
+        Parameter(
+            "DBEngineVersion",
+            Type="String",
+            Default="18.3",
+            Description="PostgreSQL engine version for the RDS instance.",
+        )
+    )
+    db_instance_class = t.add_parameter(
+        Parameter(
+            "DBInstanceClass",
+            Type="String",
+            Default="db.t3.medium",
+            Description="RDS instance class.",
+        )
+    )
+    db_allocated_storage = t.add_parameter(
+        Parameter(
+            "DBAllocatedStorage",
+            Type="Number",
+            Default=100,
+            MinValue=20,
+            Description="Allocated storage for the RDS instance, in GiB.",
+        )
+    )
+    bucket_lifecycle_days = t.add_parameter(
+        Parameter(
+            "IngestBucketLifecycleDays",
+            Type="Number",
+            Default=7,
+            MinValue=1,
+            Description=(
+                "Days after which objects in the ingest bucket expire. "
+                "Lakerunner consumes objects within minutes; this is the "
+                "garbage-collection backstop."
+            ),
+        )
+    )
+    ingest_bucket_name = t.add_parameter(
+        Parameter(
+            "IngestBucketName",
+            Type="String",
+            Default="",
+            Description=(
+                "Name for the ingest bucket. Leave blank to use the default "
+                "cardinal-ingest-<account>-<region>. Override on a redeploy "
+                "if recovering from a failed create that orphaned the bucket."
+            ),
+            AllowedPattern=r"^$|^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
+        )
+    )
+    license_secret_name = t.add_parameter(
+        Parameter(
+            "LicenseSecretName",
+            Type="String",
+            Default="cardinal-license",
+            Description=(
+                "Secrets Manager name for the license secret. Override on "
+                "redeploy if a previous create orphaned the secret."
+            ),
+            MinLength=1,
+        )
+    )
+    admin_key_secret_name = t.add_parameter(
+        Parameter(
+            "AdminKeySecretName",
+            Type="String",
+            Default="cardinal-admin-key",
+            Description=(
+                "Secrets Manager name for the first-boot admin key secret. "
+                "Override on redeploy if a previous create orphaned it."
+            ),
+            MinLength=1,
+        )
+    )
+    storage_profiles_param_name = t.add_parameter(
+        Parameter(
+            "StorageProfilesParamName",
+            Type="String",
+            Default="/cardinal/storage-profiles",
+            Description=(
+                "SSM parameter name for the operator-managed storage-profiles "
+                "JSON. Override on redeploy if a previous create orphaned it."
+            ),
+            AllowedPattern=r"^/[A-Za-z0-9._/-]{1,1011}$",
+        )
+    )
+    api_keys_param_name = t.add_parameter(
+        Parameter(
+            "ApiKeysParamName",
+            Type="String",
+            Default="/cardinal/api-keys",
+            Description=(
+                "SSM parameter name for the operator-managed external "
+                "API keys JSON. Override on redeploy if orphaned."
+            ),
+            AllowedPattern=r"^/[A-Za-z0-9._/-]{1,1011}$",
+        )
+    )
+    license_data = add_no_echo_parameter(
+        t,
+        "LicenseData",
+        description=(
+            "Cardinal license token (z64:...). Stored verbatim as the "
+            "string body of the license secret."
+        ),
+    )
+
+    add_parameter_group_metadata(
+        t,
+        groups=[
+            {
+                "label": "Networking",
+                "parameters": ["PrivateSubnets", "DBSecurityGroupId"],
+            },
+            {
+                "label": "Database sizing",
+                "parameters": [
+                    "DBEngineVersion",
+                    "DBInstanceClass",
+                    "DBAllocatedStorage",
+                ],
+            },
+            {
+                "label": "Ingest",
+                "parameters": [
+                    "IngestBucketName",
+                    "IngestBucketLifecycleDays",
+                ],
+            },
+            {
+                "label": "License",
+                "parameters": ["LicenseData"],
+            },
+            {
+                "label": "Recovery overrides (advanced)",
+                "parameters": [
+                    "LicenseSecretName",
+                    "AdminKeySecretName",
+                    "StorageProfilesParamName",
+                    "ApiKeysParamName",
+                ],
+            },
+        ],
+        labels={
+            "PrivateSubnets": "Private subnets (2+ in distinct AZs)",
+            "DBSecurityGroupId": "Security group for the RDS instance",
+            "DBEngineVersion": "PostgreSQL engine version",
+            "DBInstanceClass": "RDS instance class",
+            "DBAllocatedStorage": "Storage (GiB)",
+            "IngestBucketName": "Ingest bucket name (blank = default)",
+            "IngestBucketLifecycleDays": "Ingest object retention (days)",
+            "LicenseData": "License token (z64:...)",
+        },
+    )
+
+    # -----------------------------------------------------------------------
+    # Conditions
+    # -----------------------------------------------------------------------
+
+    t.add_condition(
+        "UseDefaultBucketName",
+        Equals(Ref(ingest_bucket_name), ""),
+    )
+
+    bucket_name_value = If(
+        "UseDefaultBucketName",
+        Sub("cardinal-ingest-${AWS::AccountId}-${AWS::Region}"),
+        Ref(ingest_bucket_name),
+    )
+
+    # -----------------------------------------------------------------------
+    # SQS ingest queue + S3 source policy
+    # -----------------------------------------------------------------------
+
+    ingest_queue = t.add_resource(
+        _retain(
+            Queue(
+                "IngestQueue",
+                Tags=_tags(component="ingest-queue"),
+            )
+        )
+    )
+
+    ingest_queue_policy = t.add_resource(
+        QueuePolicy(
+            "IngestQueuePolicy",
+            Queues=[Ref(ingest_queue)],
+            PolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "s3.amazonaws.com"},
+                        "Action": [
+                            "sqs:SendMessage",
+                            "sqs:GetQueueAttributes",
+                            "sqs:GetQueueUrl",
+                        ],
+                        "Resource": GetAtt(ingest_queue, "Arn"),
+                        "Condition": {
+                            "StringEquals": {
+                                "aws:SourceAccount": Ref("AWS::AccountId")
+                            },
+                            "ArnLike": {
+                                "aws:SourceArn": Sub(
+                                    "arn:${AWS::Partition}:s3:::${BucketName}",
+                                    BucketName=bucket_name_value,
+                                )
+                            },
+                        },
+                    }
+                ],
+            },
+        )
+    )
+
+    # -----------------------------------------------------------------------
+    # S3 ingest bucket
+    # -----------------------------------------------------------------------
+
+    ingest_bucket = t.add_resource(
+        _retain(
+            Bucket(
+                "IngestBucket",
+                BucketName=bucket_name_value,
+                LifecycleConfiguration=LifecycleConfiguration(
+                    Rules=[
+                        LifecycleRule(
+                            Id="cardinal-ingest-expire",
+                            Status="Enabled",
+                            Prefix="",
+                            ExpirationInDays=Ref(bucket_lifecycle_days),
+                            AbortIncompleteMultipartUpload=AbortIncompleteMultipartUpload(
+                                DaysAfterInitiation=1
+                            ),
+                        )
+                    ]
+                ),
+                NotificationConfiguration=NotificationConfiguration(
+                    QueueConfigurations=[
+                        QueueConfigurations(
+                            Event="s3:ObjectCreated:*",
+                            Queue=GetAtt(ingest_queue, "Arn"),
+                        )
+                    ]
+                ),
+                Tags=_tags(component="ingest-bucket"),
+                DependsOn=ingest_queue_policy.title,
+            )
+        )
+    )
+
+    # -----------------------------------------------------------------------
+    # RDS subnet group + master secret + DB instance + target attachment
+    # -----------------------------------------------------------------------
+
+    db_subnet_group = t.add_resource(
+        _retain(
+            DBSubnetGroup(
+                "DBSubnetGroup",
+                DBSubnetGroupDescription="Cardinal lakerunner DB subnet group",
+                SubnetIds=Ref(private_subnets),
+                Tags=_tags(component="db-subnet-group"),
+            )
+        )
+    )
+
+    db_master_secret = t.add_resource(
+        _retain(
+            Secret(
+                "DBMasterSecret",
+                Description=(
+                    "Cardinal RDS master credentials. Connection JSON "
+                    "(host/port/engine/dbname) is filled in by the "
+                    "associated SecretTargetAttachment."
+                ),
+                GenerateSecretString=GenerateSecretString(
+                    SecretStringTemplate='{"username":"lakerunner"}',
+                    GenerateStringKey="password",
+                    PasswordLength=40,
+                    ExcludePunctuation=True,
+                ),
+                Tags=_tags(component="db-master"),
+            )
+        )
+    )
+
+    db_instance = t.add_resource(
+        _snapshot(
+            DBInstance(
+                "DBInstance",
+                Engine="postgres",
+                EngineVersion=Ref(db_engine_version),
+                DBInstanceClass=Ref(db_instance_class),
+                AllocatedStorage=Ref(db_allocated_storage),
+                StorageType="gp3",
+                StorageEncrypted=True,
+                DBName="lakerunner",
+                Port=5432,
+                MasterUsername="lakerunner",
+                MasterUserPassword=Sub(
+                    "{{resolve:secretsmanager:${SecretArn}::password}}",
+                    SecretArn=Ref(db_master_secret),
+                ),
+                DBSubnetGroupName=Ref(db_subnet_group),
+                VPCSecurityGroups=[Ref(db_sg_id)],
+                PubliclyAccessible=False,
+                MultiAZ=False,
+                BackupRetentionPeriod=7,
+                DeletionProtection=True,
+                Tags=_tags(component="db"),
+            )
+        )
+    )
+
+    # SecretTargetAttachment rewrites the secret to embed
+    # {engine, host, port, dbname} alongside username/password -- matching
+    # the connection JSON the lakerunner task containers consume.
+    t.add_resource(
+        SecretTargetAttachment(
+            "DBMasterSecretAttachment",
+            SecretId=Ref(db_master_secret),
+            TargetId=Ref(db_instance),
+            TargetType="AWS::RDS::DBInstance",
+        )
+    )
+
+    # -----------------------------------------------------------------------
+    # Application secrets (license, internal-keys, admin-key, maestro-db)
+    # -----------------------------------------------------------------------
+
+    license_secret = t.add_resource(
+        _retain(
+            Secret(
+                "LicenseSecret",
+                Name=Ref(license_secret_name),
+                Description="Cardinal lakerunner license token (z64:...).",
+                SecretString=Ref(license_data),
+                Tags=_tags(component="license"),
+            )
+        )
+    )
+
+    internal_keys_secret = t.add_resource(
+        _retain(
+            Secret(
+                "InternalKeysSecret",
+                Description=(
+                    "Internal service keys: opaque high-entropy string "
+                    "shared between lakerunner services."
+                ),
+                GenerateSecretString=GenerateSecretString(
+                    PasswordLength=64,
+                    ExcludePunctuation=True,
+                ),
+                Tags=_tags(component="internal-keys"),
+            )
+        )
+    )
+
+    admin_key_secret = t.add_resource(
+        _retain(
+            Secret(
+                "AdminKeySecret",
+                Name=Ref(admin_key_secret_name),
+                Description=(
+                    "First-boot admin API key. JSON shape "
+                    '{"key": "<random>"} so the ECS secret pointer '
+                    '":key::" resolves at task launch.'
+                ),
+                GenerateSecretString=GenerateSecretString(
+                    SecretStringTemplate="{}",
+                    GenerateStringKey="key",
+                    PasswordLength=64,
+                    ExcludePunctuation=True,
+                ),
+                Tags=_tags(component="admin-key"),
+            )
+        )
+    )
+
+    maestro_db_secret = t.add_resource(
+        _retain(
+            Secret(
+                "MaestroDBSecret",
+                Description=(
+                    'Maestro app DB credential. JSON shape '
+                    '{"username":"maestro","password":"<random>"}.'
+                ),
+                GenerateSecretString=GenerateSecretString(
+                    SecretStringTemplate='{"username":"maestro"}',
+                    GenerateStringKey="password",
+                    PasswordLength=40,
+                    ExcludePunctuation=True,
+                ),
+                Tags=_tags(component="maestro-db"),
+            )
+        )
+    )
+
+    # -----------------------------------------------------------------------
+    # SSM parameters (operator-managed JSON, default {})
+    # -----------------------------------------------------------------------
+
+    storage_profiles_param = t.add_resource(
+        _retain(
+            SSMParameter(
+                "StorageProfilesParam",
+                Name=Ref(storage_profiles_param_name),
+                Type="String",
+                Value="{}",
+                Description="Cardinal storage profiles (operator-managed JSON).",
+                Tags={
+                    "Application": APPLICATION,
+                    "Project": PROJECT,
+                    "ManagedBy": MANAGED_BY,
+                    "Component": "ssm-storage-profiles",
+                    "Name": "cardinal-ssm-storage-profiles",
+                },
+            )
+        )
+    )
+
+    api_keys_param = t.add_resource(
+        _retain(
+            SSMParameter(
+                "ApiKeysParam",
+                Name=Ref(api_keys_param_name),
+                Type="String",
+                Value="{}",
+                Description="Cardinal external API keys (operator-managed JSON).",
+                Tags={
+                    "Application": APPLICATION,
+                    "Project": PROJECT,
+                    "ManagedBy": MANAGED_BY,
+                    "Component": "ssm-api-keys",
+                    "Name": "cardinal-ssm-api-keys",
+                },
+            )
+        )
+    )
+
+    # -----------------------------------------------------------------------
+    # Outputs (1:1 with the JSON keys that scripts/data-setup.sh emits)
+    # -----------------------------------------------------------------------
+
+    t.add_output(
+        Output(
+            "DbEndpoint",
+            Description="RDS endpoint hostname.",
+            Value=GetAtt(db_instance, "Endpoint.Address"),
+        )
+    )
+    t.add_output(
+        Output(
+            "DbPort",
+            Description="RDS endpoint port.",
+            Value=GetAtt(db_instance, "Endpoint.Port"),
+        )
+    )
+    t.add_output(
+        Output(
+            "DbName",
+            Description="RDS database name.",
+            Value="lakerunner",
+        )
+    )
+    t.add_output(
+        Output(
+            "DbMasterSecretArn",
+            Description="ARN of the RDS master-credentials secret.",
+            Value=Ref(db_master_secret),
+        )
+    )
+    t.add_output(
+        Output(
+            "MaestroDbSecretArn",
+            Description="ARN of the Maestro app DB credentials secret.",
+            Value=Ref(maestro_db_secret),
+        )
+    )
+    t.add_output(
+        Output(
+            "IngestBucketName",
+            Description="Name of the S3 ingest bucket.",
+            Value=Ref(ingest_bucket),
+        )
+    )
+    t.add_output(
+        Output(
+            "IngestQueueUrl",
+            Description="URL of the SQS ingest queue.",
+            Value=Ref(ingest_queue),
+        )
+    )
+    t.add_output(
+        Output(
+            "IngestQueueArn",
+            Description="ARN of the SQS ingest queue.",
+            Value=GetAtt(ingest_queue, "Arn"),
+        )
+    )
+    t.add_output(
+        Output(
+            "LicenseSecretArn",
+            Description="ARN of the license secret.",
+            Value=Ref(license_secret),
+        )
+    )
+    t.add_output(
+        Output(
+            "InternalKeysSecretArn",
+            Description="ARN of the internal service keys secret.",
+            Value=Ref(internal_keys_secret),
+        )
+    )
+    t.add_output(
+        Output(
+            "AdminKeySecretArn",
+            Description="ARN of the first-boot admin key secret.",
+            Value=Ref(admin_key_secret),
+        )
+    )
+    t.add_output(
+        Output(
+            "StorageProfilesParamName",
+            Description="Name of the storage-profiles SSM parameter.",
+            Value=Ref(storage_profiles_param),
+        )
+    )
+    t.add_output(
+        Output(
+            "ApiKeysParamName",
+            Description="Name of the external API-keys SSM parameter.",
+            Value=Ref(api_keys_param),
+        )
+    )
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -16,6 +16,25 @@ shape, secret JSON layout) mirrors the script 1:1.
 Outputs match the keys the script emits, so the lakerunner stack can
 consume either path identically.
 
+Importing existing resources
+----------------------------
+
+To bring an existing data-setup.sh-created install under stack
+management:
+
+1. Run a ``create-change-set --change-set-type IMPORT`` with
+   ``ImportMode=Yes`` and the matching ``*Name`` overrides set to the
+   live physical names. The CFN-only resources (``IngestQueuePolicy``
+   and ``DBMasterSecretAttachment``) are skipped in this mode -- CFN
+   import does not support resources that lack a real AWS-side
+   physical ID.
+2. After import succeeds, run a normal stack update with
+   ``ImportMode=No``. CFN creates the two skipped resources via their
+   underlying API calls (``set-queue-attributes`` and
+   ``put-secret-value``). Both are no-ops when the live config already
+   matches the template, which it will for any install bootstrapped
+   by ``scripts/data-setup.sh``.
+
 Recovery from a failed first create
 -----------------------------------
 
@@ -39,6 +58,7 @@ collide-free on retry.
 """
 
 from troposphere import (
+    AWS_NO_VALUE,
     Equals,
     GetAtt,
     If,
@@ -239,6 +259,99 @@ def build() -> Template:
         ),
     )
 
+    # -----------------------------------------------------------------------
+    # Optional explicit-name parameters (used when importing an existing
+    # data-setup.sh-created install into the stack). Blank => CFN-auto-named.
+    # -----------------------------------------------------------------------
+
+    db_instance_identifier = t.add_parameter(
+        Parameter(
+            "DBInstanceIdentifier",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional explicit DB instance identifier. Set to the "
+                "existing identifier (e.g. 'cardinal-db') when importing; "
+                "leave blank for fresh installs."
+            ),
+        )
+    )
+    db_subnet_group_name = t.add_parameter(
+        Parameter(
+            "DBSubnetGroupName",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional explicit DB subnet group name. Set when "
+                "importing an existing subnet group; blank otherwise."
+            ),
+        )
+    )
+    ingest_queue_name = t.add_parameter(
+        Parameter(
+            "IngestQueueName",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional explicit SQS queue name. Set when importing "
+                "an existing queue (e.g. 'cardinal-ingest'); blank "
+                "otherwise."
+            ),
+        )
+    )
+    db_master_secret_name = t.add_parameter(
+        Parameter(
+            "DBMasterSecretName",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional explicit name for the DB master secret. Set "
+                "to the existing name (e.g. 'cardinal-db-master') when "
+                "importing; blank otherwise."
+            ),
+        )
+    )
+    internal_keys_secret_name = t.add_parameter(
+        Parameter(
+            "InternalKeysSecretName",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional explicit name for the internal-keys secret. "
+                "Set to the existing name (e.g. 'cardinal-internal-keys') "
+                "when importing; blank otherwise."
+            ),
+        )
+    )
+    maestro_db_secret_name = t.add_parameter(
+        Parameter(
+            "MaestroDBSecretName",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional explicit name for the maestro-db secret. Set "
+                "to the existing name (e.g. 'cardinal-maestro-db') when "
+                "importing; blank otherwise."
+            ),
+        )
+    )
+    import_mode = t.add_parameter(
+        Parameter(
+            "ImportMode",
+            Type="String",
+            Default="No",
+            AllowedValues=["Yes", "No"],
+            Description=(
+                "Set to 'Yes' when running this template as a "
+                "create-change-set --change-set-type IMPORT. The "
+                "CFN-only resources (DBMasterSecretAttachment and the "
+                "IngestQueuePolicy) are skipped in this mode and must "
+                "be added by a follow-up stack update with "
+                "ImportMode=No."
+            ),
+        )
+    )
+
     add_parameter_group_metadata(
         t,
         groups=[
@@ -274,6 +387,17 @@ def build() -> Template:
                     "ApiKeysParamName",
                 ],
             },
+            {
+                "label": "Import overrides (set only when importing existing resources)",
+                "parameters": [
+                    "DBInstanceIdentifier",
+                    "DBSubnetGroupName",
+                    "IngestQueueName",
+                    "DBMasterSecretName",
+                    "InternalKeysSecretName",
+                    "MaestroDBSecretName",
+                ],
+            },
         ],
         labels={
             "PrivateSubnets": "Private subnets (2+ in distinct AZs)",
@@ -296,6 +420,28 @@ def build() -> Template:
         Equals(Ref(ingest_bucket_name), ""),
     )
 
+    # CFN has no "not-equals". Each ``AutoNameX`` is True iff the
+    # corresponding override parameter is blank. Use site idiom:
+    # ``If("AutoNameX", AWS_NO_VALUE, Ref(X))``.
+    t.add_condition(
+        "AutoNameDBInstance", Equals(Ref(db_instance_identifier), "")
+    )
+    t.add_condition(
+        "AutoNameDBSubnetGroup", Equals(Ref(db_subnet_group_name), "")
+    )
+    t.add_condition("AutoNameIngestQueue", Equals(Ref(ingest_queue_name), ""))
+    t.add_condition(
+        "AutoNameDBMasterSecret", Equals(Ref(db_master_secret_name), "")
+    )
+    t.add_condition(
+        "AutoNameInternalKeysSecret",
+        Equals(Ref(internal_keys_secret_name), ""),
+    )
+    t.add_condition(
+        "AutoNameMaestroDBSecret", Equals(Ref(maestro_db_secret_name), "")
+    )
+    t.add_condition("CreateCfnOnlyResources", Equals(Ref(import_mode), "No"))
+
     bucket_name_value = If(
         "UseDefaultBucketName",
         Sub("cardinal-ingest-${AWS::AccountId}-${AWS::Region}"),
@@ -310,6 +456,9 @@ def build() -> Template:
         _retain(
             Queue(
                 "IngestQueue",
+                QueueName=If(
+                    "AutoNameIngestQueue", Ref(AWS_NO_VALUE), Ref(ingest_queue_name)
+                ),
                 Tags=_tags(component="ingest-queue"),
             )
         )
@@ -318,6 +467,7 @@ def build() -> Template:
     ingest_queue_policy = t.add_resource(
         QueuePolicy(
             "IngestQueuePolicy",
+            Condition="CreateCfnOnlyResources",
             Queues=[Ref(ingest_queue)],
             PolicyDocument={
                 "Version": "2012-10-17",
@@ -392,6 +542,11 @@ def build() -> Template:
         _retain(
             DBSubnetGroup(
                 "DBSubnetGroup",
+                DBSubnetGroupName=If(
+                    "AutoNameDBSubnetGroup",
+                    Ref(AWS_NO_VALUE),
+                    Ref(db_subnet_group_name),
+                ),
                 DBSubnetGroupDescription="Cardinal lakerunner DB subnet group",
                 SubnetIds=Ref(private_subnets),
                 Tags=_tags(component="db-subnet-group"),
@@ -403,6 +558,11 @@ def build() -> Template:
         _retain(
             Secret(
                 "DBMasterSecret",
+                Name=If(
+                    "AutoNameDBMasterSecret",
+                    Ref(AWS_NO_VALUE),
+                    Ref(db_master_secret_name),
+                ),
                 Description=(
                     "Cardinal RDS master credentials. Connection JSON "
                     "(host/port/engine/dbname) is filled in by the "
@@ -423,6 +583,11 @@ def build() -> Template:
         _snapshot(
             DBInstance(
                 "DBInstance",
+                DBInstanceIdentifier=If(
+                    "AutoNameDBInstance",
+                    Ref(AWS_NO_VALUE),
+                    Ref(db_instance_identifier),
+                ),
                 Engine="postgres",
                 EngineVersion=Ref(db_engine_version),
                 DBInstanceClass=Ref(db_instance_class),
@@ -453,6 +618,7 @@ def build() -> Template:
     t.add_resource(
         SecretTargetAttachment(
             "DBMasterSecretAttachment",
+            Condition="CreateCfnOnlyResources",
             SecretId=Ref(db_master_secret),
             TargetId=Ref(db_instance),
             TargetType="AWS::RDS::DBInstance",
@@ -479,6 +645,11 @@ def build() -> Template:
         _retain(
             Secret(
                 "InternalKeysSecret",
+                Name=If(
+                    "AutoNameInternalKeysSecret",
+                    Ref(AWS_NO_VALUE),
+                    Ref(internal_keys_secret_name),
+                ),
                 Description=(
                     "Internal service keys: opaque high-entropy string "
                     "shared between lakerunner services."
@@ -517,6 +688,11 @@ def build() -> Template:
         _retain(
             Secret(
                 "MaestroDBSecret",
+                Name=If(
+                    "AutoNameMaestroDBSecret",
+                    Ref(AWS_NO_VALUE),
+                    Ref(maestro_db_secret_name),
+                ),
                 Description=(
                     'Maestro app DB credential. JSON shape '
                     '{"username":"maestro","password":"<random>"}.'

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -1,0 +1,326 @@
+"""Tests for the cardinal-infrastructure standalone template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import cardinal_infrastructure
+
+
+@pytest.fixture
+def td():
+    return json.loads(cardinal_infrastructure.build().to_json())
+
+
+# ---------------------------------------------------------------------------
+# Parameters
+# ---------------------------------------------------------------------------
+
+
+def test_required_parameters(td):
+    for n in (
+        "PrivateSubnets",
+        "DBSecurityGroupId",
+        "DBEngineVersion",
+        "DBInstanceClass",
+        "DBAllocatedStorage",
+        "IngestBucketLifecycleDays",
+        "IngestBucketName",
+        "LicenseSecretName",
+        "AdminKeySecretName",
+        "StorageProfilesParamName",
+        "ApiKeysParamName",
+        "LicenseData",
+    ):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_license_data_is_no_echo(td):
+    assert td["Parameters"]["LicenseData"].get("NoEcho") is True
+
+
+def test_db_engine_version_default_matches_test_account(td):
+    """The script's test deploys land on Postgres 18.3 -- pin same default."""
+    assert td["Parameters"]["DBEngineVersion"]["Default"] == "18.3"
+
+
+def test_db_instance_class_default(td):
+    assert td["Parameters"]["DBInstanceClass"]["Default"] == "db.t3.medium"
+
+
+def test_db_allocated_storage_default(td):
+    assert td["Parameters"]["DBAllocatedStorage"]["Default"] == 100
+
+
+def test_lifecycle_days_default(td):
+    assert td["Parameters"]["IngestBucketLifecycleDays"]["Default"] == 7
+
+
+def test_recovery_override_defaults(td):
+    """Defaults match the names data-setup.sh creates today."""
+    assert td["Parameters"]["LicenseSecretName"]["Default"] == "cardinal-license"
+    assert td["Parameters"]["AdminKeySecretName"]["Default"] == "cardinal-admin-key"
+    assert (
+        td["Parameters"]["StorageProfilesParamName"]["Default"]
+        == "/cardinal/storage-profiles"
+    )
+    assert td["Parameters"]["ApiKeysParamName"]["Default"] == "/cardinal/api-keys"
+
+
+def test_ingest_bucket_name_default_is_blank(td):
+    """Blank default => template synthesizes cardinal-ingest-<acct>-<region>."""
+    assert td["Parameters"]["IngestBucketName"]["Default"] == ""
+
+
+def test_no_install_id_parameters(td):
+    for n in ("InstallIdShort", "InstallIdLong"):
+        assert n not in td["Parameters"], f"{n} should not be a parameter"
+
+
+# ---------------------------------------------------------------------------
+# Resources -- presence
+# ---------------------------------------------------------------------------
+
+
+def _types(td):
+    return [r["Type"] for r in td["Resources"].values()]
+
+
+def test_creates_rds_instance_and_subnet_group(td):
+    types = _types(td)
+    assert types.count("AWS::RDS::DBInstance") == 1
+    assert types.count("AWS::RDS::DBSubnetGroup") == 1
+
+
+def test_creates_secret_target_attachment(td):
+    types = _types(td)
+    assert types.count("AWS::SecretsManager::SecretTargetAttachment") == 1
+
+
+def test_creates_four_managed_secrets_plus_master(td):
+    """db-master + license + internal-keys + admin-key + maestro-db = 5."""
+    secrets = [
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::SecretsManager::Secret"
+    ]
+    assert len(secrets) == 5
+
+
+def test_creates_two_ssm_parameters(td):
+    types = _types(td)
+    assert types.count("AWS::SSM::Parameter") == 2
+
+
+def test_creates_ingest_bucket_and_queue(td):
+    types = _types(td)
+    assert types.count("AWS::S3::Bucket") == 1
+    assert types.count("AWS::SQS::Queue") == 1
+    assert types.count("AWS::SQS::QueuePolicy") == 1
+
+
+# ---------------------------------------------------------------------------
+# Resources -- shape
+# ---------------------------------------------------------------------------
+
+
+def _by_logical_id(td, logical_id):
+    return td["Resources"][logical_id]
+
+
+def test_rds_engine_settings(td):
+    rds = _by_logical_id(td, "DBInstance")["Properties"]
+    assert rds["Engine"] == "postgres"
+    assert rds["StorageEncrypted"] is True
+    assert rds["StorageType"] == "gp3"
+    assert rds["PubliclyAccessible"] is False
+    assert rds["MultiAZ"] is False
+    assert rds["DeletionProtection"] is True
+    assert rds["BackupRetentionPeriod"] == 7
+    assert rds["Port"] == 5432
+    assert rds["DBName"] == "lakerunner"
+    assert rds["MasterUsername"] == "lakerunner"
+
+
+def test_rds_master_password_resolves_from_secret(td):
+    rds = _by_logical_id(td, "DBInstance")["Properties"]
+    sub = rds["MasterUserPassword"]["Fn::Sub"]
+    # ['{{resolve:secretsmanager:${SecretArn}::password}}', {'SecretArn': {...}}]
+    assert "resolve:secretsmanager" in sub[0]
+    assert sub[1]["SecretArn"] == {"Ref": "DBMasterSecret"}
+
+
+def test_rds_uses_snapshot_policy(td):
+    rds = _by_logical_id(td, "DBInstance")
+    assert rds["DeletionPolicy"] == "Snapshot"
+    assert rds["UpdateReplacePolicy"] == "Snapshot"
+
+
+def test_db_subnet_group_takes_private_subnets(td):
+    sg = _by_logical_id(td, "DBSubnetGroup")["Properties"]
+    assert sg["SubnetIds"] == {"Ref": "PrivateSubnets"}
+
+
+def test_db_master_secret_generates_password(td):
+    secret = _by_logical_id(td, "DBMasterSecret")["Properties"]
+    gen = secret["GenerateSecretString"]
+    assert gen["GenerateStringKey"] == "password"
+    assert gen["PasswordLength"] == 40
+    assert gen["ExcludePunctuation"] is True
+    assert "lakerunner" in gen["SecretStringTemplate"]
+
+
+def test_target_attachment_links_secret_and_db(td):
+    att = _by_logical_id(td, "DBMasterSecretAttachment")["Properties"]
+    assert att["SecretId"] == {"Ref": "DBMasterSecret"}
+    assert att["TargetId"] == {"Ref": "DBInstance"}
+    assert att["TargetType"] == "AWS::RDS::DBInstance"
+
+
+def test_license_secret_uses_parameter_value(td):
+    sec = _by_logical_id(td, "LicenseSecret")["Properties"]
+    assert sec["SecretString"] == {"Ref": "LicenseData"}
+    assert sec["Name"] == {"Ref": "LicenseSecretName"}
+
+
+def test_admin_key_secret_generates_keyed_json(td):
+    sec = _by_logical_id(td, "AdminKeySecret")["Properties"]
+    gen = sec["GenerateSecretString"]
+    assert gen["GenerateStringKey"] == "key"
+    assert gen["PasswordLength"] == 64
+    assert gen["SecretStringTemplate"] == "{}"
+    assert sec["Name"] == {"Ref": "AdminKeySecretName"}
+
+
+def test_internal_keys_secret_is_plain_string(td):
+    sec = _by_logical_id(td, "InternalKeysSecret")["Properties"]
+    gen = sec["GenerateSecretString"]
+    assert "SecretStringTemplate" not in gen
+    assert "GenerateStringKey" not in gen
+    assert gen["PasswordLength"] == 64
+
+
+def test_maestro_db_secret_generates_password_with_username(td):
+    sec = _by_logical_id(td, "MaestroDBSecret")["Properties"]
+    gen = sec["GenerateSecretString"]
+    assert gen["GenerateStringKey"] == "password"
+    assert "maestro" in gen["SecretStringTemplate"]
+
+
+def test_ssm_parameters_use_overridable_names(td):
+    sp = _by_logical_id(td, "StorageProfilesParam")["Properties"]
+    ak = _by_logical_id(td, "ApiKeysParam")["Properties"]
+    assert sp["Name"] == {"Ref": "StorageProfilesParamName"}
+    assert ak["Name"] == {"Ref": "ApiKeysParamName"}
+    assert sp["Type"] == "String"
+    assert ak["Type"] == "String"
+    assert sp["Value"] == "{}"
+    assert ak["Value"] == "{}"
+
+
+def test_ingest_queue_policy_allows_s3_with_source_conditions(td):
+    pol = _by_logical_id(td, "IngestQueuePolicy")["Properties"]["PolicyDocument"]
+    stmt = pol["Statement"][0]
+    assert stmt["Effect"] == "Allow"
+    assert stmt["Principal"]["Service"] == "s3.amazonaws.com"
+    assert "sqs:SendMessage" in stmt["Action"]
+    assert "aws:SourceAccount" in stmt["Condition"]["StringEquals"]
+    assert "aws:SourceArn" in stmt["Condition"]["ArnLike"]
+
+
+def test_ingest_bucket_depends_on_queue_policy(td):
+    """Without DependsOn, S3 create can race the queue-policy create and fail
+    bucket-notification validation."""
+    bucket = _by_logical_id(td, "IngestBucket")
+    assert bucket["DependsOn"] == "IngestQueuePolicy"
+
+
+def test_ingest_bucket_lifecycle_uses_parameter(td):
+    rules = _by_logical_id(td, "IngestBucket")["Properties"]["LifecycleConfiguration"]["Rules"]
+    rule = rules[0]
+    assert rule["Status"] == "Enabled"
+    assert rule["ExpirationInDays"] == {"Ref": "IngestBucketLifecycleDays"}
+    assert rule["AbortIncompleteMultipartUpload"]["DaysAfterInitiation"] == 1
+
+
+def test_ingest_bucket_notification_targets_queue(td):
+    notif = _by_logical_id(td, "IngestBucket")["Properties"][
+        "NotificationConfiguration"
+    ]
+    queue_cfg = notif["QueueConfigurations"][0]
+    assert queue_cfg["Event"] == "s3:ObjectCreated:*"
+    assert queue_cfg["Queue"] == {"Fn::GetAtt": ["IngestQueue", "Arn"]}
+
+
+def test_ingest_bucket_name_uses_default_or_override(td):
+    name = _by_logical_id(td, "IngestBucket")["Properties"]["BucketName"]
+    if_value = name["Fn::If"]
+    assert if_value[0] == "UseDefaultBucketName"
+    # default branch produces cardinal-ingest-<acct>-<region>
+    default_sub = if_value[1]["Fn::Sub"]
+    assert "cardinal-ingest-" in default_sub
+    assert "AWS::AccountId" in default_sub
+    assert "AWS::Region" in default_sub
+    assert if_value[2] == {"Ref": "IngestBucketName"}
+
+
+# ---------------------------------------------------------------------------
+# Deletion / replace policies
+# ---------------------------------------------------------------------------
+
+
+_RETAIN_TYPES = {
+    "AWS::SecretsManager::Secret",
+    "AWS::S3::Bucket",
+    "AWS::SQS::Queue",
+    "AWS::RDS::DBSubnetGroup",
+    "AWS::SSM::Parameter",
+}
+
+
+def test_data_resources_are_retained(td):
+    """No data-bearing resource is allowed to vanish on stack delete."""
+    for logical_id, res in td["Resources"].items():
+        if res["Type"] in _RETAIN_TYPES:
+            assert res.get("DeletionPolicy") == "Retain", (
+                f"{logical_id} ({res['Type']}) must have DeletionPolicy: Retain"
+            )
+            assert res.get("UpdateReplacePolicy") == "Retain", (
+                f"{logical_id} ({res['Type']}) must have UpdateReplacePolicy: Retain"
+            )
+
+
+def test_rds_uses_snapshot(td):
+    rds = _by_logical_id(td, "DBInstance")
+    assert rds["DeletionPolicy"] == "Snapshot"
+    assert rds["UpdateReplacePolicy"] == "Snapshot"
+
+
+# ---------------------------------------------------------------------------
+# Outputs (must match data-setup.sh JSON keys 1:1)
+# ---------------------------------------------------------------------------
+
+
+_EXPECTED_OUTPUT_KEYS = {
+    "DbEndpoint",
+    "DbPort",
+    "DbName",
+    "DbMasterSecretArn",
+    "MaestroDbSecretArn",
+    "IngestBucketName",
+    "IngestQueueUrl",
+    "IngestQueueArn",
+    "LicenseSecretArn",
+    "InternalKeysSecretArn",
+    "AdminKeySecretArn",
+    "StorageProfilesParamName",
+    "ApiKeysParamName",
+}
+
+
+def test_outputs_match_script_contract(td):
+    assert set(td["Outputs"].keys()) == _EXPECTED_OUTPUT_KEYS
+
+
+def test_outputs_have_no_export(td):
+    for name, out in td["Outputs"].items():
+        assert "Export" not in out, f"output {name} should not have an Export"

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -324,3 +324,64 @@ def test_outputs_match_script_contract(td):
 def test_outputs_have_no_export(td):
     for name, out in td["Outputs"].items():
         assert "Export" not in out, f"output {name} should not have an Export"
+
+
+# ---------------------------------------------------------------------------
+# Optional name parameters (used at import time)
+# ---------------------------------------------------------------------------
+
+
+_IMPORT_NAME_PARAMS = (
+    "DBInstanceIdentifier",
+    "DBSubnetGroupName",
+    "IngestQueueName",
+    "DBMasterSecretName",
+    "InternalKeysSecretName",
+    "MaestroDBSecretName",
+)
+
+
+def test_import_name_parameters_exist_with_blank_defaults(td):
+    for n in _IMPORT_NAME_PARAMS:
+        assert n in td["Parameters"], f"missing import-name parameter: {n}"
+        assert td["Parameters"][n]["Default"] == "", (
+            f"{n} default must be blank so fresh installs auto-name"
+        )
+
+
+_AUTO_NAME_CONDITIONS = {
+    "AutoNameDBInstance",
+    "AutoNameDBSubnetGroup",
+    "AutoNameIngestQueue",
+    "AutoNameDBMasterSecret",
+    "AutoNameInternalKeysSecret",
+    "AutoNameMaestroDBSecret",
+}
+
+
+def test_auto_name_conditions_present(td):
+    assert _AUTO_NAME_CONDITIONS <= set(td["Conditions"].keys())
+
+
+def _name_property(td, logical_id, prop):
+    return td["Resources"][logical_id]["Properties"][prop]
+
+
+def test_auto_name_use_site_pattern(td):
+    """Each import-eligible resource uses Fn::If(AutoNameX, NoValue, Ref(X))."""
+    cases = [
+        ("DBInstance", "DBInstanceIdentifier", "AutoNameDBInstance"),
+        ("DBSubnetGroup", "DBSubnetGroupName", "AutoNameDBSubnetGroup"),
+        ("IngestQueue", "QueueName", "AutoNameIngestQueue"),
+        ("DBMasterSecret", "Name", "AutoNameDBMasterSecret"),
+        ("InternalKeysSecret", "Name", "AutoNameInternalKeysSecret"),
+        ("MaestroDBSecret", "Name", "AutoNameMaestroDBSecret"),
+    ]
+    for logical_id, prop, condition in cases:
+        value = _name_property(td, logical_id, prop)
+        if_branches = value["Fn::If"]
+        assert if_branches[0] == condition
+        assert if_branches[1] == {"Ref": "AWS::NoValue"}
+        # third branch is Ref to the corresponding parameter
+        ref_param = if_branches[2]["Ref"]
+        assert ref_param in _IMPORT_NAME_PARAMS, ref_param


### PR DESCRIPTION
## Summary

- New \`cardinal-infrastructure.yaml\` template (peer to \`cardinal-vpc.yaml\`) that creates the resources \`cardinal-lakerunner\` consumes as inputs but does not manage itself: RDS + DB subnet group + master secret, S3 ingest bucket + lifecycle + S3->SQS notification, SQS ingest queue + policy, license / internal-keys / admin-key / maestro-db secrets, and the two \`/cardinal/*\` SSM parameters.
- Generator at \`src/cardinal_cfn/cardinal_infrastructure.py\`, wired into \`build.sh\` and the \`make lint\` target.
- Per-template tests at \`tests/templates/test_cardinal_infrastructure.py\` (37 assertions).

Conceptually a CloudFormation port of \`scripts/data-setup.sh\`. The opinionated config (Postgres 18.3, db.t3.medium, gp3, encrypted, 7-day backup, deletion-protection; ingest bucket 7-day expiration + 1-day multipart abort; secret JSON shapes for db-master, admin-key, maestro-db) mirrors the script 1:1. Stack outputs use the exact JSON keys the script emits today.

## Two supported deploy paths

**Fresh install:** \`create-stack\` with the network + license parameters set, all \`*Name\` parameters left blank. CFN auto-names everything except the few resources that need predictable names (S3 bucket, two SSM parameters, license + admin-key secrets).

**Adopting a data-setup.sh-created install:** the template has optional \`*Name\` parameters for every CFN-auto-named resource and an \`ImportMode\` parameter that conditions out the two CFN-only resources (\`DBMasterSecretAttachment\`, \`IngestQueuePolicy\`) which can't participate in an import change set. Procedure:

1. \`create-change-set --change-set-type IMPORT\` with \`ImportMode=Yes\` and the matching \`*Name\` overrides.
2. After import succeeds, \`update-stack\` with \`ImportMode=No\` to add the two skipped resources via their underlying API calls. Both are no-ops when the live config already matches.

## Recovery from rollback

Every resource has \`DeletionPolicy: Retain\` (RDS uses \`Snapshot\`). Resources with explicit physical names — S3 bucket, two SSM params, license + admin-key secrets — would collide on retry after a partially-completed first create. Those names are stack parameters with sensible defaults, so a recovery deploy can pass alternates without hand-editing.

## Out of scope (follow-ups)

- \`scripts/data-setup.sh\` is unchanged. Retiring it requires updating \`scripts/deploy-lakerunner.sh\` to source infra parameters from stack outputs.
- Operations doc updates (\`docs/operations/install-infrastructure.md\`) to reflect the stack as the primary path.
- Tag drift on imported resources is a known CFN limitation: imported resources keep their existing tags until a property-level change forces CFN to push the template's desired-state tags. After import, drift detection will show all 11 imported resources as \`MODIFIED\` on Tag values (the live state still has \`ManagedBy=cardinal-data-setup-script\` from the script). Functionally harmless; resolves on the next real property change to each resource.

## Test plan

- [x] \`make check\` (326 passed, 3 skipped)
- [x] \`make build\` and \`cfn-lint\` clean on the new template
- [x] **Fresh-install validation:** live deploy as \`cardinal-infrastructure-test\` in account 493746473138 / us-east-1, against the existing \`cardinal-vpc\` subnets, with non-conflicting name overrides. Reached \`CREATE_COMPLETE\` in ~6 min (RDS dominated). All 13 outputs populated, secret shapes match the script (admin-key = \`{key:<64>}\`, maestro = \`{username:"maestro",password:<40>}\`, internal-keys = 64-char string, db-master = full connection JSON via \`SecretTargetAttachment\`), RDS config matches (postgres 18.3 / db.t3.medium / 100 GB / encrypted / gp3 / single-AZ / not public / deletion-protection / 7-day backup), bucket lifecycle and S3->SQS notification correct, SSM params \`{}\`.
- [x] **Tear-down validation:** test stack deleted with deletion-protection disabled on the RDS first; \`Retain\`/\`Snapshot\` policies kept the orphans, then orphans force-cleaned. Snapshot deleted last. End state: clean.
- [x] **Import validation:** \`create-change-set --change-set-type IMPORT\` against the existing data-setup.sh-created resources (\`cardinal-db\`, \`cardinal-ingest\` bucket + queue, all 5 \`cardinal-*\` secrets, the two \`/cardinal/*\` SSM params, \`cardinal-db-subnet-group\`). Change set described 11 imports, executed cleanly to \`IMPORT_COMPLETE\`. Follow-up \`update-stack\` with \`ImportMode=No\` added \`DBMasterSecretAttachment\` and \`IngestQueuePolicy\` cleanly. All 13 outputs now point at the original physical resources. Tag drift noted above is the only outstanding diff.

## Caveat: import-time template tweak

CFN's import change set has two restrictions the template hits:

1. \`Outputs\` section must be omitted (CFN refuses "modify or add Outputs" during import).
2. \`DependsOn\` cannot reference a resource with a \`Condition\`, even if the dependency would be a no-op — CFN parses this at template-validation time before evaluating conditions.

The procedure works around both by stripping the \`Outputs:\` section and the single \`DependsOn: IngestQueuePolicy\` line from the generated YAML for the import call only. The follow-up \`update-stack\` uses the unmodified template. A future iteration could codify this in a helper script under \`scripts/\`.