### PR TITLE
otel: attach the collector to the ALB unconditionally

### DIFF
--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -5,11 +5,11 @@ image. The collector listens on the canonical OTLP ports (gRPC 4317 and
 HTTP 4318) and writes telemetry directly to the ingest S3 bucket; it has
 no database dependency and does not consume from the ingest SQS queue.
 
-ALB attachment is OPTIONAL. When OtelExposeOnAlb=Yes, this stack also
-creates a TargetGroup + ListenerRule (priority 300) on the shared HTTPS
-listener. The ECS Service's LoadBalancers block is gated by the same
-condition so a single template covers both the internal-only and ALB-
-exposed deployments.
+The collector is always attached to the shared ALB: this stack creates a
+TargetGroup + ListenerRule (priority 300) on the HTTPS listener and wires
+the ECS Service's LoadBalancers block to it. The ALB security group is
+customer-supplied and may differ from the task security group; the
+customer owns the ALB-to-task ingress rule on the OTLP gRPC port.
 
 Config injection is intentionally minimal: the image ships with a baked-in
 config (`/etc/otel/config.yaml`, referenced by the default command) and
@@ -76,8 +76,8 @@ _OTLP_GRPC_PORT = 4317
 def build() -> Template:
     t = Template()
     t.set_description(
-        "Cardinal otel: cardinalhq-otel-collector ECS Fargate service. ALB "
-        "attachment is optional and gated on OtelExposeOnAlb."
+        "Cardinal otel: cardinalhq-otel-collector ECS Fargate service, always "
+        "attached to the shared ALB HTTPS listener."
     )
 
     defaults = load_defaults()
@@ -120,8 +120,6 @@ def build() -> Template:
             Description="ARN of the license Secrets Manager secret.",
         )
     )
-    # Always declared so the root can pass them unconditionally; only
-    # consumed when OtelExposeOnAlb=Yes via the gated ALB resources.
     t.add_parameter(
         Parameter("HttpsListenerArn", Type="String", Description="ARN of the ALB HTTPS listener.")
     )
@@ -177,18 +175,6 @@ def build() -> Template:
             Description="Fargate memory (MiB) for the otel-gateway service.",
         )
     )
-    t.add_parameter(
-        Parameter(
-            "OtelExposeOnAlb",
-            Type="String",
-            AllowedValues=["Yes", "No"],
-            Default="No",
-            Description=(
-                "When Yes, attach the otel-gateway service to the shared ALB "
-                "via a TargetGroup + ListenerRule on the HTTPS listener."
-            ),
-        )
-    )
     # The cardinalhq-otel-collector image's run-with-env-config wrapper reads
     # the collector YAML from CHQ_COLLECTOR_CONFIG_YAML at task start. We
     # ship a sensible default (cardinal-otel-config.yaml) and pass it via
@@ -208,7 +194,6 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     # Conditions
     # ---------------------------------------------------------------------
-    t.add_condition("ExposeOtelOnAlb", Equals(Ref("OtelExposeOnAlb"), "Yes"))
     t.add_condition(
         "HasOtelConfigOverride", Not(Equals(Ref("OtelConfigYaml"), ""))
     )
@@ -249,10 +234,6 @@ def build() -> Template:
             {
                 "label": "Image overrides",
                 "parameters": ["OtelImage"],
-            },
-            {
-                "label": "ALB attachment",
-                "parameters": ["OtelExposeOnAlb"],
             },
         ],
     )
@@ -309,16 +290,15 @@ def build() -> Template:
     )
 
     # ---------------------------------------------------------------------
-    # Optional ALB attachment (TargetGroup + ListenerRule, gated by condition).
-    # The TargetGroup targets the gRPC port; path patterns are nominal because
-    # gRPC traffic uses HTTP/2 to a fixed path.
+    # ALB attachment (TargetGroup + ListenerRule). The TargetGroup targets
+    # the gRPC port; path patterns are nominal because gRPC traffic uses
+    # HTTP/2 to a fixed path.
     # ---------------------------------------------------------------------
     target_group = services_common.build_target_group(
         service_key=_SERVICE_KEY,
         vpc_id_param="VpcId",
         port=_OTLP_GRPC_PORT,
     )
-    target_group.Condition = "ExposeOtelOnAlb"
     t.add_resource(target_group)
 
     listener_rule = services_common.build_listener_rule(
@@ -327,7 +307,6 @@ def build() -> Template:
         listener_arn_param="HttpsListenerArn",
         path_patterns=["/v1/*"],
     )
-    listener_rule.Condition = "ExposeOtelOnAlb"
     t.add_resource(listener_rule)
 
     # ---------------------------------------------------------------------
@@ -349,8 +328,8 @@ def build() -> Template:
     )
 
     # ---------------------------------------------------------------------
-    # ECS Service (inlined, not via build_ecs_service helper, because the
-    # LoadBalancers block must be conditionally populated via Fn::If).
+    # ECS Service (inlined, not via build_ecs_service helper, so the
+    # LoadBalancers block can reference the always-present TargetGroup).
     # ---------------------------------------------------------------------
     service = t.add_resource(
         Service(
@@ -374,17 +353,13 @@ def build() -> Template:
                     Rollback=True,
                 ),
             ),
-            LoadBalancers=If(
-                "ExposeOtelOnAlb",
-                [
-                    EcsLoadBalancer(
-                        ContainerName=_SERVICE_KEY,
-                        ContainerPort=_OTLP_GRPC_PORT,
-                        TargetGroupArn=Ref(target_group),
-                    )
-                ],
-                Ref("AWS::NoValue"),
-            ),
+            LoadBalancers=[
+                EcsLoadBalancer(
+                    ContainerName=_SERVICE_KEY,
+                    ContainerPort=_OTLP_GRPC_PORT,
+                    TargetGroupArn=Ref(target_group),
+                )
+            ],
             ServiceRegistries=[
                 ServiceRegistry(RegistryArn=GetAtt(otel_discovery, "Arn")),
             ],
@@ -400,11 +375,7 @@ def build() -> Template:
     t.add_output(
         Output(
             "OtelEndpoint",
-            Value=If(
-                "ExposeOtelOnAlb",
-                Sub(f"alb:${{HttpsListenerArn}}:{_OTLP_GRPC_PORT}"),
-                Sub(f"internal:${{AWS::StackName}}:{_OTLP_GRPC_PORT}"),
-            ),
+            Value=Sub(f"alb:${{HttpsListenerArn}}:{_OTLP_GRPC_PORT}"),
         )
     )
     t.add_output(Output("OtelServiceName", Value=GetAtt(service, "Name")))

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -118,9 +118,6 @@ def _sizing_param_specs(defaults: dict) -> list[dict]:
          "description": "Fargate CPU units for the otel-gateway service."},
         {"name": "OtelMemory", "type": "String", "default": str(otel_cfg["memory_mib"]),
          "description": "Fargate memory (MiB) for the otel-gateway service."},
-        {"name": "OtelExposeOnAlb", "type": "String", "default": "No",
-         "allowed_values": ["Yes", "No"],
-         "description": "When Yes, attach the otel-gateway to the shared ALB."},
         {"name": "OtelConfigYaml", "type": "String", "default": "",
          "description": "Optional inline OTEL collector config YAML override."},
     ]
@@ -555,7 +552,6 @@ def build() -> Template:
         "OtelReplicas": Ref("OtelReplicas"),
         "OtelCpu": Ref("OtelCpu"),
         "OtelMemory": Ref("OtelMemory"),
-        "OtelExposeOnAlb": Ref("OtelExposeOnAlb"),
         "OtelConfigYaml": Ref("OtelConfigYaml"),
     })
 

--- a/tests/templates/test_otel.py
+++ b/tests/templates/test_otel.py
@@ -59,11 +59,9 @@ def test_tunable_parameters_present(td):
         assert n in td["Parameters"], f"missing parameter: {n}"
 
 
-def test_expose_on_alb_parameter(td):
-    p = td["Parameters"]["OtelExposeOnAlb"]
-    assert p["Type"] == "String"
-    assert p["AllowedValues"] == ["Yes", "No"]
-    assert p["Default"] == "No"
+def test_no_expose_on_alb_parameter(td):
+    """ALB attachment is unconditional; the toggle no longer exists."""
+    assert "OtelExposeOnAlb" not in td["Parameters"]
 
 
 # ---------------------------------------------------------------------------
@@ -71,10 +69,8 @@ def test_expose_on_alb_parameter(td):
 # ---------------------------------------------------------------------------
 
 
-def test_expose_on_alb_condition_defined(td):
-    conds = td.get("Conditions", {})
-    assert "ExposeOtelOnAlb" in conds
-    assert conds["ExposeOtelOnAlb"] == {"Fn::Equals": [{"Ref": "OtelExposeOnAlb"}, "Yes"]}
+def test_no_expose_on_alb_condition(td):
+    assert "ExposeOtelOnAlb" not in td.get("Conditions", {})
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +100,7 @@ def test_creates_one_task_definition(td):
     assert len(task_defs) == 1
 
 
-def test_target_group_and_listener_rule_have_condition(td):
+def test_target_group_and_listener_rule_unconditional(td):
     tgs = [
         r for r in td["Resources"].values()
         if r["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup"
@@ -115,8 +111,8 @@ def test_target_group_and_listener_rule_have_condition(td):
     ]
     assert len(tgs) == 1
     assert len(rules) == 1
-    assert tgs[0].get("Condition") == "ExposeOtelOnAlb"
-    assert rules[0].get("Condition") == "ExposeOtelOnAlb"
+    assert "Condition" not in tgs[0]
+    assert "Condition" not in rules[0]
 
 
 def test_listener_rule_priority_is_300(td):
@@ -127,15 +123,12 @@ def test_listener_rule_priority_is_300(td):
     assert rule["Properties"]["Priority"] == 300
 
 
-def test_ecs_service_load_balancers_is_conditional(td):
+def test_ecs_service_load_balancers_unconditional(td):
     svc = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service")
     lbs = svc["Properties"].get("LoadBalancers")
-    assert isinstance(lbs, dict), f"expected an Fn::If for LoadBalancers, got {lbs!r}"
-    assert "Fn::If" in lbs
-    branches = lbs["Fn::If"]
-    assert branches[0] == "ExposeOtelOnAlb"
-    # Non-attached branch must be AWS::NoValue.
-    assert branches[2] == {"Ref": "AWS::NoValue"}
+    assert isinstance(lbs, list), f"expected a plain list for LoadBalancers, got {lbs!r}"
+    assert len(lbs) == 1
+    assert lbs[0]["ContainerPort"] == 4317
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes the \`OtelExposeOnAlb\` toggle so the otel-collector is always attached to the shared ALB.

- \`otel.py\`: TargetGroup, ListenerRule (priority 300, \`/v1/*\`), and the ECS \`LoadBalancers\` block are now unconditional; \`OtelEndpoint\` output is always the ALB form. Dropped the parameter, the \`ExposeOtelOnAlb\` condition, and the "ALB attachment" parameter group.
- \`root.py\`: removed the \`OtelExposeOnAlb\` sizing-param spec and its forward into \`OtelStack\`.
- \`test_otel.py\`: flipped the four affected assertions to verify the parameter/condition are gone and the resources are unconditional.

The ALB security group is customer-supplied and may differ from the task security group; the customer owns the ALB-to-task ingress rule on OTLP gRPC 4317.

## Test plan

- \`make build\` (incl. cfn-lint): clean
- \`make test\`: 333 passed, 3 skipped