### PR TITLE
services: emit lakerunner self-telemetry to in-cluster otel-collector

### DIFF
--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -40,6 +40,12 @@ from troposphere.ecs import (
     NetworkConfiguration,
     Secret,
     Service,
+    ServiceRegistry,
+)
+from troposphere.servicediscovery import (
+    DnsConfig,
+    DnsRecord,
+    Service as DiscoveryService,
 )
 
 from cardinal_cfn.children import services_common
@@ -141,6 +147,17 @@ def build() -> Template:
     t.add_parameter(
         Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="VPC ID (forwarded from root).")
     )
+    t.add_parameter(
+        Parameter(
+            "ServiceNamespaceId",
+            Type="String",
+            Description=(
+                "Cloud Map private DNS namespace ID. Used to register the "
+                "collector at cardinal-otel.<namespace> for task-to-task "
+                "discovery by lakerunner self-telemetry."
+            ),
+        )
+    )
 
     # ---------------------------------------------------------------------
     # Image override
@@ -238,6 +255,7 @@ def build() -> Template:
                     "StorageProfilesParamName",
                     "HttpsListenerArn",
                     "VpcId",
+                    "ServiceNamespaceId",
                 ],
             },
             {
@@ -336,6 +354,23 @@ def build() -> Template:
     t.add_resource(listener_rule)
 
     # ---------------------------------------------------------------------
+    # Cloud Map registration so other tasks can reach the collector at
+    # cardinal-otel.<namespace>:4317 without going through the ALB. Used by
+    # lakerunner self-telemetry.
+    # ---------------------------------------------------------------------
+    otel_discovery = t.add_resource(
+        DiscoveryService(
+            "OtelDiscoveryService",
+            Name="cardinal-otel",
+            NamespaceId=Ref("ServiceNamespaceId"),
+            DnsConfig=DnsConfig(
+                DnsRecords=[DnsRecord(Type="A", TTL="10")],
+                RoutingPolicy="MULTIVALUE",
+            ),
+        )
+    )
+
+    # ---------------------------------------------------------------------
     # ECS Service (inlined, not via build_ecs_service helper, because the
     # LoadBalancers block must be conditionally populated via Fn::If).
     # ---------------------------------------------------------------------
@@ -372,6 +407,9 @@ def build() -> Template:
                 ],
                 Ref("AWS::NoValue"),
             ),
+            ServiceRegistries=[
+                ServiceRegistry(RegistryArn=GetAtt(otel_discovery, "Arn")),
+            ],
             Tags=cardinal_tags(component="compute", role=_SERVICE_KEY),
         )
     )

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -4,12 +4,13 @@ Each helper constructs and returns a single troposphere object.
 The caller is responsible for adding it to a template.
 """
 
-from troposphere import GetAtt, Ref, Split
+from troposphere import GetAtt, Ref, Split, Sub
 from troposphere.ecs import (
     AwsvpcConfiguration,
     ContainerDefinition,
     DeploymentCircuitBreaker,
     DeploymentConfiguration,
+    Environment,
     LoadBalancer as EcsLoadBalancer,
     LogConfiguration,
     NetworkConfiguration,
@@ -31,6 +32,31 @@ from troposphere.logs import LogGroup
 from cardinal_cfn.listener_priorities import priority_for
 from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.policies import apply_policy
+
+
+def lakerunner_otel_env(*, service_key: str) -> list:
+    """OTel env vars wired to the in-cluster otel-collector.
+
+    Mirrors the helm chart pattern: OTEL_SERVICE_NAME=lakerunner-<component>,
+    ENABLE_OTLP_TELEMETRY toggles the actual exporter, OTEL_EXPORTER_OTLP_ENDPOINT
+    points at the collector's Cloud Map DNS name, and OTEL_RESOURCE_ATTRIBUTES
+    carries ecs.cluster.name. All four env vars are unconditionally set; the
+    ENABLE_OTLP_TELEMETRY flag is what actually starts/stops exporting.
+
+    Expects the calling stack to declare these parameters:
+      - SelfTelemetryEndpoint (String): the OTLP gRPC URL, or "" when disabled.
+      - SelfTelemetryEnabled  (String): "true" or "false".
+      - ClusterName           (String): forwarded from the root.
+    """
+    return [
+        Environment(Name="OTEL_SERVICE_NAME", Value=f"lakerunner-{service_key}"),
+        Environment(Name="OTEL_EXPORTER_OTLP_ENDPOINT", Value=Ref("SelfTelemetryEndpoint")),
+        Environment(Name="ENABLE_OTLP_TELEMETRY", Value=Ref("SelfTelemetryEnabled")),
+        Environment(
+            Name="OTEL_RESOURCE_ATTRIBUTES",
+            Value=Sub("ecs.cluster.name=${ClusterName}"),
+        ),
+    ]
 
 
 def build_log_group(*, service_key: str, retention_days: int = 14) -> LogGroup:

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -145,6 +145,23 @@ def build() -> Template:
             Description="Name of the SSM parameter holding the storage_profiles YAML.",
         )
     )
+    t.add_parameter(
+        Parameter(
+            "SelfTelemetryEndpoint",
+            Type="String",
+            Default="",
+            Description="OTLP gRPC URL for the in-cluster otel-collector. Empty when SelfTelemetry is disabled.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "SelfTelemetryEnabled",
+            Type="String",
+            Default="false",
+            AllowedValues=["true", "false"],
+            Description="ENABLE_OTLP_TELEMETRY flag for lakerunner containers in this tier.",
+        )
+    )
 
     # Inputs the monitoring service uses to drive ECS-based autoscaling of the
     # process-* services. ClusterName is the ECS cluster name (not ARN) — both
@@ -324,7 +341,11 @@ def build() -> Template:
             path_patterns=["/*"],
         )
     )
-    admin_env = list(base_env) + _service_specific_env(admin_cfg)
+    admin_env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key="admin-api")
+        + _service_specific_env(admin_cfg)
+    )
     # Seed the lakerunner admin-api binary's first valid admin key. Without
     # this, every Authorization: Bearer <key> request fails validation
     # because the configdb has no admin keys and the binary won't accept
@@ -467,7 +488,12 @@ def _build_internal_service_block(
 ):
     """Wire up log group, task def, and ECS service for one internal service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
-    env = list(base_env) + _service_specific_env(config) + list(extra_env or [])
+    env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key=service_key)
+        + _service_specific_env(config)
+        + list(extra_env or [])
+    )
     task_def = t.add_resource(
         services_common.build_task_definition(
             service_key=service_key,

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -59,6 +59,7 @@ def build() -> Template:
     # Cross-stack inputs (forwarded from root)
     # ---------------------------------------------------------------------
     t.add_parameter(Parameter("ClusterArn", Type="String", Description="ECS cluster ARN."))
+    t.add_parameter(Parameter("ClusterName", Type="String", Description="ECS cluster name."))
     t.add_parameter(
         Parameter(
             "TaskSecurityGroupId",
@@ -108,6 +109,23 @@ def build() -> Template:
             "StorageProfilesParamName",
             Type="String",
             Description="Name of the SSM parameter holding the storage_profiles YAML.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "SelfTelemetryEndpoint",
+            Type="String",
+            Default="",
+            Description="OTLP gRPC URL for the in-cluster otel-collector. Empty when SelfTelemetry is disabled.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "SelfTelemetryEnabled",
+            Type="String",
+            Default="false",
+            AllowedValues=["true", "false"],
+            Description="ENABLE_OTLP_TELEMETRY flag for lakerunner containers in this tier.",
         )
     )
 
@@ -376,7 +394,11 @@ def _build_service_block(
 ):
     """Wire up the three resources (log group, task def, service) for one service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
-    env = list(base_env) + _service_specific_env(config)
+    env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key=service_key)
+        + _service_specific_env(config)
+    )
     task_def = t.add_resource(
         services_common.build_task_definition(
             service_key=service_key,

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -121,6 +121,23 @@ def build() -> Template:
             Description="Name of the SSM parameter holding the storage_profiles YAML.",
         )
     )
+    t.add_parameter(
+        Parameter(
+            "SelfTelemetryEndpoint",
+            Type="String",
+            Default="",
+            Description="OTLP gRPC URL for the in-cluster otel-collector. Empty when SelfTelemetry is disabled.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "SelfTelemetryEnabled",
+            Type="String",
+            Default="false",
+            AllowedValues=["true", "false"],
+            Description="ENABLE_OTLP_TELEMETRY flag for lakerunner containers in this tier.",
+        )
+    )
 
     # MigrationComplete is unused inside this stack on purpose. The root passes
     # the migration-stack output through this parameter; CloudFormation cannot
@@ -281,7 +298,11 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     worker_lg = t.add_resource(services_common.build_log_group(service_key="query-worker"))
 
-    worker_env = list(base_env) + _service_specific_env(worker_cfg)
+    worker_env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key="query-worker")
+        + _service_specific_env(worker_cfg)
+    )
     worker_task = t.add_resource(
         services_common.build_task_definition(
             service_key="query-worker",
@@ -321,7 +342,11 @@ def build() -> Template:
     api_lg = t.add_resource(services_common.build_log_group(service_key="query-api"))
 
     # query-api uses ECS API to discover live query-worker tasks.
-    api_env = list(base_env) + _service_specific_env(api_cfg) + [
+    api_env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key="query-api")
+        + _service_specific_env(api_cfg)
+    ) + [
         Environment(Name="EXECUTION_ENVIRONMENT", Value="ecs"),
         Environment(Name="QUERY_WORKER_CLUSTER_NAME", Value=Ref("ClusterName")),
         Environment(Name="QUERY_WORKER_SERVICE_NAME", Value=GetAtt(worker_service, "Name")),

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -24,6 +24,7 @@ from troposphere import (
     Output,
     Sub,
     Equals,
+    If,
 )
 from troposphere.cloudformation import Stack
 
@@ -323,6 +324,16 @@ def build() -> Template:
             "create or update."
         ),
     ))
+    t.add_parameter(Parameter(
+        "SelfTelemetry",
+        Type="String",
+        Default="Yes",
+        AllowedValues=["Yes", "No"],
+        Description=(
+            "When Yes, lakerunner tasks emit OTLP telemetry to the in-cluster "
+            "otel-collector at cardinal-otel.<namespace>:4317."
+        ),
+    ))
 
     # ---------------------------------------------------------------------
     # Image overrides
@@ -377,7 +388,7 @@ def build() -> Template:
             {"label": "Sizing", "parameters": sizing_param_names},
             {"label": "Images", "parameters": image_param_names},
             {"label": "Advanced",
-             "parameters": ["DeployMaestro",
+             "parameters": ["DeployMaestro", "SelfTelemetry",
                             "DexAdminEmail", "DexAdminPasswordHash",
                             "OidcSuperadminEmails",
                             "TemplateBaseUrl"]},
@@ -388,6 +399,17 @@ def build() -> Template:
     # Conditions
     # ---------------------------------------------------------------------
     t.add_condition("DeployMaestroEnabled", Equals(Ref("DeployMaestro"), "Yes"))
+    t.add_condition("SelfTelemetryEnabled", Equals(Ref("SelfTelemetry"), "Yes"))
+
+    # Endpoint resolves at deploy time. When disabled the URL is blanked so
+    # the OTel SDK has nothing to dial -- ENABLE_OTLP_TELEMETRY=false is the
+    # actual gate, the empty URL is belt + suspenders.
+    self_telemetry_endpoint = If(
+        "SelfTelemetryEnabled",
+        Sub("http://cardinal-otel.${ServiceNamespaceName}:4317"),
+        "",
+    )
+    self_telemetry_enabled = If("SelfTelemetryEnabled", "true", "false")
 
     # ---------------------------------------------------------------------
     # Install-id derivation (computed inline; not a parameter on root)
@@ -443,6 +465,7 @@ def build() -> Template:
             "InstallIdShort": install_short,
             "InstallIdLong": install_long,
             "ClusterArn": Ref("ClusterArn"),
+            "ClusterName": Ref("ClusterName"),
             "TaskSecurityGroupId": Ref("TaskSgId"),
             "ExecutionRoleArn": Ref("ExecutionRoleArn"),
             "TaskRoleArn": Ref("TaskRoleArn"),
@@ -458,6 +481,8 @@ def build() -> Template:
             "StorageProfilesParamName": Ref("StorageProfilesParamName"),
             "MigrationComplete": migration_complete,
             "LakerunnerImage": lakerunner_image,
+            "SelfTelemetryEndpoint": self_telemetry_endpoint,
+            "SelfTelemetryEnabled": self_telemetry_enabled,
         }
 
     services_query_params = _service_tier_common()
@@ -527,6 +552,7 @@ def build() -> Template:
         "StorageProfilesParamName": Ref("StorageProfilesParamName"),
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
         "VpcId": Ref("VpcId"),
+        "ServiceNamespaceId": Ref("ServiceNamespaceId"),
         "OtelImage": otel_image,
         "OtelReplicas": Ref("OtelReplicas"),
         "OtelCpu": Ref("OtelCpu"),


### PR DESCRIPTION
## Summary

- Register the cardinalhq-otel-collector in Cloud Map as ``cardinal-otel`` so other tasks can reach it task-to-task without going through the ALB.
- Set OTel env vars on every lakerunner container (query-api, query-worker, process-{logs,metrics,traces}, pubsub-sqs, sweeper, monitoring, admin-api, alert-evaluator) matching the helm-chart pattern:
  - ``OTEL_SERVICE_NAME=lakerunner-<component>``
  - ``OTEL_EXPORTER_OTLP_ENDPOINT=http://cardinal-otel.<namespace>:4317``
  - ``ENABLE_OTLP_TELEMETRY=true``
  - ``OTEL_RESOURCE_ATTRIBUTES=ecs.cluster.name=<ClusterName>``
- New root parameter ``SelfTelemetry`` (Yes/No, default Yes); when No the endpoint is blanked and ``ENABLE_OTLP_TELEMETRY=false``.

## Test plan

- [x] ``make build`` (cfn-lint clean)
- [x] ``make test`` (327 passed)
- [x] verified the four OTel env vars appear on every lakerunner container in the rendered templates
- [x] verified ``OtelDiscoveryService`` named ``cardinal-otel`` exists in otel.yaml with ``ServiceRegistries`` attached to ``OtelGrpcService``