### PR TITLE
otel: export OtelInternalUrl output for in-VPC OTLP/HTTP callers

### DIFF
--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -143,6 +143,16 @@ def build() -> Template:
             ),
         )
     )
+    t.add_parameter(
+        Parameter(
+            "ServiceNamespaceName",
+            Type="String",
+            Description=(
+                "Cloud Map private DNS namespace name (e.g. cardinal.local). "
+                "Used only to compose the OtelInternalUrl output."
+            ),
+        )
+    )
 
     # ---------------------------------------------------------------------
     # Image override
@@ -226,6 +236,7 @@ def build() -> Template:
                     "HttpsListenerArn",
                     "VpcId",
                     "ServiceNamespaceId",
+                    "ServiceNamespaceName",
                 ],
             },
             {
@@ -385,6 +396,17 @@ def build() -> Template:
         Output(
             "OtelEndpoint",
             Value=Sub(f"alb:${{HttpsListenerArn}}:{_OTLP_HTTP_PORT}"),
+        )
+    )
+    # In-cluster OTLP/HTTP URL via Cloud Map service discovery. Consumers that
+    # want a directly-dialable endpoint (instead of building one themselves
+    # from the service name and namespace) read this output.
+    t.add_output(
+        Output(
+            "OtelInternalUrl",
+            Value=Sub(
+                f"http://cardinal-otel.${{ServiceNamespaceName}}:{_OTLP_HTTP_PORT}"
+            ),
         )
     )
     t.add_output(Output("OtelServiceName", Value=GetAtt(service, "Name")))

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -568,6 +568,7 @@ def build() -> Template:
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceId": Ref("ServiceNamespaceId"),
+        "ServiceNamespaceName": Ref("ServiceNamespaceName"),
         "OtelImage": otel_image,
         "OtelReplicas": Ref("OtelReplicas"),
         "OtelCpu": Ref("OtelCpu"),


### PR DESCRIPTION
## Summary

- The existing \`OtelEndpoint\` output is a synthetic \`alb:<listener-arn>:4318\` descriptor -- not a directly-dialable URL or an ARN.
- Add an \`OtelInternalUrl\` output that resolves to \`http://cardinal-otel.\${ServiceNamespaceName}:4318\` -- the Cloud Map service-discovery URL lakerunner self-telemetry already constructs.
- Threads \`ServiceNamespaceName\` from the root into the otel child so the child can compose the URL.

Note: this URL only resolves from inside the VPC (or anywhere using the VPC's resolver). External callers should continue to use the ALB on HTTPS \`/v1/*\`.

## Test plan

- [x] \`make build\` -- regenerates templates, cfn-lint clean
- [x] Verified \`OtelInternalUrl\` output and \`ServiceNamespaceName\` parameter present in \`generated-templates/cardinal-lakerunner/otel.yaml\`
- [ ] Optional: deploy to the lakerunner test account and confirm the output value