### PR TITLE
maestro: wire LICENSE_DATA secret onto mcp-gateway container

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -411,7 +411,11 @@ def build() -> Template:
         Environment=db_env + [
             Environment(Name="MCP_PORT", Value=str(mcp_gateway_port)),
         ],
-        Secrets=list(db_secrets),
+        # mcp-gateway loads its license via license-go; LICENSE_DATA env var
+        # is honored (priority > LICENSE_FILE > /app/license/license.json).
+        Secrets=list(db_secrets) + [
+            Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
+        ],
         DependsOn=[{"ContainerName": "db-init", "Condition": "SUCCESS"}],
         LogConfiguration=LogConfiguration(
             LogDriver="awslogs",

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -245,6 +245,21 @@ def test_maestro_container_password_secret_present(td):
     assert "MAESTRO_DB_PASSWORD" in secret_names
 
 
+def test_mcp_gateway_container_has_license_data(td):
+    """mcp-gateway's license-go loader honors LICENSE_DATA env var;
+    without it the container falls through to /app/license/license.json
+    and the task fails at startup."""
+    mcp = _container(td, "mcp-gateway")
+    secret_names = {s["Name"] for s in mcp.get("Secrets", [])}
+    assert "LICENSE_DATA" in secret_names
+
+
+def test_maestro_container_has_license_data(td):
+    maestro_c = _container(td, "maestro")
+    secret_names = {s["Name"] for s in maestro_c.get("Secrets", [])}
+    assert "LICENSE_DATA" in secret_names
+
+
 def test_dex_init_container_env_has_issuer_url(td):
     dex_init_c = _container(td, "dex-init")
     env_names = {e["Name"] for e in dex_init_c.get("Environment", [])}


### PR DESCRIPTION
**Symptom.** Fresh deploy of \`cardinal-lakerunner\` v0.0.57: \`mcp-gateway\` container exits 1 on startup, maestro never reaches Running, MaestroStack rolls back the parent.

\`\`\`
ERROR license load/validation failed
  error="loading license envelope: reading license file \"/app/license/license.json\":
  open /app/license/license.json: no such file or directory"
\`\`\`

**Cause.** \`mcp-gateway\` uses \`cardinalhq/license-go\` v0.2.0, which supports \`LICENSE_DATA\` env var with priority over the file fallback (see \`license-go@v0.2.0/loader.go\`: *"Priority: LICENSE_DATA env var > LICENSE_FILE path > default path."*). We were wiring \`LICENSE_DATA\` onto the \`maestro\` container only — not onto \`mcp-gateway\` — so the gateway fell through to \`/app/license/license.json\`, which doesn't exist in the unified Docker image. The EKS chart satisfies this via a Kubernetes secret volume mount; ECS Fargate cannot mount a Secrets Manager secret as a file, so the env-var path the library already supports is what we need.

**Fix.** Add \`Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn"))\` to the \`mcp-gateway\` container's \`Secrets\` list in \`maestro.py\`. Add regression tests asserting both \`mcp-gateway\` and \`maestro\` carry \`LICENSE_DATA\`.

**Verification**
- \`make build\` — clean, cfn-lint passes.
- \`make test\` — 325 passed, 3 skipped (shellcheck-related).
- Live confirmation: I'll bump the test deploy to v0.0.58 after this merges and post the result.