### PR TITLE
otel: expose OTLP/HTTP 4318 on the ALB, health-check 13133

### DIFF
--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -5,11 +5,14 @@ image. The collector listens on the canonical OTLP ports (gRPC 4317 and
 HTTP 4318) and writes telemetry directly to the ingest S3 bucket; it has
 no database dependency and does not consume from the ingest SQS queue.
 
-The collector is always attached to the shared ALB: this stack creates a
-TargetGroup + ListenerRule (priority 300) on the HTTPS listener and wires
-the ECS Service's LoadBalancers block to it. The ALB security group is
-customer-supplied and may differ from the task security group; the
-customer owns the ALB-to-task ingress rule on the OTLP gRPC port.
+The collector is always attached to the shared ALB, exposing OTLP/HTTP
+(4318): this stack creates a TargetGroup + ListenerRule (priority 300,
+"/v1/*") on the HTTPS listener and wires the ECS Service's LoadBalancers
+block to it. Health checks hit the collector's health_check extension on
+13133. The gRPC receiver (4317) is not ALB-exposed but stays reachable
+task-to-task via Cloud Map. The ALB security group is customer-supplied
+and may differ from the task security group; the customer owns the
+ALB-to-task ingress rule on the OTLP HTTP port.
 
 Config injection is intentionally minimal: the image ships with a baked-in
 config (`/etc/otel/config.yaml`, referenced by the default command) and
@@ -65,12 +68,15 @@ from cardinal_cfn.parameters import (
 # entry must reference.
 _SERVICE_KEY = "otel-grpc"
 
-# OTLP ports. The ALB target points at the gRPC port; HTTP receivers run on
-# 4318 and remain reachable task-to-task. Path patterns on the listener rule
-# are largely irrelevant when targeting a gRPC service, but ListenerRule
-# requires at least one condition — "/v1/*" matches the OTLP HTTP receivers'
-# canonical path prefix.
-_OTLP_GRPC_PORT = 4317
+# OTLP ports. The ALB exposes OTLP/HTTP (4318): it's plain HTTP, so a standard
+# HTTP target group + the "/v1/*" listener rule (OTLP HTTP's canonical path
+# prefix: /v1/traces|metrics|logs) work without gRPC/HTTP-2 complications. The
+# gRPC receiver (4317) stays reachable task-to-task via Cloud Map but is not
+# ALB-exposed. The collector's health_check extension serves HTTP 200 at "/"
+# on 13133, so the target group health-checks that port (not the OTLP port,
+# which has no plain-HTTP health path).
+_OTLP_HTTP_PORT = 4318
+_HEALTH_PORT = 13133
 
 
 def build() -> Template:
@@ -285,19 +291,22 @@ def build() -> Template:
             environment=env,
             secrets=secrets,
             log_group_ref=log_group,
-            container_port=_OTLP_GRPC_PORT,
+            container_port=_OTLP_HTTP_PORT,
         )
     )
 
     # ---------------------------------------------------------------------
-    # ALB attachment (TargetGroup + ListenerRule). The TargetGroup targets
-    # the gRPC port; path patterns are nominal because gRPC traffic uses
-    # HTTP/2 to a fixed path.
+    # ALB attachment (TargetGroup + ListenerRule). Traffic targets OTLP/HTTP
+    # (4318) and the "/v1/*" rule matches /v1/traces|metrics|logs. Health
+    # checks hit the collector's health_check extension on 13133 (HTTP 200 at
+    # "/"); the OTLP port has no plain-HTTP health path.
     # ---------------------------------------------------------------------
     target_group = services_common.build_target_group(
         service_key=_SERVICE_KEY,
         vpc_id_param="VpcId",
-        port=_OTLP_GRPC_PORT,
+        port=_OTLP_HTTP_PORT,
+        health_check_path="/",
+        health_check_port=_HEALTH_PORT,
     )
     t.add_resource(target_group)
 
@@ -356,7 +365,7 @@ def build() -> Template:
             LoadBalancers=[
                 EcsLoadBalancer(
                     ContainerName=_SERVICE_KEY,
-                    ContainerPort=_OTLP_GRPC_PORT,
+                    ContainerPort=_OTLP_HTTP_PORT,
                     TargetGroupArn=Ref(target_group),
                 )
             ],
@@ -375,7 +384,7 @@ def build() -> Template:
     t.add_output(
         Output(
             "OtelEndpoint",
-            Value=Sub(f"alb:${{HttpsListenerArn}}:{_OTLP_GRPC_PORT}"),
+            Value=Sub(f"alb:${{HttpsListenerArn}}:{_OTLP_HTTP_PORT}"),
         )
     )
     t.add_output(Output("OtelServiceName", Value=GetAtt(service, "Name")))

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -81,8 +81,18 @@ def build_target_group(
     vpc_id_param: str,
     port: int,
     health_check_path: str = "/healthz",
+    health_check_port: int | None = None,
 ) -> TargetGroup:
-    """ALB target group for a service that attaches to the ALB."""
+    """ALB target group for a service that attaches to the ALB.
+
+    ``health_check_port`` overrides the port the ALB probes when the health
+    endpoint lives on a different port than the traffic port (e.g. the otel
+    collector serves OTLP on 4318 but its health_check extension on 13133).
+    Defaults to the traffic port.
+    """
+    kwargs = {}
+    if health_check_port is not None:
+        kwargs["HealthCheckPort"] = str(health_check_port)
     return TargetGroup(
         _resource_title(service_key, "TargetGroup"),
         Port=port,
@@ -93,6 +103,7 @@ def build_target_group(
         HealthCheckProtocol="HTTP",
         Matcher=Matcher(HttpCode="200"),
         Tags=cardinal_tags(component="networking", role=f"{service_key}-tg"),
+        **kwargs,
     )
 
 

--- a/tests/templates/test_otel.py
+++ b/tests/templates/test_otel.py
@@ -115,6 +115,21 @@ def test_target_group_and_listener_rule_unconditional(td):
     assert "Condition" not in rules[0]
 
 
+def test_target_group_serves_otlp_http_health_checks_13133(td):
+    """Traffic on OTLP/HTTP 4318; health check on the health_check extension
+    (13133), since 4317 is gRPC and 4318 has no plain-HTTP health path."""
+    tg = next(
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup"
+    )
+    props = tg["Properties"]
+    assert props["Port"] == 4318
+    assert props["Protocol"] == "HTTP"
+    assert props["HealthCheckPort"] == "13133"
+    assert props["HealthCheckPath"] == "/"
+    assert props["HealthCheckProtocol"] == "HTTP"
+
+
 def test_listener_rule_priority_is_300(td):
     rule = next(
         r for r in td["Resources"].values()
@@ -128,7 +143,7 @@ def test_ecs_service_load_balancers_unconditional(td):
     lbs = svc["Properties"].get("LoadBalancers")
     assert isinstance(lbs, list), f"expected a plain list for LoadBalancers, got {lbs!r}"
     assert len(lbs) == 1
-    assert lbs[0]["ContainerPort"] == 4317
+    assert lbs[0]["ContainerPort"] == 4318
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the otel target group coming up **unhealthy** once the ALB attachment became unconditional (v0.0.69).

**Root cause:** the target group health-checked `HTTP GET /healthz` against port **4317**, which is the OTLP **gRPC** port. An HTTP/1.1 probe to a gRPC port never returns 200, so targets stayed unhealthy. (An HTTP/1.1 target group also can't actually proxy gRPC, and the `/v1/*` listener rule is an OTLP **HTTP** path prefix — the original config was internally inconsistent.)

**Fix:** point the ALB at OTLP/HTTP (4318):

- target group `Port: 4318`, `Protocol: HTTP`
- health check on the collector's `health_check` extension: `HealthCheckPort: 13133`, `HealthCheckPath: /` (HTTP 200)
- ECS `LoadBalancers` ContainerPort + task port mapping → 4318
- existing `/v1/*` listener rule (priority 300) unchanged — now matches `/v1/traces|metrics|logs`

The gRPC receiver (4317) stays reachable task-to-task via Cloud Map; it's just no longer ALB-exposed. This matches the reference helm chart's ingress (OTLP HTTP 4318) and the internal self-telemetry endpoint (`http://cardinal-otel...:4318`).

`build_target_group` gains an optional `health_check_port` for the split traffic/health-port case.

## Test plan

- `make build` (incl. cfn-lint): clean
- `make test`: 341 passed, 3 skipped (new: `test_target_group_serves_otlp_http_health_checks_13133`)