### PR TITLE
services-query: fix ALB rule path patterns (#111)

### DIFF
--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -335,12 +335,34 @@ def build() -> Template:
             health_check_path=api_health_path,
         )
     )
+    # The binary serves /api/v1/{logs,metrics,spans,promql,logql}/... plus
+    # /api/v1/{ping,services,features}. An ALB listener-rule condition caps
+    # path-pattern values at 5, so route them through two rules sharing the
+    # query-api target group.
     api_listener_rule = t.add_resource(
         services_common.build_listener_rule(
             service_key="query-api",
             target_group_ref=api_tg,
             listener_arn_param="HttpsListenerArn",
-            path_patterns=["/api/v1/query/*"],
+            path_patterns=[
+                "/api/v1/logs/*",
+                "/api/v1/metrics/*",
+                "/api/v1/spans/*",
+                "/api/v1/promql/*",
+                "/api/v1/logql/*",
+            ],
+        )
+    )
+    api_listener_rule_extra = t.add_resource(
+        services_common.build_listener_rule(
+            service_key="query-api-extra",
+            target_group_ref=api_tg,
+            listener_arn_param="HttpsListenerArn",
+            path_patterns=[
+                "/api/v1/ping",
+                "/api/v1/services",
+                "/api/v1/features",
+            ],
         )
     )
     api_task = t.add_resource(

--- a/src/cardinal_cfn/listener_priorities.py
+++ b/src/cardinal_cfn/listener_priorities.py
@@ -9,9 +9,13 @@ future per-service stack splits collision-free.
 
 
 LISTENER_PRIORITIES: dict = {
-    "query-api":     100,
-    "maestro-dex":   210,
-    "otel-grpc":     300,
+    "query-api":       100,
+    # query-api's listener rule needs a second slot because the binary's
+    # routes span more than the 5 path-pattern values an ALB listener
+    # rule allows in a single condition.
+    "query-api-extra": 105,
+    "maestro-dex":     210,
+    "otel-grpc":       300,
     # Maestro is the default app: a true catch-all "/*" rule. It MUST be
     # numerically the highest (lowest priority) so all other rules win.
     "maestro-https": 49999,

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -99,26 +99,60 @@ def test_query_worker_does_not_attach_to_alb(td):
                 )
 
 
-def test_only_one_listener_rule_and_one_target_group(td):
+def test_one_target_group_and_two_listener_rules(td):
+    """query-api: single target group fanned in by two listener rules; the
+    ALB caps path-pattern values at 5 per condition and the binary serves
+    routes that don't all fit in one rule."""
     tgs = [r for r in td["Resources"].values()
            if r["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup"]
     rules = [r for r in td["Resources"].values()
              if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule"]
     assert len(tgs) == 1
-    assert len(rules) == 1
+    assert len(rules) == 2
+    # Both rules forward to the same target group.
+    tg_logical = [k for k, r in td["Resources"].items()
+                  if r["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup"][0]
+    for rule in rules:
+        action = rule["Properties"]["Actions"][0]
+        assert action["TargetGroupArn"] == {"Ref": tg_logical}, action
 
 
-def test_listener_rule_uses_query_api_path_pattern(td):
-    rule = next(r for r in td["Resources"].values()
-                if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule")
-    conditions = rule["Properties"]["Conditions"]
-    found = False
-    for cond in conditions:
-        if cond.get("Field") == "path-pattern":
-            values = cond["PathPatternConfig"]["Values"]
-            assert values == ["/api/v1/query/*"]
-            found = True
-    assert found, "expected a path-pattern condition"
+def test_listener_rules_cover_binary_routes(td):
+    """The path patterns must match the binary's actual routes (queryapi/
+    querier.go:965-984): /api/v1/{logs,metrics,spans,promql,logql}/...
+    plus /api/v1/{ping,services,features}. The legacy /api/v1/query/*
+    pattern (binary never served it) must not reappear."""
+    rules = [r for r in td["Resources"].values()
+             if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule"]
+    all_patterns = set()
+    for rule in rules:
+        for cond in rule["Properties"]["Conditions"]:
+            if cond.get("Field") == "path-pattern":
+                all_patterns.update(cond["PathPatternConfig"]["Values"])
+    expected = {
+        "/api/v1/logs/*", "/api/v1/metrics/*", "/api/v1/spans/*",
+        "/api/v1/promql/*", "/api/v1/logql/*",
+        "/api/v1/ping", "/api/v1/services", "/api/v1/features",
+    }
+    assert expected.issubset(all_patterns), (
+        f"missing patterns: {expected - all_patterns}"
+    )
+    assert "/api/v1/query/*" not in all_patterns, (
+        "the legacy /api/v1/query/* pattern matches no binary route"
+    )
+
+
+def test_no_listener_rule_exceeds_alb_path_pattern_cap(td):
+    """AWS ELB allows at most 5 path-pattern values per condition."""
+    rules = [r for r in td["Resources"].values()
+             if r["Type"] == "AWS::ElasticLoadBalancingV2::ListenerRule"]
+    for rule in rules:
+        for cond in rule["Properties"]["Conditions"]:
+            if cond.get("Field") == "path-pattern":
+                values = cond["PathPatternConfig"]["Values"]
+                assert len(values) <= 5, (
+                    f"rule with > 5 path-pattern values: {values}"
+                )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The query-api ALB listener rule was hardcoded to \`/api/v1/query/*\`, a path the lakerunner binary never served. Every customer query fell through to the maestro catch-all and returned 401 (or 500). Discovered during e2e validation of v0.0.65 (workaround: added a temporary listener rule on the live stack to keep validating; queries then succeeded end-to-end).

Fixes #111.

## Approach

Split into two listener rules forwarding to the same query-api target group. ALB caps path-pattern values at five per condition, and the binary's routes (queryapi/querier.go:965-984) need eight:

- **rule 1** (priority 100): \`/api/v1/logs/*\`, \`/api/v1/metrics/*\`, \`/api/v1/spans/*\`, \`/api/v1/promql/*\`, \`/api/v1/logql/*\`
- **rule 2** (priority 105): \`/api/v1/ping\`, \`/api/v1/services\`, \`/api/v1/features\`

Reserved priority 105 as \`query-api-extra\` in \`listener_priorities.py\` so a future per-service stack split stays collision-free.

## Test plan

- [x] \`make build\` — generators emit two ListenerRule resources, both forwarding to the query-api TG
- [x] \`make test\` — 334 passed, 1 skipped; updated assertions cover both rules, the ≤5-value cap, and that \`/api/v1/query/*\` is gone
- [x] \`make lint\` — cfn-lint clean
- [ ] e2e: deploy v0.0.66 to test account; queries hit query-api directly (no ALB rule patch needed)