### PR TITLE
internal-keys: drop dead cardinal-internal-keys plumbing (moved to lrdb upstream)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ Two customer-facing CloudFormation root templates:
 
 Plus a single shell driver:
 
-- `scripts/data-setup.sh` — raw-AWS-CLI data provisioner. Creates RDS, S3 ingest, SQS, the five `cardinal-*` Secrets Manager secrets, and the two SSM parameters. Idempotent; emits a JSON document on stdout whose keys map 1:1 to the lakerunner stack's infra-setup parameters. The customer supplies all IAM roles, security groups, the ECS cluster, and the Cloud Map private DNS namespace out-of-band; they are inputs to the script, which forwards their identifiers into the JSON output.
+- `scripts/data-setup.sh` — raw-AWS-CLI data provisioner. Creates RDS, S3 ingest, SQS, the four `cardinal-*` Secrets Manager secrets (`-db-master`, `-license`, `-admin-key`, `-maestro-db`), and the two SSM parameters. Idempotent; emits a JSON document on stdout whose keys map 1:1 to the lakerunner stack's infra-setup parameters. The customer supplies all IAM roles, security groups, the ECS cluster, and the Cloud Map private DNS namespace out-of-band; they are inputs to the script, which forwards their identifiers into the JSON output.
 
 The lakerunner root nests these children — application-tier resources only:
 

--- a/docs/operations/infrastructure-stack-parameters.md
+++ b/docs/operations/infrastructure-stack-parameters.md
@@ -9,7 +9,7 @@ https://cardinal-cfn.s3.<region>.amazonaws.com/lakerunner/<version>/cardinal-inf
 
 The stack creates the data-plane resources consumed by the
 `cardinal-lakerunner` application stack: RDS, S3 ingest bucket, SQS ingest
-queue, the five `cardinal-*` secrets, and the two `/cardinal/*` SSM
+queue, the four `cardinal-*` secrets, and the two `/cardinal/*` SSM
 parameters.
 
 There are only two supported scenarios:
@@ -74,7 +74,6 @@ DBInstanceIdentifier
 DBSubnetGroupName
 IngestQueueName
 DBMasterSecretName
-InternalKeysSecretName
 MaestroDBSecretName
 ```
 
@@ -165,10 +164,6 @@ Create this file as `infrastructure-import-parameters.json`:
     "ParameterValue": "cardinal-db-master"
   },
   {
-    "ParameterKey": "InternalKeysSecretName",
-    "ParameterValue": "cardinal-internal-keys"
-  },
-  {
     "ParameterKey": "MaestroDBSecretName",
     "ParameterValue": "cardinal-maestro-db"
   },
@@ -250,13 +245,6 @@ Create this file as `infrastructure-resources-to-import.json`:
   },
   {
     "ResourceType": "AWS::SecretsManager::Secret",
-    "LogicalResourceId": "InternalKeysSecret",
-    "ResourceIdentifier": {
-      "Id": "arn:aws:secretsmanager:<region>:<account-id>:secret:cardinal-internal-keys-<suffix>"
-    }
-  },
-  {
-    "ResourceType": "AWS::SecretsManager::Secret",
     "LogicalResourceId": "AdminKeySecret",
     "ResourceIdentifier": {
       "Id": "arn:aws:secretsmanager:<region>:<account-id>:secret:cardinal-admin-key-<suffix>"
@@ -314,7 +302,6 @@ Repeat that command for:
 
 ```text
 cardinal-license
-cardinal-internal-keys
 cardinal-admin-key
 cardinal-maestro-db
 ```
@@ -407,10 +394,6 @@ as `infrastructure-import-parameters.json`, except `ImportMode` is `No`:
   {
     "ParameterKey": "DBMasterSecretName",
     "ParameterValue": "cardinal-db-master"
-  },
-  {
-    "ParameterKey": "InternalKeysSecretName",
-    "ParameterValue": "cardinal-internal-keys"
   },
   {
     "ParameterKey": "MaestroDBSecretName",

--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -104,7 +104,7 @@ Resources created with fixed names:
 - SQS queue: `cardinal-ingest`
 - S3 bucket: `cardinal-ingest-<account>-<region>`
 - Secrets: `cardinal-db-master`, `cardinal-license`,
-  `cardinal-internal-keys`, `cardinal-admin-key`, `cardinal-maestro-db`
+  `cardinal-admin-key`, `cardinal-maestro-db`
 - SSM params: `/cardinal/storage-profiles`, `/cardinal/api-keys`
 
 These fixed names imply one Cardinal install per AWS account/region.
@@ -116,10 +116,9 @@ The script prints a JSON document to stdout. Its keys map 1:1 to the
 
 `DbEndpoint`, `DbPort`, `DbName`, `DbMasterSecretArn`,
 `MaestroDbSecretArn`, `IngestBucketName`, `IngestQueueUrl`,
-`IngestQueueArn`, `LicenseSecretArn`, `InternalKeysSecretArn`,
-`AdminKeySecretArn`, `StorageProfilesParamName`, `ApiKeysParamName`,
-`ClusterName`, `ClusterArn`, `ServiceNamespaceId`,
-`ServiceNamespaceName`.
+`IngestQueueArn`, `LicenseSecretArn`, `AdminKeySecretArn`,
+`StorageProfilesParamName`, `ApiKeysParamName`, `ClusterName`,
+`ClusterArn`, `ServiceNamespaceId`, `ServiceNamespaceName`.
 
 The next install step consumes these as direct inputs.
 

--- a/docs/operations/install-lakerunner.md
+++ b/docs/operations/install-lakerunner.md
@@ -59,8 +59,8 @@ infra = json.loads(pathlib.Path("/tmp/infra-outputs.json").read_text())
 infra_keys = [
     "DbEndpoint", "DbPort", "DbName", "DbMasterSecretArn",
     "MaestroDbSecretArn", "IngestBucketName", "IngestQueueUrl",
-    "IngestQueueArn", "LicenseSecretArn", "InternalKeysSecretArn",
-    "AdminKeySecretArn", "StorageProfilesParamName", "ApiKeysParamName",
+    "IngestQueueArn", "LicenseSecretArn", "AdminKeySecretArn",
+    "StorageProfilesParamName", "ApiKeysParamName",
     "ClusterName", "ClusterArn",
     "ServiceNamespaceId", "ServiceNamespaceName",
 ]

--- a/docs/operations/tearing-down.md
+++ b/docs/operations/tearing-down.md
@@ -82,8 +82,8 @@ is fixed and named deterministically:
 | Secret: db master | `cardinal-db-master-*` (Secrets Manager auto-suffixed) |
 | Secret: maestro db | `cardinal-maestro-db-*` |
 | Secret: license | `cardinal-license-*` |
-| Secret: internal keys | `cardinal-internal-keys-*` |
 | Secret: admin key | `cardinal-admin-key-*` |
+| Secret: internal keys (legacy installs only) | `cardinal-internal-keys-*` |
 | SSM parameter | `/cardinal/storage-profiles` |
 | SSM parameter | `/cardinal/api-keys` |
 | SQS queue | `cardinal-ingest` |

--- a/scripts/data-setup.sh
+++ b/scripts/data-setup.sh
@@ -63,7 +63,6 @@ SQS_QUEUE_NAME="cardinal-ingest"
 
 SECRET_DB_MASTER="cardinal-db-master"
 SECRET_LICENSE="cardinal-license"
-SECRET_INTERNAL_KEYS="cardinal-internal-keys"
 SECRET_ADMIN_KEY="cardinal-admin-key"
 SECRET_MAESTRO_DB="cardinal-maestro-db"
 
@@ -332,7 +331,7 @@ update_db_master_secret() {
 }
 
 # ============================================================================
-#  SECRETS  --  license, internal-keys, admin-key, maestro-db
+#  SECRETS  --  license, admin-key, maestro-db
 #                Each is create-only: never overwrite on re-run.
 # ============================================================================
 
@@ -407,10 +406,6 @@ main() {
         "$license_data" \
         "Cardinal lakerunner license" \
         license)
-    internal_keys_arn=$(ensure_secret_with_value "$SECRET_INTERNAL_KEYS" \
-        "$(gen_hex32)" \
-        "Internal service keys (random 32-byte hex)" \
-        internal-keys)
     # admin-key is JSON {"key": "..."} so the ECS secret pointer ":key::"
     # resolves at task launch.
     admin_key_arn=$(ensure_secret_with_value "$SECRET_ADMIN_KEY" \
@@ -443,7 +438,6 @@ main() {
         --arg IngestQueueUrl "$queue_url" \
         --arg IngestQueueArn "$QUEUE_ARN" \
         --arg LicenseSecretArn "$license_arn" \
-        --arg InternalKeysSecretArn "$internal_keys_arn" \
         --arg AdminKeySecretArn "$admin_key_arn" \
         --arg StorageProfilesParamName "$SSM_STORAGE_PROFILES" \
         --arg ApiKeysParamName "$SSM_API_KEYS" \
@@ -458,7 +452,6 @@ main() {
             IngestBucketName:$IngestBucketName,
             IngestQueueUrl:$IngestQueueUrl, IngestQueueArn:$IngestQueueArn,
             LicenseSecretArn:$LicenseSecretArn,
-            InternalKeysSecretArn:$InternalKeysSecretArn,
             AdminKeySecretArn:$AdminKeySecretArn,
             StorageProfilesParamName:$StorageProfilesParamName,
             ApiKeysParamName:$ApiKeysParamName,

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -6,7 +6,7 @@ Customer-deployable peer to ``cardinal-vpc``. Creates the resources that
 - RDS PostgreSQL instance + DB subnet group + master secret
 - S3 ingest bucket + lifecycle policy + S3 -> SQS notification
 - SQS ingest queue + queue policy
-- License / internal-keys / admin-key / maestro-db secrets
+- License / admin-key / maestro-db secrets
 - /cardinal/storage-profiles and /cardinal/api-keys SSM parameters
 
 Conceptually a CloudFormation port of ``scripts/data-setup.sh``; the
@@ -53,8 +53,8 @@ collide on retry. To recover:
    ``delete-secret --force-delete-without-recovery``), then redeploy.
 
 Resources without explicit names (RDS, SQS, DB subnet group, the
-db-master / internal-keys / maestro-db secrets) are CFN-named and
-collide-free on retry.
+db-master / maestro-db secrets) are CFN-named and collide-free on
+retry.
 """
 
 from troposphere import (
@@ -311,18 +311,6 @@ def build() -> Template:
             ),
         )
     )
-    internal_keys_secret_name = t.add_parameter(
-        Parameter(
-            "InternalKeysSecretName",
-            Type="String",
-            Default="",
-            Description=(
-                "Optional explicit name for the internal-keys secret. "
-                "Set to the existing name (e.g. 'cardinal-internal-keys') "
-                "when importing; blank otherwise."
-            ),
-        )
-    )
     maestro_db_secret_name = t.add_parameter(
         Parameter(
             "MaestroDBSecretName",
@@ -394,7 +382,6 @@ def build() -> Template:
                     "DBSubnetGroupName",
                     "IngestQueueName",
                     "DBMasterSecretName",
-                    "InternalKeysSecretName",
                     "MaestroDBSecretName",
                 ],
             },
@@ -432,10 +419,6 @@ def build() -> Template:
     t.add_condition("AutoNameIngestQueue", Equals(Ref(ingest_queue_name), ""))
     t.add_condition(
         "AutoNameDBMasterSecret", Equals(Ref(db_master_secret_name), "")
-    )
-    t.add_condition(
-        "AutoNameInternalKeysSecret",
-        Equals(Ref(internal_keys_secret_name), ""),
     )
     t.add_condition(
         "AutoNameMaestroDBSecret", Equals(Ref(maestro_db_secret_name), "")
@@ -647,7 +630,7 @@ def build() -> Template:
     )
 
     # -----------------------------------------------------------------------
-    # Application secrets (license, internal-keys, admin-key, maestro-db)
+    # Application secrets (license, admin-key, maestro-db)
     # -----------------------------------------------------------------------
 
     license_secret = t.add_resource(
@@ -658,28 +641,6 @@ def build() -> Template:
                 Description="Cardinal lakerunner license token (z64:...).",
                 SecretString=Ref(license_data),
                 Tags=_tags(component="license"),
-            )
-        )
-    )
-
-    internal_keys_secret = t.add_resource(
-        _retain(
-            Secret(
-                "InternalKeysSecret",
-                Name=If(
-                    "AutoNameInternalKeysSecret",
-                    Ref(AWS_NO_VALUE),
-                    Ref(internal_keys_secret_name),
-                ),
-                Description=(
-                    "Internal service keys: opaque high-entropy string "
-                    "shared between lakerunner services."
-                ),
-                GenerateSecretString=GenerateSecretString(
-                    PasswordLength=64,
-                    ExcludePunctuation=True,
-                ),
-                Tags=_tags(component="internal-keys"),
             )
         )
     )
@@ -808,8 +769,6 @@ def build() -> Template:
                  GetAtt(ingest_queue, "Arn"))
     _emit_output("LicenseSecretArn", "ARN of the license secret.",
                  Ref(license_secret))
-    _emit_output("InternalKeysSecretArn", "ARN of the internal service keys secret.",
-                 Ref(internal_keys_secret))
     _emit_output("AdminKeySecretArn", "ARN of the first-boot admin key secret.",
                  Ref(admin_key_secret))
     _emit_output("StorageProfilesParamName", "Name of the storage-profiles SSM parameter.",

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -151,13 +151,6 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "InternalServiceKeysSecretArn",
-            Type="String",
-            Description="ARN of the internal service keys (HMAC) Secrets Manager secret.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
             "ApiKeysParamName",
             Type="String",
             Description="Name of the SSM parameter holding the api_keys YAML.",
@@ -293,7 +286,6 @@ def build() -> Template:
                     "DbPort",
                     "DbSecretArn",
                     "LicenseSecretArn",
-                    "InternalServiceKeysSecretArn",
                     "ApiKeysParamName",
                     "StorageProfilesParamName",
                     "MaestroDbSecretArn",
@@ -492,7 +484,6 @@ def build() -> Template:
         ],
         Secrets=list(db_secrets) + [
             Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
-            Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         ],
         DependsOn=[
             {"ContainerName": "db-init", "Condition": "SUCCESS"},

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -121,13 +121,6 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "InternalServiceKeysSecretArn",
-            Type="String",
-            Description="ARN of the internal service keys (HMAC) Secrets Manager secret.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
             "ApiKeysParamName",
             Type="String",
             Description="Name of the SSM parameter holding the api_keys YAML.",
@@ -241,7 +234,6 @@ def build() -> Template:
                     "BucketName",
                     "QueueArn",
                     "LicenseSecretArn",
-                    "InternalServiceKeysSecretArn",
                     "ApiKeysParamName",
                     "StorageProfilesParamName",
                     "HttpsListenerArn",
@@ -302,7 +294,6 @@ def build() -> Template:
     ] + _service_specific_env(otel_cfg)
 
     secrets = [
-        Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -133,13 +133,6 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "InternalServiceKeysSecretArn",
-            Type="String",
-            Description="ARN of the internal service keys (HMAC) Secrets Manager secret.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
             "ApiKeysParamName",
             Type="String",
             Description="Name of the SSM parameter holding the api_keys YAML.",
@@ -262,7 +255,6 @@ def build() -> Template:
                     "QueueUrl",
                     "QueueArn",
                     "LicenseSecretArn",
-                    "InternalServiceKeysSecretArn",
                     "ApiKeysParamName",
                     "StorageProfilesParamName",
                     "MigrationComplete",
@@ -305,7 +297,6 @@ def build() -> Template:
         Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
-        Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -98,13 +98,6 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "InternalServiceKeysSecretArn",
-            Type="String",
-            Description="ARN of the internal service keys (HMAC) Secrets Manager secret.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
             "ApiKeysParamName",
             Type="String",
             Description="Name of the SSM parameter holding the api_keys YAML.",
@@ -251,7 +244,6 @@ def build() -> Template:
                     "QueueUrl",
                     "QueueArn",
                     "LicenseSecretArn",
-                    "InternalServiceKeysSecretArn",
                     "ApiKeysParamName",
                     "StorageProfilesParamName",
                     "MigrationComplete",
@@ -305,7 +297,6 @@ def build() -> Template:
         Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
-        Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -109,13 +109,6 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "InternalServiceKeysSecretArn",
-            Type="String",
-            Description="ARN of the internal service keys (HMAC) Secrets Manager secret.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
             "ApiKeysParamName",
             Type="String",
             Description="Name of the SSM parameter holding the api_keys YAML.",
@@ -232,7 +225,6 @@ def build() -> Template:
                     "QueueUrl",
                     "QueueArn",
                     "LicenseSecretArn",
-                    "InternalServiceKeysSecretArn",
                     "ApiKeysParamName",
                     "StorageProfilesParamName",
                     "MigrationComplete",
@@ -280,7 +272,6 @@ def build() -> Template:
         Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
         Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
         Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
-        Secret(Name="LRDB_INTERNAL_KEYS", ValueFrom=Ref("InternalServiceKeysSecretArn")),
         Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
     ]
 

--- a/src/cardinal_cfn/policies.py
+++ b/src/cardinal_cfn/policies.py
@@ -10,7 +10,6 @@ POLICIES: dict = {
     "rds-instance":                 ("Snapshot", "Snapshot"),
     "s3-ingest-bucket":             ("Retain", "Retain"),
     "db-master-secret":             ("Retain", "Retain"),
-    "internal-service-keys-secret": ("Delete", "Delete"),
     "admin-api-key-secret":         ("Retain", "Retain"),
     "license-secret":               ("Retain", "Retain"),
     "sqs-ingest-queue":             ("Delete", "Delete"),

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -153,9 +153,9 @@ _ROLE_SG_PARAMS = [
 # ---------------------------------------------------------------------------
 # Infra-setup output parameters: identifiers for the resources the
 # scripts/data-setup.sh driver already created. Names match the script's
-# JSON output keys 1:1. Sensitive values (license/admin/internal-keys) come
-# in as Secret ARNs -- the underlying secret values stay in Secrets Manager
-# and are never seen by CloudFormation.
+# JSON output keys 1:1. Sensitive values (license/admin) come in as Secret
+# ARNs -- the underlying secret values stay in Secrets Manager and are
+# never seen by CloudFormation.
 # ---------------------------------------------------------------------------
 _INFRA_SETUP_PARAMS = [
     ("DbEndpoint", "String", None, "RDS endpoint hostname (infra-setup output)."),
@@ -173,8 +173,6 @@ _INFRA_SETUP_PARAMS = [
      "ARN of the SQS ingest queue (infra-setup output)."),
     ("LicenseSecretArn", "String", None,
      "ARN of the cardinal-license secret (infra-setup output)."),
-    ("InternalKeysSecretArn", "String", None,
-     "ARN of the cardinal-internal-keys secret (infra-setup output)."),
     ("AdminKeySecretArn", "String", None,
      "ARN of the cardinal-admin-key secret (infra-setup output)."),
     ("StorageProfilesParamName", "String", None,
@@ -430,7 +428,6 @@ def build() -> Template:
             "QueueUrl": Ref("IngestQueueUrl"),
             "QueueArn": Ref("IngestQueueArn"),
             "LicenseSecretArn": Ref("LicenseSecretArn"),
-            "InternalServiceKeysSecretArn": Ref("InternalKeysSecretArn"),
             "ApiKeysParamName": Ref("ApiKeysParamName"),
             "StorageProfilesParamName": Ref("StorageProfilesParamName"),
             "MigrationComplete": migration_complete,
@@ -500,7 +497,6 @@ def build() -> Template:
         "BucketName": Ref("IngestBucketName"),
         "QueueArn": Ref("IngestQueueArn"),
         "LicenseSecretArn": Ref("LicenseSecretArn"),
-        "InternalServiceKeysSecretArn": Ref("InternalKeysSecretArn"),
         "ApiKeysParamName": Ref("ApiKeysParamName"),
         "StorageProfilesParamName": Ref("StorageProfilesParamName"),
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
@@ -529,7 +525,6 @@ def build() -> Template:
         "DbSecretArn": Ref("DbMasterSecretArn"),
         "MaestroDbSecretArn": Ref("MaestroDbSecretArn"),
         "LicenseSecretArn": Ref("LicenseSecretArn"),
-        "InternalServiceKeysSecretArn": Ref("InternalKeysSecretArn"),
         "ApiKeysParamName": Ref("ApiKeysParamName"),
         "StorageProfilesParamName": Ref("StorageProfilesParamName"),
         "MigrationComplete": migration_complete,

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -97,13 +97,13 @@ def test_creates_secret_target_attachment(td):
     assert types.count("AWS::SecretsManager::SecretTargetAttachment") == 1
 
 
-def test_creates_four_managed_secrets_plus_master(td):
-    """db-master + license + internal-keys + admin-key + maestro-db = 5."""
+def test_creates_three_managed_secrets_plus_master(td):
+    """db-master + license + admin-key + maestro-db = 4."""
     secrets = [
         r for r in td["Resources"].values()
         if r["Type"] == "AWS::SecretsManager::Secret"
     ]
-    assert len(secrets) == 5
+    assert len(secrets) == 4
 
 
 def test_creates_two_ssm_parameters(td):
@@ -189,14 +189,6 @@ def test_admin_key_secret_generates_keyed_json(td):
     assert gen["PasswordLength"] == 64
     assert gen["SecretStringTemplate"] == "{}"
     assert sec["Name"] == {"Ref": "AdminKeySecretName"}
-
-
-def test_internal_keys_secret_is_plain_string(td):
-    sec = _by_logical_id(td, "InternalKeysSecret")["Properties"]
-    gen = sec["GenerateSecretString"]
-    assert "SecretStringTemplate" not in gen
-    assert "GenerateStringKey" not in gen
-    assert gen["PasswordLength"] == 64
 
 
 def test_maestro_db_secret_generates_password_with_username(td):
@@ -380,7 +372,6 @@ _EXPECTED_OUTPUT_KEYS = {
     "IngestQueueUrl",
     "IngestQueueArn",
     "LicenseSecretArn",
-    "InternalKeysSecretArn",
     "AdminKeySecretArn",
     "StorageProfilesParamName",
     "ApiKeysParamName",
@@ -416,7 +407,6 @@ _IMPORT_NAME_PARAMS = (
     "DBSubnetGroupName",
     "IngestQueueName",
     "DBMasterSecretName",
-    "InternalKeysSecretName",
     "MaestroDBSecretName",
 )
 
@@ -434,7 +424,6 @@ _AUTO_NAME_CONDITIONS = {
     "AutoNameDBSubnetGroup",
     "AutoNameIngestQueue",
     "AutoNameDBMasterSecret",
-    "AutoNameInternalKeysSecret",
     "AutoNameMaestroDBSecret",
 }
 
@@ -454,7 +443,6 @@ def test_auto_name_use_site_pattern(td):
         ("DBSubnetGroup", "DBSubnetGroupName", "AutoNameDBSubnetGroup"),
         ("IngestQueue", "QueueName", "AutoNameIngestQueue"),
         ("DBMasterSecret", "Name", "AutoNameDBMasterSecret"),
-        ("InternalKeysSecret", "Name", "AutoNameInternalKeysSecret"),
         ("MaestroDBSecret", "Name", "AutoNameMaestroDBSecret"),
     ]
     for logical_id, prop, condition in cases:

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -34,7 +34,6 @@ def test_required_cross_stack_parameters(td):
         "DbSecretArn",
         "MaestroDbSecretArn",
         "LicenseSecretArn",
-        "InternalServiceKeysSecretArn",
         "ApiKeysParamName",
         "StorageProfilesParamName",
         "MigrationComplete",

--- a/tests/templates/test_otel.py
+++ b/tests/templates/test_otel.py
@@ -29,7 +29,6 @@ def test_required_cross_stack_parameters(td):
         "BucketName",
         "QueueArn",
         "LicenseSecretArn",
-        "InternalServiceKeysSecretArn",
         "ApiKeysParamName",
         "StorageProfilesParamName",
         "HttpsListenerArn",

--- a/tests/templates/test_root.py
+++ b/tests/templates/test_root.py
@@ -33,7 +33,6 @@ def test_required_parameters(td):
         "IngestQueueUrl",
         "IngestQueueArn",
         "LicenseSecretArn",
-        "InternalKeysSecretArn",
         "AdminKeySecretArn",
         "StorageProfilesParamName",
         "ApiKeysParamName",

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -35,7 +35,6 @@ def test_required_cross_stack_parameters(td):
         "QueueUrl",
         "QueueArn",
         "LicenseSecretArn",
-        "InternalServiceKeysSecretArn",
         "ApiKeysParamName",
         "StorageProfilesParamName",
         "MigrationComplete",

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -33,7 +33,6 @@ def test_required_cross_stack_parameters(td):
         "QueueUrl",
         "QueueArn",
         "LicenseSecretArn",
-        "InternalServiceKeysSecretArn",
         "ApiKeysParamName",
         "StorageProfilesParamName",
         "MigrationComplete",

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -36,7 +36,6 @@ def test_required_cross_stack_parameters(td):
         "QueueUrl",
         "QueueArn",
         "LicenseSecretArn",
-        "InternalServiceKeysSecretArn",
         "ApiKeysParamName",
         "StorageProfilesParamName",
         "MigrationComplete",

--- a/tests/unit/test_policies.py
+++ b/tests/unit/test_policies.py
@@ -18,7 +18,6 @@ def test_policies_table_covers_data_resources():
         "rds-instance",
         "s3-ingest-bucket",
         "db-master-secret",
-        "internal-service-keys-secret",
         "admin-api-key-secret",
         "sqs-ingest-queue",
         "alb",
@@ -39,13 +38,6 @@ def test_apply_policy_for_ingest_bucket_retains():
     apply_policy(r, "s3-ingest-bucket")
     assert r.DeletionPolicy == "Retain"
     assert r.UpdateReplacePolicy == "Retain"
-
-
-def test_apply_policy_for_internal_keys_deletes():
-    r = FakeResource()
-    apply_policy(r, "internal-service-keys-secret")
-    assert r.DeletionPolicy == "Delete"
-    assert r.UpdateReplacePolicy == "Delete"
 
 
 def test_apply_policy_unknown_kind_raises():


### PR DESCRIPTION
The shared internal service key that alert-evaluator uses to call query-api as any org (the \`x-chq-internal-key\` header) moved into the lakerunner database in lakerunner v1.16.0 (commit 262001eb, PR #578). lakerunner now reads it from the \`lrdb.internal_service_key\` table:

- \`lakerunner migrate\` creates the table (already runs in our \`migration.yaml\`).
- The **sweeper** auto-seeds a random 32-byte hex row if the table is empty on startup (\`cmd/sweeper/sweeper.go\` -> \`ensureInternalKey\`). The sweeper lives in \`services-control\`.
- \`query-api\` validates presented keys via \`internalkey.NewProvider\` polling the table; \`alert-evaluator\` fetches the active key the same way and hard-fails on boot if none exists (ECS retries until the sweeper has run).
- Nothing reads the \`LRDB_INTERNAL_KEYS\` env var anymore.

This PR removes the now-dead plumbing in this repo.

## Changes

**Generators / script**
- \`scripts/data-setup.sh\`: stop creating the \`cardinal-internal-keys\` secret; drop \`InternalKeysSecretArn\` from the emitted JSON contract.
- \`cardinal_infrastructure.py\`: drop the \`InternalKeysSecret\` resource, the \`InternalKeysSecretName\` import-override parameter, the \`AutoNameInternalKeysSecret\` condition, and the \`InternalKeysSecretArn\` output.
- \`root.py\`: drop the \`InternalKeysSecretArn\` infra-setup parameter and the \`InternalServiceKeysSecretArn\` wiring into all five service children.
- \`services-{query,process,control}\`, \`otel\`, \`maestro\`: drop the per-child \`InternalServiceKeysSecretArn\` parameter and the \`LRDB_INTERNAL_KEYS\` task secret-env mapping.
- \`policies.py\`: drop the vestigial \`"internal-service-keys-secret"\` entry.

**Tests** -- updated parameter / output / condition expectation lists (secret count 5 -> 4); removed \`test_internal_keys_secret_is_plain_string\` and \`test_apply_policy_for_internal_keys_deletes\`.

**Docs** -- \`CLAUDE.md\`, \`install-infrastructure.md\`, \`install-lakerunner.md\`, \`infrastructure-stack-parameters.md\`, and \`tearing-down.md\` (kept \`cardinal-internal-keys\` in the manual-deletion list, marked "legacy installs only").

## Operational notes

\`InternalKeysSecret\` carries \`DeletionPolicy: Retain\`, so an existing \`cardinal-infrastructure\` stack that picks up this change does **not** delete the physical \`cardinal-internal-keys\` secret on its next update -- CFN just stops managing it. Orphaned and harmless; delete by hand whenever. \`data-setup.sh\`-bootstrapped installs are the same -- the script never deleted secrets, so the orphan just sits there.

## Verification

- \`make build\` -- generators run cleanly, cfn-lint passes on all templates.
- \`make test\` -- 323 passed, 3 skipped (shellcheck-related, no shellcheck installed locally).