### PR TITLE
maestro: wire MCP_MIGRATE_RECOVER_FROM_DIRTY onto mcp-gateway

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -253,6 +253,19 @@ def build() -> Template:
             ),
         )
     )
+    t.add_parameter(
+        Parameter(
+            "McpMigrateRecoverFromDirty",
+            Type="String",
+            Default="false",
+            AllowedValues=["true", "false"],
+            Description=(
+                "When true, sets MCP_MIGRATE_RECOVER_FROM_DIRTY=true on the "
+                "mcp-gateway container, allowing it to recover from a "
+                "previously failed (dirty) maestro DB migration on startup."
+            ),
+        )
+    )
     add_no_echo_parameter(
         t,
         "DexAdminPasswordHash",
@@ -294,7 +307,11 @@ def build() -> Template:
             },
             {
                 "label": "Maestro tunables",
-                "parameters": ["MaestroTaskCpu", "MaestroTaskMemory"],
+                "parameters": [
+                    "MaestroTaskCpu",
+                    "MaestroTaskMemory",
+                    "McpMigrateRecoverFromDirty",
+                ],
             },
             {
                 "label": "Image overrides",
@@ -410,6 +427,10 @@ def build() -> Template:
         PortMappings=[PortMapping(ContainerPort=mcp_gateway_port, Protocol="tcp")],
         Environment=db_env + [
             Environment(Name="MCP_PORT", Value=str(mcp_gateway_port)),
+            Environment(
+                Name="MCP_MIGRATE_RECOVER_FROM_DIRTY",
+                Value=Ref("McpMigrateRecoverFromDirty"),
+            ),
         ],
         # mcp-gateway loads its license via license-go; LICENSE_DATA env var
         # is honored (priority > LICENSE_FILE > /app/license/license.json).

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -105,6 +105,10 @@ def _sizing_param_specs(defaults: dict) -> list[dict]:
         {"name": "DexClientId", "type": "String",
          "default": str(maestro_cfg["dex"]["client_id"]),
          "description": "OIDC client ID the maestro UI uses against DEX."},
+        {"name": "McpMigrateRecoverFromDirty", "type": "String",
+         "default": "false", "allowed_values": ["true", "false"],
+         "description": "When true, mcp-gateway tries to recover from a "
+                        "previously failed (dirty) maestro DB migration on startup."},
         # OTEL
         {"name": "OtelReplicas", "type": "Number", "default": int(otel_cfg["replicas"]),
          "min": 1, "description": "Desired replicas for the otel-gateway service."},
@@ -534,6 +538,7 @@ def build() -> Template:
         "DexInitImage": dex_init_image,
         "MaestroTaskCpu": Ref("MaestroTaskCpu"),
         "MaestroTaskMemory": Ref("MaestroTaskMemory"),
+        "McpMigrateRecoverFromDirty": Ref("McpMigrateRecoverFromDirty"),
         "DexClientId": Ref("DexClientId"),
         "DexAdminEmail": Ref("DexAdminEmail"),
         "DexAdminPasswordHash": Ref("DexAdminPasswordHash"),


### PR DESCRIPTION
## Summary

- New root + maestro stack parameter ``McpMigrateRecoverFromDirty`` (``true``/``false``, default ``false``).
- Forwarded from root to MaestroStack and set as ``MCP_MIGRATE_RECOVER_FROM_DIRTY`` on the ``mcp-gateway`` container so it can recover from a previously failed (dirty) maestro DB migration on startup.

## Test plan

- [x] ``make build`` (regenerates templates, cfn-lint clean)
- [x] ``make test`` (327 passed)