### PR TITLE
defaults: bump lakerunner -> v1.21.0, maestro -> v1.27.11

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.20.5"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.26.5"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.21.0"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.27.11"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
## Summary

- Bump default ``lakerunner`` image from ``v1.20.5`` -> ``v1.21.0``.
- Bump default ``maestro`` image from ``v1.26.5`` -> ``v1.27.11``.

## Test plan

- [x] ``make build`` (cfn-lint clean)
- [x] ``make test`` (327 passed)