### PR TITLE
defaults: bump lakerunner -> v1.20.5, maestro -> v1.26.5

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.19.2"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.8.6"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.20.5"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.26.5"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
Bumps the default container images to the latest `v*` image tags:

| Image | Was | Now |
|---|---|---|
| `public.ecr.aws/cardinalhq.io/lakerunner` | `v1.19.2` | `v1.20.5` |
| `public.ecr.aws/cardinalhq.io/maestro` | `v1.8.6` | `v1.26.5` |

OTEL collector left unchanged. The bare `N.N.N` tags in those repos are helm-chart versions, not images, and are ignored. `v1.20.5` / `v1.26.5` are the highest non-rc `v*` tags (maestro's `latest` points at `v1.26.5`).

`make build` (cfn-lint clean) and `make test` (323 passed, 3 skipped) green. The new defaults propagate to `LakerunnerImage` (root + migration + services-{query,process,control}) and `MaestroImage` (root + maestro).