### PR TITLE
cardinal-alb-sg: standalone ALB security group helper stack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ check: test	## Pre-push gate (alias for test)
 lint:	## Run cfn-lint on every generated template
 	source $(VENV_DIR)/bin/activate && cfn-lint \
 	  generated-templates/cardinal-vpc.yaml \
+	  generated-templates/cardinal-alb-sg.yaml \
 	  generated-templates/cardinal-infrastructure.yaml \
 	  generated-templates/cardinal-lakerunner.yaml \
 	  generated-templates/cardinal-lakerunner/*.yaml

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ export PYTHONPATH="$(pwd)/src${PYTHONPATH:+:$PYTHONPATH}"
 echo "Generating cardinal-vpc.yaml..."
 python3 -m cardinal_cfn.cardinal_vpc > generated-templates/cardinal-vpc.yaml
 
+echo "Generating cardinal-alb-sg.yaml..."
+python3 -m cardinal_cfn.cardinal_alb_sg > generated-templates/cardinal-alb-sg.yaml
+
 echo "Generating cardinal-infrastructure.yaml..."
 python3 -m cardinal_cfn.cardinal_infrastructure > generated-templates/cardinal-infrastructure.yaml
 
@@ -42,6 +45,7 @@ done
 echo
 echo "Linting CFN templates..."
 cfn-lint generated-templates/cardinal-vpc.yaml \
+         generated-templates/cardinal-alb-sg.yaml \
          generated-templates/cardinal-infrastructure.yaml \
          generated-templates/cardinal-lakerunner.yaml \
          generated-templates/cardinal-lakerunner/*.yaml || \

--- a/src/cardinal_cfn/cardinal_alb_sg.py
+++ b/src/cardinal_cfn/cardinal_alb_sg.py
@@ -1,0 +1,93 @@
+"""cardinal-alb-sg: standalone ALB security group.
+
+A deliberately tiny, optional helper stack. Creates one named security
+group meant for the shared ALB: inbound HTTPS (443) from the private
+RFC1918 ranges and unrestricted egress. The resulting GroupId is fed to
+the cardinal-lakerunner root as ``AlbSgId`` (which is independent of the
+task security group, ``TaskSgId``).
+
+The task SG must still allow inbound from this SG on each service port
+(e.g. otel gRPC 4317) for ALB->task traffic; that ingress rule is owned by
+whoever manages the task SG and is intentionally out of scope here.
+"""
+
+from troposphere import (
+    GetAtt,
+    Output,
+    Parameter,
+    Ref,
+    Tags,
+    Template,
+)
+from troposphere.ec2 import SecurityGroup, SecurityGroupRule
+
+
+# Private RFC1918 ranges allowed inbound on 443.
+_ALLOWED_CIDRS = ["10.0.0.0/8", "172.16.0.0/12"]
+_HTTPS_PORT = 443
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal ALB security group: HTTPS (443) inbound from the private "
+        "RFC1918 ranges, unrestricted egress. Feed GroupId to the "
+        "cardinal-lakerunner root as AlbSgId."
+    )
+
+    t.add_parameter(
+        Parameter(
+            "VpcId",
+            Type="AWS::EC2::VPC::Id",
+            Description="VPC the security group is created in.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "SecurityGroupName",
+            Type="String",
+            Default="cardinal-alb-sg",
+            Description="Name for the security group (GroupName and Name tag).",
+        )
+    )
+
+    sg = t.add_resource(
+        SecurityGroup(
+            "AlbSecurityGroup",
+            GroupName=Ref("SecurityGroupName"),
+            GroupDescription="Cardinal ALB: HTTPS in from RFC1918, all egress.",
+            VpcId=Ref("VpcId"),
+            SecurityGroupIngress=[
+                SecurityGroupRule(
+                    IpProtocol="tcp",
+                    FromPort=_HTTPS_PORT,
+                    ToPort=_HTTPS_PORT,
+                    CidrIp=cidr,
+                    Description=f"HTTPS from {cidr}",
+                )
+                for cidr in _ALLOWED_CIDRS
+            ],
+            SecurityGroupEgress=[
+                SecurityGroupRule(
+                    IpProtocol="-1",
+                    CidrIp="0.0.0.0/0",
+                    Description="All egress",
+                )
+            ],
+            Tags=Tags(Name=Ref("SecurityGroupName")),
+        )
+    )
+
+    t.add_output(
+        Output(
+            "AlbSecurityGroupId",
+            Description="Security group ID; pass to cardinal-lakerunner as AlbSgId.",
+            Value=GetAtt(sg, "GroupId"),
+        )
+    )
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml())

--- a/tests/templates/test_cardinal_alb_sg.py
+++ b/tests/templates/test_cardinal_alb_sg.py
@@ -1,0 +1,60 @@
+"""Tests for the cardinal-alb-sg standalone template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import cardinal_alb_sg
+
+
+@pytest.fixture
+def td():
+    return json.loads(cardinal_alb_sg.build().to_json())
+
+
+def test_required_parameters(td):
+    for n in ("VpcId", "SecurityGroupName"):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_security_group_name_default(td):
+    assert td["Parameters"]["SecurityGroupName"]["Default"] == "cardinal-alb-sg"
+
+
+def _sg(td):
+    sgs = [r for r in td["Resources"].values() if r["Type"] == "AWS::EC2::SecurityGroup"]
+    assert len(sgs) == 1
+    return sgs[0]
+
+
+def test_group_name_is_parameterized(td):
+    assert _sg(td)["Properties"]["GroupName"] == {"Ref": "SecurityGroupName"}
+
+
+def test_ingress_is_https_from_rfc1918(td):
+    ingress = _sg(td)["Properties"]["SecurityGroupIngress"]
+    cidrs = {r["CidrIp"] for r in ingress}
+    assert cidrs == {"10.0.0.0/8", "172.16.0.0/12"}
+    for r in ingress:
+        assert r["IpProtocol"] == "tcp"
+        assert r["FromPort"] == 443
+        assert r["ToPort"] == 443
+
+
+def test_egress_is_all_traffic_anywhere(td):
+    egress = _sg(td)["Properties"]["SecurityGroupEgress"]
+    assert len(egress) == 1
+    assert egress[0]["IpProtocol"] == "-1"
+    assert egress[0]["CidrIp"] == "0.0.0.0/0"
+
+
+def test_output_exposes_group_id(td):
+    assert "AlbSecurityGroupId" in td["Outputs"]
+    assert td["Outputs"]["AlbSecurityGroupId"]["Value"] == {
+        "Fn::GetAtt": ["AlbSecurityGroup", "GroupId"]
+    }
+
+
+def test_outputs_have_no_export(td):
+    for name, out in td["Outputs"].items():
+        assert "Export" not in out, f"output {name} should not have an Export"


### PR DESCRIPTION
## Summary

Adds a tiny optional standalone template, `cardinal-alb-sg.yaml`, that creates one **named** security group for the shared ALB:

- inbound HTTPS (443) from `10.0.0.0/8` and `172.16.0.0/12`
- unrestricted egress

Its `AlbSecurityGroupId` output is fed to the lakerunner root as `AlbSgId`, which is independent of the task security group (`TaskSgId`). The task SG still owns the ALB->task ingress rule on each service port (e.g. otel gRPC 4317).

- New generator `src/cardinal_cfn/cardinal_alb_sg.py` (mirrors `cardinal_vpc.py`).
- Wired into `build.sh` and the `Makefile` lint target; `release.yml`'s `s3 sync` publishes it automatically.
- Per-template tests in `tests/templates/test_cardinal_alb_sg.py`.

## Test plan

- `make build` (incl. cfn-lint): clean
- `make test`: 340 passed, 3 skipped