### PR TITLE
self-telemetry: use OTLP/HTTP port 4318, not gRPC 4317

### DIFF
--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -355,7 +355,8 @@ def build() -> Template:
 
     # ---------------------------------------------------------------------
     # Cloud Map registration so other tasks can reach the collector at
-    # cardinal-otel.<namespace>:4317 without going through the ALB. Used by
+    # cardinal-otel.<namespace>:4318 (OTLP/HTTP) without going through the
+    # ALB. Used by
     # lakerunner self-telemetry.
     # ---------------------------------------------------------------------
     otel_discovery = t.add_resource(

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -331,7 +331,7 @@ def build() -> Template:
         AllowedValues=["Yes", "No"],
         Description=(
             "When Yes, lakerunner tasks emit OTLP telemetry to the in-cluster "
-            "otel-collector at cardinal-otel.<namespace>:4317."
+            "otel-collector at cardinal-otel.<namespace>:4318 (OTLP/HTTP)."
         ),
     ))
 
@@ -403,10 +403,12 @@ def build() -> Template:
 
     # Endpoint resolves at deploy time. When disabled the URL is blanked so
     # the OTel SDK has nothing to dial -- ENABLE_OTLP_TELEMETRY=false is the
-    # actual gate, the empty URL is belt + suspenders.
+    # actual gate, the empty URL is belt + suspenders. Port 4318 is OTLP/HTTP;
+    # lakerunner's OTel SDK uses the HTTP exporter, so 4317 (gRPC) returns
+    # HTTP/2 SETTINGS frames the SDK can't parse.
     self_telemetry_endpoint = If(
         "SelfTelemetryEnabled",
-        Sub("http://cardinal-otel.${ServiceNamespaceName}:4317"),
+        Sub("http://cardinal-otel.${ServiceNamespaceName}:4318"),
         "",
     )
     self_telemetry_enabled = If("SelfTelemetryEnabled", "true", "false")


### PR DESCRIPTION
## Summary

Lakerunner's OTel SDK uses the OTLP/HTTP exporter; pointing it at port 4317 produced ``net/http: HTTP/1.x transport connection broken: malformed HTTP response`` errors because the gRPC listener replied with HTTP/2 SETTINGS frames. Switch the self-telemetry endpoint to ``http://cardinal-otel.<namespace>:4318`` (OTLP/HTTP), which the collector already listens on per the bundled config.

## Test plan

- [x] ``make build`` (cfn-lint clean)
- [x] ``make test`` (327 passed)