### PR TITLE
services-control+maestro: maestro reaches lakerunner via Cloud Map (not the ALB)

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -127,6 +127,17 @@ def build() -> Template:
             Description="DNS name of the shared ALB (used to derive issuer URLs).",
         )
     )
+    t.add_parameter(
+        Parameter(
+            "ServiceNamespaceName",
+            Type="String",
+            Description=(
+                "Cloud Map private DNS namespace name (e.g. cardinal-<id>.local). "
+                "Used to reach lakerunner query-api and admin-api directly from "
+                "maestro without hairpinning through the ALB."
+            ),
+        )
+    )
     t.add_parameter(Parameter("DbEndpoint", Type="String", Description="RDS endpoint hostname."))
     t.add_parameter(Parameter("DbPort", Type="String", Default="5432", Description="RDS port."))
     t.add_parameter(
@@ -503,19 +514,24 @@ def build() -> Template:
             Environment(Name="OIDC_SUPERADMIN_EMAILS", Value=Ref("OidcSuperadminEmails")),
             # Idempotent seed-if-missing bootstrap: org + owner + a
             # shared_cardinal lakerunner datasource (auto_add_to_all_orgs).
-            # The query endpoint is the main 443 listener; the admin endpoint
-            # is admin-api's dedicated 9443 listener. NODE_TLS_REJECT_UNAUTHORIZED=0
-            # (set above) lets the bootstrap reach them over the self-signed cert.
+            # Both URLs point at the in-cluster Cloud Map names (query-api
+            # and admin-api both register a ServiceDiscovery::Service in
+            # ServicesQueryStack / ServicesControlStack), so maestro reaches
+            # lakerunner over plain HTTP on the task port and does NOT
+            # depend on the bundled self-signed ALB cert. The ALB
+            # attachments stay in place for any external/admin-UI callers.
+            # NODE_TLS_REJECT_UNAUTHORIZED=0 above is still needed for the
+            # DEX issuer / JWKS fetch, which continues to go via the ALB.
             Environment(Name="MAESTRO_BOOTSTRAP_ORG_ID", Value=Ref("OrganizationId")),
             Environment(Name="MAESTRO_BOOTSTRAP_ORG_NAME", Value=Ref("OrgName")),
             Environment(Name="MAESTRO_BOOTSTRAP_OWNER_EMAIL", Value=Ref("DexAdminEmail")),
             Environment(
                 Name="MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL",
-                Value=Sub("https://${AlbDnsName}"),
+                Value=Sub("http://query-api.${ServiceNamespaceName}:8080"),
             ),
             Environment(
                 Name="MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL",
-                Value=Sub("https://${AlbDnsName}:9443"),
+                Value=Sub("http://admin-api.${ServiceNamespaceName}:9091"),
             ),
         ],
         Secrets=list(db_secrets) + [

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -2,7 +2,10 @@
 
 Owns four ECS Fargate services:
 
-- admin-api (ALB-attached on dedicated 9443 listener; path catch-all `/*`)
+- admin-api (ALB-attached on dedicated 9443 listener; path catch-all `/*`,
+  also registered in Cloud Map as `admin-api.<namespace>:9091` so peers
+  inside the cluster — currently just maestro — can reach it without
+  hairpinning through the ALB and tripping the self-signed cert path)
 - sweeper (internal)
 - monitoring (internal; gRPC port not exposed on the ALB)
 - alert-evaluator (internal)
@@ -20,6 +23,11 @@ from troposphere import (
     Template,
 )
 from troposphere.ecs import Environment, Secret
+from troposphere.servicediscovery import (
+    DnsConfig,
+    DnsRecord,
+    Service as DiscoveryService,
+)
 
 from cardinal_cfn.children import services_common
 from cardinal_cfn.defaults import load_defaults
@@ -105,6 +113,17 @@ def build() -> Template:
             "ServiceNamespaceName",
             Type="String",
             Description="Cloud Map private DNS namespace name (e.g. cardinal-<id>.local).",
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "ServiceNamespaceId",
+            Type="String",
+            Description=(
+                "Cloud Map private DNS namespace ID. Used to register "
+                "admin-api so in-cluster peers (maestro) can reach it at "
+                "admin-api.<namespace>:9091 without going through the ALB."
+            ),
         )
     )
     t.add_parameter(Parameter("DbEndpoint", Type="String", Description="RDS endpoint hostname."))
@@ -346,6 +365,22 @@ def build() -> Template:
             container_port=admin_container_port,
         )
     )
+    # Register admin-api in Cloud Map so peers in the cluster (maestro) can
+    # reach it at http://admin-api.<namespace>:9091 without hairpinning out
+    # to the ALB's 9443 HTTPS listener. The ALB attachment stays for the
+    # external/admin-UI path; only the in-cluster maestro -> admin-api hop
+    # switches to the direct name (see children/maestro.py).
+    admin_discovery = t.add_resource(
+        DiscoveryService(
+            "AdminApiDiscoveryService",
+            Name="admin-api",
+            NamespaceId=Ref("ServiceNamespaceId"),
+            DnsConfig=DnsConfig(
+                DnsRecords=[DnsRecord(Type="A", TTL="10")],
+                RoutingPolicy="MULTIVALUE",
+            ),
+        )
+    )
     admin_service = t.add_resource(
         services_common.build_ecs_service(
             service_key="admin-api",
@@ -357,6 +392,7 @@ def build() -> Template:
             target_group_ref=admin_tg,
             container_name="admin-api",
             container_port=admin_container_port,
+            service_registry_ref=admin_discovery,
             listener_rule_refs=[admin_listener_rule],
         )
     )

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -536,6 +536,7 @@ def build() -> Template:
         "AdminApiKeySecretArn": Ref("AdminKeySecretArn"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceName": Ref("ServiceNamespaceName"),
+        "ServiceNamespaceId": Ref("ServiceNamespaceId"),
         "ClusterName": Ref("ClusterName"),
         "ProcessLogsServiceName":
             GetAtt(services_process_stack, "Outputs.ProcessLogsServiceName"),
@@ -583,6 +584,7 @@ def build() -> Template:
         "VpcId": Ref("VpcId"),
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
         "AlbDnsName": GetAtt(alb_stack, "Outputs.AlbDnsName"),
+        "ServiceNamespaceName": Ref("ServiceNamespaceName"),
         "DbEndpoint": Ref("DbEndpoint"),
         "DbPort": Ref("DbPort"),
         "DbSecretArn": Ref("DbMasterSecretArn"),

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -29,6 +29,7 @@ def test_required_cross_stack_parameters(td):
         "VpcId",
         "HttpsListenerArn",
         "AlbDnsName",
+        "ServiceNamespaceName",
         "DbEndpoint",
         "DbPort",
         "DbSecretArn",
@@ -252,10 +253,13 @@ def test_maestro_container_has_bootstrap_env(td):
     assert env["MAESTRO_BOOTSTRAP_ORG_ID"] == {"Ref": "OrganizationId"}
     assert env["MAESTRO_BOOTSTRAP_ORG_NAME"] == {"Ref": "OrgName"}
     assert env["MAESTRO_BOOTSTRAP_OWNER_EMAIL"] == {"Ref": "DexAdminEmail"}
-    assert env["MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL"]["Fn::Sub"] == "https://${AlbDnsName}"
+    assert (
+        env["MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL"]["Fn::Sub"]
+        == "http://query-api.${ServiceNamespaceName}:8080"
+    )
     assert (
         env["MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL"]["Fn::Sub"]
-        == "https://${AlbDnsName}:9443"
+        == "http://admin-api.${ServiceNamespaceName}:9091"
     )
 
 

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -133,6 +133,46 @@ def test_admin_https_listener_arn_parameter(td):
 
 
 # ---------------------------------------------------------------------------
+# Cloud Map registration for admin-api
+# ---------------------------------------------------------------------------
+
+
+def test_service_namespace_id_parameter_present(td):
+    """ServiceNamespaceId is forwarded from root so admin-api can register
+    a Cloud Map A record at admin-api.<namespace>:9091."""
+    assert "ServiceNamespaceId" in td["Parameters"]
+
+
+def test_admin_api_discovery_service_registered(td):
+    """admin-api gets a ServiceDiscovery::Service so peers in the cluster
+    (maestro) can reach it without going through the ALB."""
+    discoveries = {
+        logical_id: res
+        for logical_id, res in td["Resources"].items()
+        if res["Type"] == "AWS::ServiceDiscovery::Service"
+    }
+    assert "AdminApiDiscoveryService" in discoveries
+    props = discoveries["AdminApiDiscoveryService"]["Properties"]
+    assert props["Name"] == "admin-api"
+    assert props["NamespaceId"] == {"Ref": "ServiceNamespaceId"}
+    records = props["DnsConfig"]["DnsRecords"]
+    assert any(r["Type"] == "A" for r in records)
+
+
+def test_admin_api_service_has_service_registries(td):
+    """The admin-api ECS service must reference the discovery service so
+    its task IPs land in DNS."""
+    svc = next(
+        res
+        for logical_id, res in td["Resources"].items()
+        if res["Type"] == "AWS::ECS::Service" and logical_id.endswith("AdminApiService")
+    )
+    assert "ServiceRegistries" in svc["Properties"]
+    arn = svc["Properties"]["ServiceRegistries"][0]["RegistryArn"]
+    assert arn == {"Fn::GetAtt": ["AdminApiDiscoveryService", "Arn"]}
+
+
+# ---------------------------------------------------------------------------
 # ALB attachment differentiation
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Register admin-api in Cloud Map (mirrors what query-api already does), so peers in the cluster can reach it at `admin-api.<namespace>:9091` without hairpinning through the ALB.
- Switch maestro's two bootstrap URLs to the in-cluster Cloud Map names:
  - `MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL` -> `http://query-api.${ServiceNamespaceName}:8080`
  - `MAESTRO_BOOTSTRAP_LAKERUNNER_ADMIN_API_URL` -> `http://admin-api.${ServiceNamespaceName}:9091`

ALB target group attachments stay in place; the 443 / 9443 listeners and their path rules are unchanged. Only the maestro -> lakerunner hop moves off the ALB.

## Why

The admin path forced `NODE_TLS_REJECT_UNAUTHORIZED=0` to tolerate the bundled self-signed ALB cert, which weakened every other outbound TLS call from the maestro container. Going direct over the in-cluster name lets us use plain HTTP on the task port, the same way alert-evaluator already reaches query-api on `:8080`. `NODE_TLS_REJECT_UNAUTHORIZED=0` stays set because the DEX issuer / JWKS fetch keeps using the ALB.

## Operator-visible caveats

- The customer-owned `TaskSgId` must permit intra-cluster TCP/9091 between tasks. TCP/8080 already works (alert-evaluator -> query-api), so most SGs are fine; 9091 has not been needed before, so it is worth checking before rolling this image out.
- The seeded `shared_cardinal` lakerunner datasource is rendered only at maestro's first run (idempotent seed-if-missing). Existing installs keep their old `https://${AlbDnsName}` URLs in `configdb`; this PR only affects fresh deploys. To migrate existing rows, either re-seed or update the datasource URL in the maestro admin UI after the next deploy.

## Test plan

- [x] `make check` (346 passed, 3 pre-existing skips)
- [x] `make build` (cfn-lint clean)
- [x] New unit tests added: `AdminApiDiscoveryService` exists, `ServiceRegistries` wired, `ServiceNamespaceId` declared, both maestro URLs use the direct names.
- [ ] Deploy to a dev install and confirm maestro -> admin-api succeeds without `NODE_TLS_REJECT_UNAUTHORIZED=0`. (We are not removing that env in this PR; DEX still needs it.)