### PR TITLE
gitignore: ignore local do-not-commit.sh scratch script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ __pycache__/
 
 # Generated CloudFormation templates
 generated-templates/
+
+# Local scratch / not-for-commit scripts
+do-not-commit.sh


### PR DESCRIPTION
Keeps the local `do-not-commit.sh` scratch script out of `git status` so it can't be staged by accident.