### PR TITLE
images: bump maestro to v1.43.11

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,7 +34,7 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.24.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.39.1"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.43.11"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
   dex:        "ghcr.io/dexidp/dex:v2.41.1"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
Carries cardinalhq/conductor#818 — failed-sync-job surfacing + accept http:// admin URLs at the runtime client + route-side URL validation. The in-cluster Cloud Map path landed in v0.0.72; this is the maestro image that actually supports speaking http to admin-api over Cloud Map.