### PR TITLE
maestro: bump default image to v1.28.1

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,7 +34,7 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.21.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.27.11"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.28.1"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
Bump cardinal-defaults.yaml maestro image pin to match the maestro/v1.28.1 release.