### PR TITLE
migration: ensure-storage-profile sidecar so canonical org self-heals

### DIFF
--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -1,20 +1,33 @@
 """migration.yaml nested stack: DB migrator task definition + a long-running
 ECS service that runs the migrator once and then sleeps.
 
-No Lambda. The migrator task definition has three containers:
+No Lambda. The migrator task definition has four containers:
 
   1. configdb-init (non-essential): psql CREATE DATABASE configdb if absent.
   2. migrator (non-essential): `lakerunner migrate --databases=lrdb,configdb`,
      dependsOn configdb-init=COMPLETE.
-  3. keepalive (essential): sleeps forever, dependsOn migrator=SUCCESS.
+  3. ensure-storage-profile (non-essential): idempotent psql upsert that
+     guarantees the canonical single-install storage_profile row exists in
+     configdb.bucket_configurations + configdb.organization_buckets. The
+     lakerunner image's initializeIfNeededFunc only seeds configdb when those
+     tables are empty, so installs whose first migration landed before
+     #117 (the storage-profiles {} bug) or which got partially seeded under
+     a different org/collector never get the canonical row -- ingest still
+     works via the otel-collector path, but maestro UI queries (post-#121)
+     run as the canonical 12340000 org and fail with "storage profile not
+     found." This sidecar self-heals that on every image bump.
+  4. keepalive (essential): sleeps forever, dependsOn ensure-storage-profile=
+     SUCCESS. A failed upsert blocks keepalive -> the ECS deployment circuit
+     breaker fails the service -> the root stack rolls back. Loud, not silent.
 
 Because keepalive is the only essential container and ECS will not start it
-until migrator exits 0, the task is not RUNNING -- and therefore the ECS
-service is not at steady state, and therefore the MigrationStack nested stack
-is not CREATE_COMPLETE -- until migrations succeed. The service-tier stacks
-already DependsOn MigrationStack, so they only deploy after migrations run. An
-image change redeploys the service (new migrator run) before those stacks
-update, exactly as the old custom-resource trigger did.
+until its dependencies exit 0, the task is not RUNNING -- and therefore the
+ECS service is not at steady state, and therefore the MigrationStack nested
+stack is not CREATE_COMPLETE -- until migrations and the canonical-profile
+upsert both succeed. The service-tier stacks already DependsOn MigrationStack,
+so they only deploy after that gate clears. An image change redeploys the
+service (new migrator run + new upsert) before those stacks update, exactly
+as the old custom-resource trigger did.
 """
 
 from troposphere import (
@@ -86,6 +99,29 @@ def build() -> Template:
             "ApiKeysParamName",
             Type="String",
             Description="Name of the SSM parameter holding the api_keys YAML.",
+        )
+    )
+
+    # Inputs for the ensure-storage-profile sidecar. The canonical
+    # single-install org id and the ingest bucket name are exactly the values
+    # the SSM-driven seed would have written, so the sidecar's row is
+    # indistinguishable from a clean first-install seed.
+    t.add_parameter(
+        Parameter(
+            "OrgId",
+            Type="String",
+            Default="12340000-0000-4000-8000-000000000000",
+            Description=(
+                "Canonical single-install organization UUID. Must match the "
+                "infrastructure stack's storage-profiles/api-keys seed."
+            ),
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "IngestBucketName",
+            Type="String",
+            Description="Name of the S3 ingest bucket (infra-setup output).",
         )
     )
 
@@ -202,14 +238,75 @@ def build() -> Template:
         LogConfiguration=_logs("migrator"),
     )
 
+    # ensure-storage-profile: idempotent upsert that guarantees the canonical
+    # org's storage_profile row exists in configdb. Schema verified against
+    # the live lakerunner repo migrations (1755582182, 1755706737, 1755713265,
+    # 1755727712, 1755747368, 1755747422, 1755753938, 1779112554). ON CONFLICT
+    # uses bucket_configurations.bucket_name UNIQUE and the
+    # organization_buckets (organization_id, bucket_id, instance_num,
+    # collector_name) UNIQUE constraint -- both present on every live install.
+    # The legacy organization_id UNIQUE on organization_buckets was dropped in
+    # 1755727712 (allow_multiple_buckets_per_org), so this never collides with
+    # operator-added second buckets for the same org. DO NOTHING preserves
+    # operator edits made via the maestro UI.
+    #
+    # SQL goes in via stdin (not -c) so psql performs \set + :'var' client-side
+    # quoting -- psql's -c mode does not interpret :'var', and shell-substituting
+    # values into the SQL string would lean on parameter pattern hygiene the
+    # migration child does not own. The heredoc is UNQUOTED so $VARS expand via
+    # the shell before psql sees them; \set then re-quotes them properly for
+    # SQL via :'name' substitution inside the INSERT statements.
+    ensure_sp_container = ContainerDefinition(
+        Name="ensure-storage-profile",
+        Image=Ref("DbInitImage"),
+        Essential=False,
+        DependsOn=[ContainerDependency(ContainerName="migrator", Condition="SUCCESS")],
+        EntryPoint=["sh", "-c"],
+        Command=[
+            "set -e\n"
+            "export PGSSLMODE=require PGPASSWORD=\"$CONFIGDB_PASSWORD\"\n"
+            "psql -v ON_ERROR_STOP=1 \\\n"
+            "  -h \"$CONFIGDB_HOST\" -p \"$CONFIGDB_PORT\" \\\n"
+            "  -U \"$CONFIGDB_USER\" -d \"$CONFIGDB_DBNAME\" <<SQL\n"
+            "\\set bucket '$BUCKET_NAME'\n"
+            "\\set region '$AWS_REGION_NAME'\n"
+            "\\set org    '$ORG_ID'\n"
+            "INSERT INTO bucket_configurations\n"
+            "  (bucket_name, cloud_provider, region, use_path_style)\n"
+            "VALUES (:'bucket', 'aws', :'region', TRUE)\n"
+            "ON CONFLICT (bucket_name) DO NOTHING;\n"
+            "INSERT INTO organization_buckets\n"
+            "  (organization_id, bucket_id, instance_num, collector_name)\n"
+            "SELECT (:'org')::uuid, id, 1, 'lakerunner'\n"
+            "FROM bucket_configurations WHERE bucket_name = :'bucket'\n"
+            "ON CONFLICT (organization_id, bucket_id, instance_num, collector_name)\n"
+            "DO NOTHING;\n"
+            "SQL\n"
+        ],
+        Environment=[
+            Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
+            Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
+            Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
+            Environment(Name="BUCKET_NAME", Value=Ref("IngestBucketName")),
+            Environment(Name="AWS_REGION_NAME", Value=Ref("AWS::Region")),
+            Environment(Name="ORG_ID", Value=Ref("OrgId")),
+        ],
+        Secrets=[
+            Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
+            Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
+        ],
+        LogConfiguration=_logs("ensure-storage-profile"),
+    )
+
     keepalive_container = ContainerDefinition(
         Name="keepalive",
         Image=Ref("DbInitImage"),
-        # The single essential container. ECS will not start it until migrator
-        # exits 0, so the task -- and thus the service, and thus this nested
-        # stack -- only reaches a stable RUNNING state after migrations succeed.
+        # The single essential container. ECS will not start it until the
+        # canonical-profile upsert has exited 0, so the task -- and thus the
+        # service, and thus this nested stack -- only reaches a stable RUNNING
+        # state after both the migrator and the upsert succeed.
         Essential=True,
-        DependsOn=[ContainerDependency(ContainerName="migrator", Condition="SUCCESS")],
+        DependsOn=[ContainerDependency(ContainerName="ensure-storage-profile", Condition="SUCCESS")],
         EntryPoint=["sh", "-c"],
         Command=["echo 'migrations complete; idling'; exec sleep 2147483647"],
         LogConfiguration=_logs("keepalive"),
@@ -225,7 +322,12 @@ def build() -> Template:
             Memory="512",
             ExecutionRoleArn=Ref("ExecutionRoleArn"),
             TaskRoleArn=Ref("TaskRoleArn"),
-            ContainerDefinitions=[configdb_init_container, migrator_container, keepalive_container],
+            ContainerDefinitions=[
+                configdb_init_container,
+                migrator_container,
+                ensure_sp_container,
+                keepalive_container,
+            ],
             Tags=cardinal_tags(component="migration", role="migrator-task"),
         )
     )

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -468,6 +468,8 @@ def build() -> Template:
         "DbSecretArn": Ref("DbMasterSecretArn"),
         "StorageProfilesParamName": Ref("StorageProfilesParamName"),
         "ApiKeysParamName": Ref("ApiKeysParamName"),
+        "OrgId": Ref("OrganizationId"),
+        "IngestBucketName": Ref("IngestBucketName"),
         "LakerunnerImage": lakerunner_image,
         "DbInitImage": Ref("DbInitImage"),
     })

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -40,7 +40,8 @@ def test_required_parameters(template_dict):
               "TaskSecurityGroupId", "ExecutionRoleArn", "TaskRoleArn",
               "PrivateSubnetsCsv", "DbEndpoint", "DbSecretArn",
               "LakerunnerImage", "DbInitImage",
-              "StorageProfilesParamName", "ApiKeysParamName"):
+              "StorageProfilesParamName", "ApiKeysParamName",
+              "OrgId", "IngestBucketName"):
         assert n in template_dict["Parameters"], f"missing parameter: {n}"
 
 
@@ -98,8 +99,10 @@ def test_creates_task_definition(template_dict):
     assert "AWS::ECS::TaskDefinition" in _types(template_dict)
 
 
-def test_three_containers_present(template_dict):
-    assert set(_containers(template_dict)) == {"configdb-init", "migrator", "keepalive"}
+def test_four_containers_present(template_dict):
+    assert set(_containers(template_dict)) == {
+        "configdb-init", "migrator", "ensure-storage-profile", "keepalive",
+    }
 
 
 def test_exactly_one_essential_container(template_dict):
@@ -109,14 +112,54 @@ def test_exactly_one_essential_container(template_dict):
 
 
 def test_container_ordering_chain(template_dict):
+    """configdb-init -> migrator -> ensure-storage-profile -> keepalive. The
+    canonical-profile upsert sits on the keepalive critical path so any
+    failure surfaces as a stack rollback, not silent log noise."""
     cs = _containers(template_dict)
     assert "DependsOn" not in cs["configdb-init"]
     assert cs["migrator"]["DependsOn"] == [
         {"ContainerName": "configdb-init", "Condition": "COMPLETE"}
     ]
-    assert cs["keepalive"]["DependsOn"] == [
+    assert cs["ensure-storage-profile"]["DependsOn"] == [
         {"ContainerName": "migrator", "Condition": "SUCCESS"}
     ]
+    assert cs["keepalive"]["DependsOn"] == [
+        {"ContainerName": "ensure-storage-profile", "Condition": "SUCCESS"}
+    ]
+
+
+def test_ensure_storage_profile_is_non_essential(template_dict):
+    """It runs the upsert once and exits; keepalive's DependsOn=SUCCESS is
+    what gates task stability on a clean exit."""
+    assert _containers(template_dict)["ensure-storage-profile"].get("Essential") is False
+
+
+def test_ensure_storage_profile_upsert_is_idempotent(template_dict):
+    """SQL must use ON CONFLICT DO NOTHING on both inserts so re-runs after
+    operator edits never clobber existing rows."""
+    cmd = " ".join(_containers(template_dict)["ensure-storage-profile"]["Command"])
+    cmd_oneline = " ".join(cmd.split())  # collapse all whitespace
+    assert "ON CONFLICT (bucket_name) DO NOTHING" in cmd_oneline
+    assert (
+        "ON CONFLICT (organization_id, bucket_id, instance_num, collector_name) DO NOTHING"
+        in cmd_oneline
+    )
+    # collector_name must match the SSM-driven seed in cardinal_infrastructure
+    assert "'lakerunner'" in cmd_oneline
+
+
+def test_ensure_storage_profile_uses_configdb_credentials(template_dict):
+    """Sidecar reads CONFIGDB_* env + secrets and connects with sslmode=require."""
+    c = _containers(template_dict)["ensure-storage-profile"]
+    env = {e["Name"]: e["Value"] for e in c["Environment"]}
+    assert env["CONFIGDB_DBNAME"] == "configdb"
+    assert {"Ref": "DbEndpoint"} == env["CONFIGDB_HOST"]
+    assert {"Ref": "IngestBucketName"} == env["BUCKET_NAME"]
+    assert {"Ref": "OrgId"} == env["ORG_ID"]
+    secrets = {s["Name"] for s in c["Secrets"]}
+    assert {"CONFIGDB_USER", "CONFIGDB_PASSWORD"} <= secrets
+    cmd = " ".join(c["Command"])
+    assert "PGSSLMODE=require" in cmd
 
 
 def test_migrator_container_uses_lakerunner_image(template_dict):


### PR DESCRIPTION
## Summary

- Adds a 4th container, `ensure-storage-profile`, between `migrator` and `keepalive` in the migrator task definition. It runs an idempotent `INSERT ... ON CONFLICT DO NOTHING` upsert against `bucket_configurations` + `organization_buckets` to guarantee the canonical org's storage profile exists in configdb on every deploy.
- Flips `keepalive`'s `DependsOn` from `migrator=SUCCESS` to `ensure-storage-profile=SUCCESS`, so a failed upsert surfaces as a stack rollback (deployment circuit breaker), not silent log noise.
- Threads `OrgId` + `IngestBucketName` from the root into the migration child.

## Why

`initializeIfNeededFunc` in the lakerunner image only seeds configdb when those two tables are empty. Installs that:

- ran first migration before #117 (the storage-profiles `{}` bug), or
- got partial seeding under a different org / collector,

never get the canonical `12340000-0000-4000-8000-000000000000` row. Post-#121 the maestro UI issues queries as that canonical org and gets `storage profile not found` -- a non-recoverable state in deploy environments that don't have a DB console. Ingest still works (otel-collector path doesn't read the same row), masking the symptom until someone runs an interactive query.

The sidecar is idempotent: it runs on every migrator task replacement (every `LakerunnerImage` bump), and `DO NOTHING` preserves operator edits made via maestro/admin-api.

## How it's safe

- Schema verified against live prod configdb via `lakerunner-readonly`:
  - `bucket_configurations` UNIQUE on `bucket_name` (`lrconfig_bucket_configurations_bucket_name_key`) -- present.
  - `organization_buckets` UNIQUE on `(organization_id, bucket_id, instance_num, collector_name)` (`organization_buckets_org_bucket_instance_collector_unique`) -- present.
  - Legacy `organization_id UNIQUE` on `organization_buckets` was dropped in migration `1755727712_allow_multiple_buckets_per_org` -- confirmed absent live, so the upsert never collides with operator-added second buckets.
- SQL parsed against live schema by executing the exact rendered command body under `BEGIN; ... ROLLBACK;` -- read-only role rejected the INSERT at the PERMISSION layer (proving the SQL is syntactically valid against the live schema).
- SQL goes in via stdin heredoc + psql `\set` + `:'var'`, so psql performs client-side quoting. No shell-substituted values land inside the SQL string, no SQL injection surface.
- `use_path_style=TRUE` matches the SSM YAML in `cardinal_infrastructure.py:565` exactly, so the sidecar's row is indistinguishable from a clean first-install seed.
- `collector_name='lakerunner'` matches both `data-setup.sh` and `cardinal_infrastructure.py` SSM seeds.

## Test plan

- [x] `make build` -- all templates regenerate; cfn-lint clean
- [x] `make test` -- 349 passed, 3 skipped (added 4 new tests: container ordering, non-essential flag, idempotent upsert, configdb-cred wiring)
- [x] SQL ground-truthed against live prod configdb (BEGIN/ROLLBACK with `lakerunner-readonly`)
- [ ] Cut v0.0.74 and deploy to test account 493746473138 to confirm sidecar succeeds on a clean install
- [ ] Customer at 167872550306 bumps `VERSION="v0.0.74"` and observes canonical row appearing in configdb after the migrator task replacement