### PR TITLE
infra+maestro: seed org ingest key and pre-populate the Maestro org

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.21.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.28.1"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.24.0"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.39.1"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"

--- a/docs/superpowers/specs/2026-05-22-org-bootstrap-and-maestro-seed-design.md
+++ b/docs/superpowers/specs/2026-05-22-org-bootstrap-and-maestro-seed-design.md
@@ -1,0 +1,118 @@
+# Org bootstrap + Maestro seed design
+
+Status: approved 2026-05-22
+
+## Problem
+
+Two gaps surfaced after a fresh install:
+
+1. The canonical org has storage but no ingest API key. `cardinal_infrastructure.py`
+   seeds the `storage-profiles` SSM parameter for org
+   `12340000-0000-4000-8000-000000000000` but seeds `api-keys` as the empty list
+   `[]`. The org can store data but has no key to ingest with.
+2. Maestro starts with no org, no owner, and no lakerunner datasource. Org, owner,
+   and the "managed lakerunner" datasource are all created by hand through the
+   DEX-authenticated superadmin UI. The steady state we actually want -- one org,
+   owned by the admin, already wired to the local lakerunner -- has to be rebuilt
+   manually every install.
+
+The admin API key itself is already handled: lakerunner reads `ADMIN_INITIAL_API_KEY`
+(`internal/adminconfig`), and `services_control.py` already injects it from the
+`cardinal-admin-key` secret. No change needed there.
+
+## Canonical org
+
+One single-install org, referenced identically by Lakerunner and Maestro:
+
+- id: `12340000-0000-4000-8000-000000000000` (the existing placeholder; kept)
+- name: "My Organization"
+- owner: the `DexAdminEmail` parameter (the bundled superadmin)
+
+An `OrganizationId` parameter (default = that UUID) replaces the hardcoded copies
+so storage-profiles, api-keys, and the Maestro bootstrap all reference one value.
+
+## Workstream A -- org ingest key (this repo, `cardinal_infrastructure.py`)
+
+- Add `OrganizationId` parameter (default `12340000-0000-4000-8000-000000000000`).
+- Add `InitialIngestApiKey` `NoEcho` parameter (default empty). The operator supplies
+  it through their `do-not-commit-infra.sh` driver, since those carry the install's
+  real values; `data-setup.sh` is only a helper and is not on the operator's path.
+- `storage-profiles` SSM value: reference `${OrganizationId}` instead of the literal.
+- `api-keys` SSM value: when `InitialIngestApiKey` is set, seed a one-entry YAML list
+  (`organization_id` = `OrganizationId`, `keys` = `[InitialIngestApiKey]`); when empty,
+  keep `[]` (today's behavior, backward compatible).
+
+`OrganizationId` is not emitted as a stack output: the infra stack's outputs are
+contractually 1:1 with `data-setup.sh`, and the org id is a config constant, not a
+provisioned resource identifier. The root stack's `OrganizationId` parameter defaults
+to the same UUID, so no wiring is required; an operator overriding it must set the same
+value on both stacks. `data-setup.sh` (a helper that is off the operator's path) is left
+seeding `api-keys` as `[]`; the operator-facing seed lives in the infra stack.
+
+The `api-keys` SSM parameter is plaintext YAML by design (an `AWS::SSM::Parameter`
+cannot be a `SecureString` in CloudFormation), so the key lands in plaintext SSM
+regardless; `NoEcho` only keeps it out of the CloudFormation console echo. This is
+the existing accepted posture for this parameter.
+
+This bootstrap ingest key is independent of any keys Maestro later provisions through
+the admin API. Maestro starts with zero ingest keys, so there is no conflict; the two
+key sets coexist.
+
+## Workstream B -- Maestro bootstrap (upstream, `cardinalhq/conductor`)
+
+File a feature issue for an idempotent, seed-if-missing startup bootstrap in
+`packages/maestro`, gated on the env contract below. When the env vars are present
+and the rows are absent, it creates:
+
+1. a user = `MAESTRO_BOOTSTRAP_OWNER_EMAIL`,
+2. an org = `MAESTRO_BOOTSTRAP_ORG_ID` / `MAESTRO_BOOTSTRAP_ORG_NAME`, with that user
+   as an `owner` membership (`maestro_org_memberships`),
+3. a `shared_cardinal` row in `maestro_lakerunner_deployments` with `admin_api_url`,
+   `admin_api_key`, `query_api_url`, and `auto_add_to_all_orgs = true`.
+
+It reuses existing machinery: `isAutoAddEligible` + the shared-install reconciler
+(`lakerunner-shared-install-reconciler.ts`) already enqueue a `provision_org` job per
+org, and `executeProvisionOrg` (`lakerunner-provisioning.ts`) calls lakerunner's admin
+API live (`createLakerunnerAdminClient` -> `provisionOrganization`). Because that is an
+async, retrying job queue, no click and no CloudFormation ordering dependency are
+needed: if admin-api is not reachable yet, the job retries until it is.
+
+Maestro reaches the admin API over the ALB's self-signed cert; the maestro container
+already sets `NODE_TLS_REJECT_UNAUTHORIZED=0`, so the call is not rejected.
+
+## Workstream C -- Maestro env wiring (this repo, `maestro.py` + `root.py`)
+
+Thread the bootstrap contract into the `maestro` container. Implemented now even
+though conductor does not read the vars yet -- they are inert until the feature ships,
+and the same person owns both ends of the contract, so the names will not drift.
+
+| Env var | Source |
+|---|---|
+| `MAESTRO_BOOTSTRAP_ORG_ID` | `Ref(OrganizationId)` |
+| `MAESTRO_BOOTSTRAP_ORG_NAME` | `Ref(OrgName)` (param, default "My Organization") |
+| `MAESTRO_BOOTSTRAP_OWNER_EMAIL` | `Ref(DexAdminEmail)` |
+| `MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL` | `Sub("https://${AlbDnsName}")` |
+| `MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL` | `Sub("https://${AlbDnsName}:9443")` |
+| `MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY` | secret -> `${AdminApiKeySecretArn}:key::` |
+
+New maestro.yaml parameters: `AdminApiKeySecretArn` (matches the services-control name;
+root passes `Ref("AdminKeySecretArn")`), `OrganizationId`, `OrgName`. Root gains
+`OrganizationId` (default UUID) and `OrgName` (default "My Organization") parameters and
+forwards all three to the maestro child.
+
+The query endpoint base is `https://<alb>` (query-api serves `/api/v1/...` on the main
+443 listener); the admin endpoint is `https://<alb>:9443` (admin-api's dedicated
+catch-all listener).
+
+## Testing
+
+- `make build` (cfn-lint clean).
+- Per-template assertions: infra api-keys seeded with org+key when the parameter is set
+  and `[]` when empty; storage-profiles references `OrganizationId`; maestro container
+  carries the six bootstrap env entries and the admin-key secret; root forwards the new
+  parameters to the maestro child.
+
+## Out of scope
+
+- The conductor feature implementation (tracked by the workstream-B issue).
+- Any change to `ADMIN_INITIAL_API_KEY` on the lakerunner side (already works).

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -42,6 +42,7 @@ from troposphere import (
     Equals,
     GetAtt,
     If,
+    Not,
     Output,
     Parameter,
     Ref,
@@ -230,12 +231,40 @@ def build() -> Template:
             AllowedPattern=r"^/[A-Za-z0-9._/-]{1,1011}$",
         )
     )
+    organization_id = t.add_parameter(
+        Parameter(
+            "OrganizationId",
+            Type="String",
+            Default="12340000-0000-4000-8000-000000000000",
+            Description=(
+                "Canonical single-install organization UUID. Used in both the "
+                "storage-profiles and api-keys SSM seeds; thread the same value "
+                "into the lakerunner stack's OrganizationId parameter."
+            ),
+            AllowedPattern=(
+                r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            ),
+        )
+    )
     license_data = add_no_echo_parameter(
         t,
         "LicenseData",
         description=(
             "Cardinal license token (z64:...). Stored verbatim as the "
             "string body of the license secret."
+        ),
+    )
+    # api-keys is plaintext YAML by design (an SSM parameter cannot be a
+    # SecureString in CloudFormation), so this key lands in plaintext SSM
+    # regardless; NoEcho only keeps it out of the console echo.
+    initial_ingest_api_key = add_no_echo_parameter(
+        t,
+        "InitialIngestApiKey",
+        default="",
+        description=(
+            "Ingest API key seeded into the api-keys SSM parameter for "
+            "OrganizationId. Leave blank to seed an empty list (no key)."
         ),
     )
 
@@ -266,6 +295,10 @@ def build() -> Template:
                 "parameters": ["LicenseData"],
             },
             {
+                "label": "Organization",
+                "parameters": ["OrganizationId", "InitialIngestApiKey"],
+            },
+            {
                 "label": "Recovery overrides (advanced)",
                 "parameters": [
                     "LicenseSecretName",
@@ -284,6 +317,8 @@ def build() -> Template:
             "IngestBucketName": "Ingest bucket name (blank = default)",
             "IngestBucketLifecycleDays": "Ingest object retention (days)",
             "LicenseData": "License token (z64:...)",
+            "OrganizationId": "Organization UUID",
+            "InitialIngestApiKey": "Initial ingest API key (blank = none)",
         },
     )
 
@@ -294,6 +329,11 @@ def build() -> Template:
     t.add_condition(
         "UseDefaultBucketName",
         Equals(Ref(ingest_bucket_name), ""),
+    )
+
+    t.add_condition(
+        "HasInitialIngestApiKey",
+        Not(Equals(Ref(initial_ingest_api_key), "")),
     )
 
     bucket_name_value = If(
@@ -516,7 +556,7 @@ def build() -> Template:
                 Name=Ref(storage_profiles_param_name),
                 Type="String",
                 Value=Sub(
-                    "- organization_id: 12340000-0000-4000-8000-000000000000\n"
+                    "- organization_id: ${OrgId}\n"
                     "  instance_num: 1\n"
                     "  collector_name: lakerunner\n"
                     "  cloud_provider: aws\n"
@@ -524,6 +564,7 @@ def build() -> Template:
                     "  bucket: ${BucketName}\n"
                     "  insecure_tls: false\n"
                     "  use_path_style: true\n",
+                    OrgId=Ref(organization_id),
                     BucketName=bucket_name_value,
                 ),
                 Description="Cardinal storage profiles (YAML; operator-managed).",
@@ -544,7 +585,17 @@ def build() -> Template:
                 "ApiKeysParam",
                 Name=Ref(api_keys_param_name),
                 Type="String",
-                Value="[]",
+                Value=If(
+                    "HasInitialIngestApiKey",
+                    Sub(
+                        "- organization_id: ${OrgId}\n"
+                        "  keys:\n"
+                        "    - ${Key}\n",
+                        OrgId=Ref(organization_id),
+                        Key=Ref(initial_ingest_api_key),
+                    ),
+                    "[]",
+                ),
                 Description="Cardinal external API keys (YAML; operator-managed).",
                 Tags={
                     "Application": APPLICATION,

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -147,6 +147,17 @@ def build() -> Template:
             Description="ARN of the license Secrets Manager secret.",
         )
     )
+    t.add_parameter(
+        Parameter(
+            "AdminApiKeySecretArn",
+            Type="String",
+            Description=(
+                "ARN of the cardinal-admin-key secret. Mounted into the maestro "
+                "container as MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY so the "
+                "seeded lakerunner datasource holds the same key admin-api validates."
+            ),
+        )
+    )
 
     # MigrationComplete is unused on purpose (same convention as services-*).
     # The root passes the migration-stack output through this parameter so
@@ -239,6 +250,26 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
+            "OrganizationId",
+            Type="String",
+            Default="12340000-0000-4000-8000-000000000000",
+            Description=(
+                "Canonical single-install organization UUID. Seeded as the org "
+                "Maestro pre-populates; matches the lakerunner storage-profiles / "
+                "api-keys org so both sides own the same data feed."
+            ),
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "OrgName",
+            Type="String",
+            Default="My Organization",
+            Description="Display name for the pre-populated organization.",
+        )
+    )
+    t.add_parameter(
+        Parameter(
             "McpMigrateRecoverFromDirty",
             Type="String",
             Default="false",
@@ -283,8 +314,13 @@ def build() -> Template:
                     "DbPort",
                     "DbSecretArn",
                     "LicenseSecretArn",
+                    "AdminApiKeySecretArn",
                     "MigrationComplete",
                 ],
+            },
+            {
+                "label": "Organization bootstrap",
+                "parameters": ["OrganizationId", "OrgName"],
             },
             {
                 "label": "Maestro tunables",
@@ -465,9 +501,29 @@ def build() -> Template:
             # token has groups=[], so without this the DEX admin lands on
             # /onboard with no way to bootstrap an org.
             Environment(Name="OIDC_SUPERADMIN_EMAILS", Value=Ref("OidcSuperadminEmails")),
+            # Idempotent seed-if-missing bootstrap: org + owner + a
+            # shared_cardinal lakerunner datasource (auto_add_to_all_orgs).
+            # The query endpoint is the main 443 listener; the admin endpoint
+            # is admin-api's dedicated 9443 listener. NODE_TLS_REJECT_UNAUTHORIZED=0
+            # (set above) lets the bootstrap reach them over the self-signed cert.
+            Environment(Name="MAESTRO_BOOTSTRAP_ORG_ID", Value=Ref("OrganizationId")),
+            Environment(Name="MAESTRO_BOOTSTRAP_ORG_NAME", Value=Ref("OrgName")),
+            Environment(Name="MAESTRO_BOOTSTRAP_OWNER_EMAIL", Value=Ref("DexAdminEmail")),
+            Environment(
+                Name="MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL",
+                Value=Sub("https://${AlbDnsName}"),
+            ),
+            Environment(
+                Name="MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL",
+                Value=Sub("https://${AlbDnsName}:9443"),
+            ),
         ],
         Secrets=list(db_secrets) + [
             Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
+            Secret(
+                Name="MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY",
+                ValueFrom=Sub("${AdminApiKeySecretArn}:key::"),
+            ),
         ],
         DependsOn=[
             {"ContainerName": "db-init", "Condition": "SUCCESS"},

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -286,6 +286,22 @@ def build() -> Template:
         ),
     ))
     t.add_parameter(Parameter(
+        "OrganizationId",
+        Type="String",
+        Default="12340000-0000-4000-8000-000000000000",
+        Description=(
+            "Canonical single-install organization UUID. Must match the value "
+            "the infrastructure stack seeded into storage-profiles / api-keys; "
+            "Maestro pre-populates this org and wires it to the local lakerunner."
+        ),
+    ))
+    t.add_parameter(Parameter(
+        "OrgName",
+        Type="String",
+        Default="My Organization",
+        Description="Display name for the org Maestro pre-populates.",
+    ))
+    t.add_parameter(Parameter(
         "TemplateBaseUrl",
         Type="String",
         Default=DEFAULT_TEMPLATE_BASE_URL,
@@ -386,6 +402,7 @@ def build() -> Template:
              "parameters": ["DeployMaestro", "SelfTelemetry",
                             "DexAdminEmail", "DexAdminPasswordHash",
                             "OidcSuperadminEmails",
+                            "OrganizationId", "OrgName",
                             "TemplateBaseUrl"]},
         ],
     )
@@ -582,6 +599,9 @@ def build() -> Template:
         "DexAdminEmail": Ref("DexAdminEmail"),
         "DexAdminPasswordHash": Ref("DexAdminPasswordHash"),
         "OidcSuperadminEmails": Ref("OidcSuperadminEmails"),
+        "AdminApiKeySecretArn": Ref("AdminKeySecretArn"),
+        "OrganizationId": Ref("OrganizationId"),
+        "OrgName": Ref("OrgName"),
     }, depends_on=["MigrationStack"], condition="DeployMaestroEnabled")
 
     # ---------------------------------------------------------------------

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -123,8 +123,17 @@ def test_ssm_seeds_render_nonempty_yaml_lists(td):
     for field in ("organization_id", "collector_name", "cloud_provider", "region", "bucket"):
         assert field in body, f"storage profile missing {field}"
 
+    # api-keys is conditional: a one-entry YAML list when InitialIngestApiKey is
+    # set, otherwise "[]". Both branches must be YAML lists (never a "{}" map).
     ak = td["Resources"]["ApiKeysParam"]["Properties"]["Value"]
-    assert ak == "[]", f"api keys must seed an empty list, got: {ak!r}"
+    seeded, empty = ak["Fn::If"][1], ak["Fn::If"][2]
+    assert ak["Fn::If"][0] == "HasInitialIngestApiKey"
+    assert empty == "[]"
+    seeded_body = seeded["Fn::Sub"][0]
+    assert seeded_body.lstrip().startswith("- "), seeded_body
+    assert "{}" not in seeded_body
+    for field in ("organization_id", "keys"):
+        assert field in seeded_body, f"api-keys seed missing {field}"
 
 
 def test_creates_ingest_bucket_and_queue(td):

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -245,6 +245,32 @@ def test_maestro_container_env_has_db_settings(td):
         assert n in env_names, f"maestro env missing {n}"
 
 
+def test_maestro_container_has_bootstrap_env(td):
+    """Org/owner/datasource seed contract consumed by the conductor feature."""
+    maestro_c = _container(td, "maestro")
+    env = {e["Name"]: e["Value"] for e in maestro_c.get("Environment", [])}
+    assert env["MAESTRO_BOOTSTRAP_ORG_ID"] == {"Ref": "OrganizationId"}
+    assert env["MAESTRO_BOOTSTRAP_ORG_NAME"] == {"Ref": "OrgName"}
+    assert env["MAESTRO_BOOTSTRAP_OWNER_EMAIL"] == {"Ref": "DexAdminEmail"}
+    assert env["MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL"]["Fn::Sub"] == "https://${AlbDnsName}"
+    assert (
+        env["MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL"]["Fn::Sub"]
+        == "https://${AlbDnsName}:9443"
+    )
+
+
+def test_maestro_container_admin_api_key_from_secret(td):
+    """The seeded datasource's admin key is the same cardinal-admin-key secret
+    that admin-api validates via ADMIN_INITIAL_API_KEY."""
+    maestro_c = _container(td, "maestro")
+    secrets = {s["Name"]: s["ValueFrom"] for s in maestro_c.get("Secrets", [])}
+    assert "AdminApiKeySecretArn" in td["Parameters"]
+    assert (
+        secrets["MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY"]["Fn::Sub"]
+        == "${AdminApiKeySecretArn}:key::"
+    )
+
+
 def test_maestro_container_db_user_and_password_from_master_secret(td):
     """User and password both come from the master DB secret (no maestro role)."""
     maestro_c = _container(td, "maestro")


### PR DESCRIPTION
## What

Makes the canonical single-install org real on both sides of the product, so a fresh install reaches the steady state — one org (`12340000-…`, "My Organization"), owned by the admin, with a working ingest key and a Maestro datasource wired to the local lakerunner — without manual UI steps.

### Org ingest key (`cardinal_infrastructure.py`)

The infra stack seeded `storage-profiles` for org `12340000-…` but seeded `api-keys` as `[]`, so the org could store data but had no key to ingest with.

- New `OrganizationId` parameter (default `12340000-0000-4000-8000-000000000000`), referenced from the storage-profiles seed instead of a hardcoded literal.
- New `NoEcho` `InitialIngestApiKey` parameter. When set, `api-keys` is seeded as a one-entry YAML list (`organization_id` + `keys`); when blank, it stays `[]` (backward compatible). Operators supply the key through their `do-not-commit-infra.sh` driver.

### Maestro org/datasource bootstrap wiring (`maestro.py`, `root.py`)

Threads a `MAESTRO_BOOTSTRAP_*` env contract into the maestro container so the upstream conductor bootstrap (cardinalhq/conductor#784) can seed the org, its owner, and a `shared_cardinal` lakerunner datasource:

- `MAESTRO_BOOTSTRAP_ORG_ID` / `ORG_NAME` / `OWNER_EMAIL` (owner = `DexAdminEmail`)
- `MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL` = `https://${AlbDnsName}`
- `MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL` = `https://${AlbDnsName}:9443`
- `MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_KEY` from the `cardinal-admin-key` secret (same key admin-api validates via `ADMIN_INITIAL_API_KEY`)

New `OrganizationId` / `OrgName` root parameters, plus `AdminApiKeySecretArn`, are forwarded to the maestro child. The env vars are inert until the conductor feature ships.

## Notes

- The admin API key itself already works end-to-end (`ADMIN_INITIAL_API_KEY` in lakerunner ↔ `cardinal-admin-key` secret); no lakerunner change was needed.
- `OrganizationId` is intentionally **not** an infra stack output: infra outputs are contractually 1:1 with `data-setup.sh`, and the org id is a config constant. Root's `OrganizationId` defaults to the same UUID, so no wiring is needed; override both stacks together if changing it.
- Provisioning is async (Maestro's reconciler + retrying `provision_org` job), so no CFN ordering dependency on admin-api is required.

## Testing

- `make build` (cfn-lint clean), `make test` — 343 passed (+2 new maestro contract tests).

Design spec: `docs/superpowers/specs/2026-05-22-org-bootstrap-and-maestro-seed-design.md`

Companion upstream work: cardinalhq/conductor#784 (Maestro bootstrap feature).
