### PR TITLE
infrastructure: seed storage-profiles/api-keys SSM params as YAML lists, not {}

### DIFF
--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -501,7 +501,12 @@ def build() -> Template:
     )
 
     # -----------------------------------------------------------------------
-    # SSM parameters (operator-managed JSON, default {})
+    # SSM parameters (operator-managed YAML). The migrator's initializer
+    # (lakerunner migrate, since #109/#110) imports these into configdb and
+    # expects YAML *lists* -- a top-level map (e.g. "{}") fails to unmarshal
+    # into []initialize.StorageProfile and aborts the migration. Mirror
+    # data-setup.sh: seed storage-profiles with an install-specific profile
+    # (bucket + region substituted) and api-keys with an empty list.
     # -----------------------------------------------------------------------
 
     storage_profiles_param = t.add_resource(
@@ -510,8 +515,18 @@ def build() -> Template:
                 "StorageProfilesParam",
                 Name=Ref(storage_profiles_param_name),
                 Type="String",
-                Value="{}",
-                Description="Cardinal storage profiles (operator-managed JSON).",
+                Value=Sub(
+                    "- organization_id: 12340000-0000-4000-8000-000000000000\n"
+                    "  instance_num: 1\n"
+                    "  collector_name: lakerunner\n"
+                    "  cloud_provider: aws\n"
+                    "  region: ${AWS::Region}\n"
+                    "  bucket: ${BucketName}\n"
+                    "  insecure_tls: false\n"
+                    "  use_path_style: true\n",
+                    BucketName=bucket_name_value,
+                ),
+                Description="Cardinal storage profiles (YAML; operator-managed).",
                 Tags={
                     "Application": APPLICATION,
                     "Project": PROJECT,
@@ -529,8 +544,8 @@ def build() -> Template:
                 "ApiKeysParam",
                 Name=Ref(api_keys_param_name),
                 Type="String",
-                Value="{}",
-                Description="Cardinal external API keys (operator-managed JSON).",
+                Value="[]",
+                Description="Cardinal external API keys (YAML; operator-managed).",
                 Tags={
                     "Application": APPLICATION,
                     "Project": PROJECT,

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -111,6 +111,22 @@ def test_creates_two_ssm_parameters(td):
     assert types.count("AWS::SSM::Parameter") == 2
 
 
+def test_ssm_seeds_render_nonempty_yaml_lists(td):
+    # Regression: the migrator imports these into configdb and needs YAML
+    # *lists*. A top-level map ("{}") fails to unmarshal into
+    # []initialize.StorageProfile and aborts the migration -- the bug that hit
+    # CFN-infra installs because #110 fixed only data-setup.sh, not this path.
+    sp = td["Resources"]["StorageProfilesParam"]["Properties"]["Value"]
+    body = sp["Fn::Sub"][0] if isinstance(sp, dict) else sp
+    assert body.lstrip().startswith("- "), f"storage profiles must be a YAML list: {body!r}"
+    assert "{}" not in body
+    for field in ("organization_id", "collector_name", "cloud_provider", "region", "bucket"):
+        assert field in body, f"storage profile missing {field}"
+
+    ak = td["Resources"]["ApiKeysParam"]["Properties"]["Value"]
+    assert ak == "[]", f"api keys must seed an empty list, got: {ak!r}"
+
+
 def test_creates_ingest_bucket_and_queue(td):
     types = _types(td)
     assert types.count("AWS::S3::Bucket") == 1
@@ -203,8 +219,7 @@ def test_ssm_parameters_use_overridable_names(td):
     assert ak["Name"] == {"Ref": "ApiKeysParamName"}
     assert sp["Type"] == "String"
     assert ak["Type"] == "String"
-    assert sp["Value"] == "{}"
-    assert ak["Value"] == "{}"
+    # Seed values are asserted in test_ssm_seeds_render_nonempty_yaml_lists.
 
 
 def test_ingest_queue_policy_allows_s3_with_source_conditions(td):


### PR DESCRIPTION
## Problem

The migration stack circuit-breaks on installs provisioned via the **cardinal-infrastructure CloudFormation stack** (as opposed to `data-setup.sh`). Reproduced end-to-end in a clean account.

The migrator task's containers tell the story:
- `configdb-init` exits 0 (DB creds/SSL/network all fine)
- `migrator` exits **1**: `failed to import storage profiles: yaml: unmarshal errors: cannot unmarshal !!map into []initialize.StorageProfile`
- `keepalive` never starts → ECS deployment circuit breaker (~6-7 min) → MigrationStack fails → root rolls back

## Root cause

`cardinal_infrastructure.py` seeded `/cardinal/storage-profiles` and `/cardinal/api-keys` with `Value="{}"` (an empty YAML **map**). Since #109/#110 the migrator imports these into configdb and requires YAML **lists**; `{}` fails to unmarshal.

#109/#110 fixed the seed in `data-setup.sh` and wired the migrator to consume it, but **never updated the parallel CFN generator** — so the two provisioning paths diverged and CFN-infra installs kept seeding `{}`.

## Fix

Mirror `data-setup.sh`:
- storage-profiles → an install-specific profile list (`organization_id, instance_num, collector_name, cloud_provider, region, bucket, insecure_tls, use_path_style`; bucket + region substituted)
- api-keys → `[]`

Add a regression test (`test_ssm_seeds_render_nonempty_yaml_lists`) asserting both seeds render as non-empty YAML lists, so the paths can't silently diverge again.

## Verification

Built the full stack from scratch in a test account: migrator exits 0 (`Initialization completed successfully`, `profiles=1`), MigrationStack and the entire root stack reach CREATE_COMPLETE, and telemetry flows continuously into `db/<seeded-org>/lakerunner/...`. `make test` (333 passed) and `make lint` clean.