### PR TITLE
services-process: create process-* at min_replicas, not the autoscaler max

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,10 @@ Pre-allocated, registered in `src/cardinal_cfn/listener_priorities.py`. Each ser
 
 The three service tier stacks (`services-query`, `services-process`, `services-control`) own *only* per-service resources: ECS Service, TaskDefinition, TargetGroup, ListenerRule, per-service log group. Anything shared across services lives in `alb` or arrives as an infra-setup parameter (cluster, task SG, task/execution roles, secret ARNs, SSM param names). This rule keeps the door open to a future per-service-stack split with minimal disruption.
 
+### Process-tier autoscaling
+
+`services-process` creates `process-{logs,metrics,traces}` at one replica (`min_replicas` from `cardinal-defaults.yaml`). The `monitoring` service in `services-control` scales them up to the `ProcessLogsReplicas` / `ProcessMetricsReplicas` / `ProcessTracesReplicas` cap (default 10 each) via `ecs:UpdateService`. Those parameters are the autoscaler *ceiling*, not the initial `DesiredCount` — creating the services at the ceiling would launch ~3x the steady-state task count on every deploy and can exhaust the account's Fargate vCPU quota. `pubsub-sqs` is not autoscaled; `PubsubSqsReplicas` (default 1) is its literal `DesiredCount`. The root forwards the same `Process*Replicas` Refs to both `services-process` (where they are now unused — kept symmetric with the customer-facing surface) and `services-control` (the autoscaler max).
+
 ## Build and testing
 
 Canonical workflow uses the Makefile:

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -157,9 +157,11 @@ def build() -> Template:
     # process-* services. ClusterName is the ECS cluster name (not ARN) — both
     # the autoscaler's ECS_CLUSTER env var and the IAM resource ARNs need the
     # name form. The three service-name inputs come from services-process stack
-    # outputs; the three replica inputs are the same Refs that gate the
-    # process-* DesiredCount in services-process, so the autoscaler's max
-    # tracks whatever the customer set at deploy time.
+    # outputs; the three replica inputs are the per-service max replicas (the
+    # Process*Replicas parameters, also exposed on services-process). The
+    # process-* services are created at one replica there; the autoscaler then
+    # scales them up to this max, so it tracks whatever the customer set at
+    # deploy time.
     t.add_parameter(
         Parameter(
             "ClusterName",

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -7,9 +7,11 @@ Owns four ECS Fargate services that ingest from SQS and write to S3:
 - process-metrics (signal_type: metrics, replicas + memory tunable)
 - process-traces (signal_type: traces, replicas + memory tunable)
 
-None of these services attach to the ALB. Replicas parameters set the maximum
-desired count; the external monitoring service manages actual scaling. CPU
-values come from cardinal-defaults.yaml directly.
+None of these services attach to the ALB. The process-* services are created
+at one replica (min_replicas); the monitoring service in services-control
+scales them up to the Process*Replicas cap via ecs:UpdateService -- launching
+at the max would triple the steady-state Fargate footprint on every deploy.
+CPU values come from cardinal-defaults.yaml directly.
 """
 
 from troposphere import (
@@ -147,6 +149,12 @@ def build() -> Template:
     # Per the project CLAUDE.md table: process-* services expose Replicas and
     # Memory as parameters; CPU stays in YAML. pubsub-sqs exposes Replicas
     # only; CPU and Memory both stay in YAML.
+    #
+    # For process-*, "Replicas" is the autoscaler's *max* cap, not the initial
+    # desired count -- the services are created at min_replicas (see the
+    # per-service blocks below) and the monitoring service scales up to this
+    # value. The same Refs are forwarded to services-control as the
+    # autoscaler's per-service max.
     # ---------------------------------------------------------------------
     t.add_parameter(
         Parameter(
@@ -154,8 +162,10 @@ def build() -> Template:
             Type="Number",
             Default=str(_max_replicas(logs_cfg)),
             Description=(
-                "Maximum desired replicas for lakerunner-process-logs. The "
-                "monitoring service manages actual replica count up to this max."
+                "Maximum replicas the monitoring autoscaler may scale "
+                "lakerunner-process-logs to. The service is created at "
+                "min_replicas and the autoscaler scales it up to this cap "
+                "under load."
             ),
         )
     )
@@ -173,8 +183,10 @@ def build() -> Template:
             Type="Number",
             Default=str(_max_replicas(metrics_cfg)),
             Description=(
-                "Maximum desired replicas for lakerunner-process-metrics. The "
-                "monitoring service manages actual replica count up to this max."
+                "Maximum replicas the monitoring autoscaler may scale "
+                "lakerunner-process-metrics to. The service is created at "
+                "min_replicas and the autoscaler scales it up to this cap "
+                "under load."
             ),
         )
     )
@@ -192,8 +204,10 @@ def build() -> Template:
             Type="Number",
             Default=str(_max_replicas(traces_cfg)),
             Description=(
-                "Maximum desired replicas for lakerunner-process-traces. The "
-                "monitoring service manages actual replica count up to this max."
+                "Maximum replicas the monitoring autoscaler may scale "
+                "lakerunner-process-traces to. The service is created at "
+                "min_replicas and the autoscaler scales it up to this cap "
+                "under load."
             ),
         )
     )
@@ -296,7 +310,14 @@ def build() -> Template:
     ]
 
     # ---------------------------------------------------------------------
-    # Per-service blocks (log group, task role, task def, ECS service)
+    # Per-service blocks (log group, task def, ECS service).
+    #
+    # process-* services are created at their min replica count; the monitoring
+    # service (services-control) then scales them up to Process*Replicas via
+    # ecs:UpdateService. Starting at the max would launch ~3x the steady-state
+    # task count on every deploy (and can blow the account's Fargate vCPU
+    # quota). pubsub-sqs has no autoscaler, so its DesiredCount is the
+    # PubsubSqsReplicas parameter directly.
     # ---------------------------------------------------------------------
     services = [
         {
@@ -304,7 +325,7 @@ def build() -> Template:
             "config": logs_cfg,
             "cpu": logs_cfg["cpu"],
             "memory_mib": Ref("ProcessLogsMemory"),
-            "desired_count": Ref("ProcessLogsReplicas"),
+            "desired_count": _min_replicas(logs_cfg),
             "output_name": "ProcessLogsServiceName",
         },
         {
@@ -312,7 +333,7 @@ def build() -> Template:
             "config": metrics_cfg,
             "cpu": metrics_cfg["cpu"],
             "memory_mib": Ref("ProcessMetricsMemory"),
-            "desired_count": Ref("ProcessMetricsReplicas"),
+            "desired_count": _min_replicas(metrics_cfg),
             "output_name": "ProcessMetricsServiceName",
         },
         {
@@ -320,7 +341,7 @@ def build() -> Template:
             "config": traces_cfg,
             "cpu": traces_cfg["cpu"],
             "memory_mib": Ref("ProcessTracesMemory"),
-            "desired_count": Ref("ProcessTracesReplicas"),
+            "desired_count": _min_replicas(traces_cfg),
             "output_name": "ProcessTracesServiceName",
         },
         {
@@ -393,14 +414,28 @@ def _build_service_block(
 
 
 def _max_replicas(service_cfg: dict) -> int:
-    """Default replicas for an autoscaling-eligible service.
+    """Autoscaler max-replica cap for an autoscaling-eligible service.
 
-    process-* configs encode min/max under autoscaling; the parameter default
-    uses max_replicas. Falls back to `replicas` if autoscaling is absent.
+    process-* configs encode min/max under autoscaling; the Process*Replicas
+    parameter default uses max_replicas. Falls back to `replicas` if
+    autoscaling is absent.
     """
     autoscaling = service_cfg.get("autoscaling")
     if autoscaling and "max_replicas" in autoscaling:
         return int(autoscaling["max_replicas"])
+    return int(service_cfg["replicas"])
+
+
+def _min_replicas(service_cfg: dict) -> int:
+    """Initial ECS DesiredCount for an autoscaling-eligible service.
+
+    The service is created at this count; the monitoring service (in
+    services-control) scales it up to the Process*Replicas cap under load.
+    Falls back to `replicas` if autoscaling is absent.
+    """
+    autoscaling = service_cfg.get("autoscaling")
+    if autoscaling and "min_replicas" in autoscaling:
+        return int(autoscaling["min_replicas"])
     return int(service_cfg["replicas"])
 
 

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -188,23 +188,39 @@ def test_pubsub_sqs_task_definition_uses_yaml_defaults(td):
     assert not isinstance(mem, dict), f"PubsubSqs Memory unexpectedly templated: {mem!r}"
 
 
-def test_desired_count_uses_replicas_param(td):
+def test_process_services_start_at_one_replica(td):
+    """process-* are created at min_replicas (1); the monitoring autoscaler in
+    services-control scales them up to the Process*Replicas cap. Launching at
+    the max would triple the steady-state Fargate footprint on every deploy."""
     services = {
         logical_id: r
         for logical_id, r in td["Resources"].items()
         if r["Type"] == "AWS::ECS::Service"
     }
-    expected_refs = {
-        "ProcessLogsService": "ProcessLogsReplicas",
-        "ProcessMetricsService": "ProcessMetricsReplicas",
-        "ProcessTracesService": "ProcessTracesReplicas",
-        "PubsubSqsService": "PubsubSqsReplicas",
+    for logical_id in ("ProcessLogsService", "ProcessMetricsService", "ProcessTracesService"):
+        dc = services[logical_id]["Properties"]["DesiredCount"]
+        assert dc == 1, f"{logical_id} should be created at 1 replica; got {dc!r}"
+
+
+def test_pubsub_sqs_desired_count_uses_replicas_param(td):
+    """pubsub-sqs has no autoscaler, so its DesiredCount is the parameter."""
+    services = {
+        logical_id: r
+        for logical_id, r in td["Resources"].items()
+        if r["Type"] == "AWS::ECS::Service"
     }
-    for logical_id, expected_ref in expected_refs.items():
-        svc = services[logical_id]
-        dc = svc["Properties"]["DesiredCount"]
-        assert isinstance(dc, dict) and dc.get("Ref") == expected_ref, (
-            f"{logical_id} DesiredCount should be Ref({expected_ref}); got {dc!r}"
+    dc = services["PubsubSqsService"]["Properties"]["DesiredCount"]
+    assert isinstance(dc, dict) and dc.get("Ref") == "PubsubSqsReplicas", (
+        f"PubsubSqsService DesiredCount should be Ref(PubsubSqsReplicas); got {dc!r}"
+    )
+
+
+def test_process_replicas_params_default_to_autoscaler_max(td):
+    """Process*Replicas defaults are the autoscaler ceiling (max_replicas from
+    cardinal-defaults.yaml), not the initial desired count."""
+    for n in ("ProcessLogsReplicas", "ProcessMetricsReplicas", "ProcessTracesReplicas"):
+        assert td["Parameters"][n]["Default"] == "10", (
+            f"{n} default should be the autoscaling max; got {td['Parameters'][n]['Default']!r}"
         )
 
 


### PR DESCRIPTION
## Summary

The `process-{logs,metrics,traces}` ECS services were created with `DesiredCount = Ref(Process*Replicas)`. Those parameters are the autoscaler *ceiling* (default 10 each), not the steady-state count — so every deploy launched ~3x the steady-state task count, which can blow the account's Fargate vCPU quota before the `monitoring` service scales them back down.

This changes the three services to start at `min_replicas` (1). The `monitoring` service in `services-control` still scales them up to `Process*Replicas` via `ecs:UpdateService` under load. `pubsub-sqs` is unchanged — it has no autoscaler, so its `DesiredCount` stays `Ref(PubsubSqsReplicas)`.

## Changes

- `services_process.py`: new `_min_replicas()` helper; `process-*` `DesiredCount` now uses it; refreshed parameter descriptions and module/inline comments.
- `services_control.py`: comment refresh — the replica inputs are the autoscaler max, and the services start at one replica.
- `CLAUDE.md`: new "Process-tier autoscaling" section documenting the behaviour.
- `tests/templates/test_services_process.py`: assert `process-*` start at 1 replica, `pubsub-sqs` `DesiredCount` is the param, and `Process*Replicas` defaults are the autoscaler max.

## Testing

- `make check` — 325 passed, 3 skipped.