### PR TITLE
otel: expose ALB DNS name + bump CI actions off Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
       CARDINAL_BUCKET_NAME: cardinal-cfn-us-east-1
       CARDINAL_BUCKET_REGION: us-east-1
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 
@@ -51,7 +51,7 @@ jobs:
           source .venv/bin/activate
           ./build.sh
 
-      - uses: aws-actions/configure-aws-credentials@v4
+      - uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::992382549843:role/cardinal-cfn-publisher
           aws-region: ${{ env.AWS_REGION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
       - name: Install dependencies

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -130,6 +130,17 @@ def build() -> Template:
         Parameter("HttpsListenerArn", Type="String", Description="ARN of the ALB HTTPS listener.")
     )
     t.add_parameter(
+        Parameter(
+            "AlbDnsName",
+            Type="String",
+            Description=(
+                "AWS-assigned ALB DNS name (e.g. internal-cardinal-...elb.amazonaws.com). "
+                "Surfaced as an output for callers that prefer the ALB path over "
+                "Cloud Map service discovery."
+            ),
+        )
+    )
+    t.add_parameter(
         Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="VPC ID (forwarded from root).")
     )
     t.add_parameter(
@@ -234,6 +245,7 @@ def build() -> Template:
                     "QueueArn",
                     "LicenseSecretArn",
                     "HttpsListenerArn",
+                    "AlbDnsName",
                     "VpcId",
                     "ServiceNamespaceId",
                     "ServiceNamespaceName",
@@ -407,6 +419,16 @@ def build() -> Template:
             Value=Sub(
                 f"http://cardinal-otel.${{ServiceNamespaceName}}:{_OTLP_HTTP_PORT}"
             ),
+        )
+    )
+    # AWS-assigned ALB DNS name -- publicly resolvable but resolves to private
+    # IPs (the ALB is internal-scheme). Useful for callers with VPC reachability
+    # that prefer the ALB path (HTTPS, /v1/* listener rule) over Cloud Map.
+    t.add_output(Output("OtelAlbDnsName", Value=Ref("AlbDnsName")))
+    t.add_output(
+        Output(
+            "OtelExternalUrl",
+            Value=Sub("https://${AlbDnsName}"),
         )
     )
     t.add_output(Output("OtelServiceName", Value=GetAtt(service, "Name")))

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -566,6 +566,7 @@ def build() -> Template:
         "QueueArn": Ref("IngestQueueArn"),
         "LicenseSecretArn": Ref("LicenseSecretArn"),
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
+        "AlbDnsName": GetAtt(alb_stack, "Outputs.AlbDnsName"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceId": Ref("ServiceNamespaceId"),
         "ServiceNamespaceName": Ref("ServiceNamespaceName"),


### PR DESCRIPTION
## Summary

- \`otel.yaml\` now also outputs \`OtelAlbDnsName\` (the AWS-assigned \`internal-...elb.amazonaws.com\` hostname) and \`OtelExternalUrl\` (\`https://\${AlbDnsName}\`), alongside the existing \`OtelInternalUrl\` (Cloud Map URL). Caller can pick whichever path matches their network reachability.
- Threads \`AlbDnsName\` from the root into the otel child.
- Bumps \`actions/checkout\` v4 -> v6, \`actions/setup-python\` v5 -> v6, and \`aws-actions/configure-aws-credentials\` v4 -> v6 across \`release.yml\` and \`test.yml\`. Clears the Node 20 deprecation warning surfaced on the v0.0.75 release run.

The ALB is \`Scheme=internal\`, so the DNS name is publicly resolvable but resolves to RFC1918 IPs -- usable from in-VPC, peered VPCs, VPN/TGW/Direct Connect, not the open internet.

## Test plan

- [x] \`make build\` -- regenerates templates, cfn-lint clean
- [x] Verified the four otel outputs (\`OtelEndpoint\`, \`OtelInternalUrl\`, \`OtelExternalUrl\`, \`OtelAlbDnsName\`) in \`generated-templates/cardinal-lakerunner/otel.yaml\`
- [ ] Test workflow runs green on this PR (exercises the new \`actions/checkout@v6\` + \`setup-python@v6\`)
- [ ] Optional: tag drives \`release.yml\` against \`aws-actions/configure-aws-credentials@v6\`