### PR TITLE
otel: move ALB attachment to dedicated plain-HTTP listener on 4318

### DIFF
--- a/src/cardinal_cfn/children/alb.py
+++ b/src/cardinal_cfn/children/alb.py
@@ -1,8 +1,13 @@
-"""alb.yaml nested stack: ALB and HTTPS listeners (443 / 9443).
+"""alb.yaml nested stack: ALB and listeners (HTTPS 443 / 9443, HTTP 4318).
 
 The ALB security group and the ALB-to-task ingress rules are customer-owned
 (see ``docs/operations/required-roles.md``); this stack consumes the SG ID
 and never creates or mutates security groups.
+
+The OTel listener is HTTP (not HTTPS): the ALB is internal-scheme and the
+deployment model assumes the caller has VPC-layer reachability (peering /
+TGW / VPN). Plain OTLP/HTTP on 4318 matches the target group's protocol
+and removes the need to install the ALB cert on external senders.
 """
 
 from troposphere import (
@@ -122,10 +127,37 @@ def build() -> Template:
         )
     )
 
+    # Dedicated plain-HTTP listener for the OTel collector on the canonical
+    # OTLP/HTTP port (4318). Internal-scheme ALB + caller-owned VPC
+    # reachability means TLS termination at the ALB adds no value over the
+    # underlying peering encryption; serving plain HTTP keeps SDK clients on
+    # http://<alb>:4318 without needing the ALB cert in their trust store.
+    # The collector rule (registered from otel.py) owns this listener; the
+    # default 404 only fires for non-OTLP paths.
+    otel_listener = t.add_resource(
+        Listener(
+            "OtelHttpListener",
+            LoadBalancerArn=Ref(alb),
+            Port=4318,
+            Protocol="HTTP",
+            DefaultActions=[
+                Action(
+                    Type="fixed-response",
+                    FixedResponseConfig=FixedResponseConfig(
+                        StatusCode="404",
+                        ContentType="text/plain",
+                        MessageBody="no listener rule matched",
+                    ),
+                )
+            ],
+        )
+    )
+
     t.add_output(Output("AlbArn", Value=Ref(alb)))
     t.add_output(Output("AlbDnsName", Value=GetAtt(alb, "DNSName")))
     t.add_output(Output("HttpsListenerArn", Value=Ref(listener)))
     t.add_output(Output("AdminHttpsListenerArn", Value=Ref(admin_listener)))
+    t.add_output(Output("OtelHttpListenerArn", Value=Ref(otel_listener)))
 
     return t
 

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -6,13 +6,17 @@ HTTP 4318) and writes telemetry directly to the ingest S3 bucket; it has
 no database dependency and does not consume from the ingest SQS queue.
 
 The collector is always attached to the shared ALB, exposing OTLP/HTTP
-(4318): this stack creates a TargetGroup + ListenerRule (priority 300,
-"/v1/*") on the HTTPS listener and wires the ECS Service's LoadBalancers
-block to it. Health checks hit the collector's health_check extension on
-13133. The gRPC receiver (4317) is not ALB-exposed but stays reachable
-task-to-task via Cloud Map. The ALB security group is customer-supplied
-and may differ from the task security group; the customer owns the
-ALB-to-task ingress rule on the OTLP HTTP port.
+on its own dedicated plain-HTTP listener at port 4318: this stack creates
+a TargetGroup + ListenerRule (priority 300, "/v1/*") on the OTel listener
+and wires the ECS Service's LoadBalancers block to it. The listener is
+HTTP (not HTTPS) because the ALB is internal-scheme and external senders
+arrive over VPC peering / TGW / VPN -- TLS at the ALB would only force
+those senders to install the ALB cert. Health checks hit the collector's
+health_check extension on 13133. The gRPC receiver (4317) is not
+ALB-exposed but stays reachable task-to-task via Cloud Map. The ALB
+security group is customer-supplied and may differ from the task security
+group; the customer owns the ALB-to-task ingress rule on 4318 and any
+peer-source ingress rule on the ALB itself.
 
 Config injection is intentionally minimal: the image ships with a baked-in
 config (`/etc/otel/config.yaml`, referenced by the default command) and
@@ -127,7 +131,11 @@ def build() -> Template:
         )
     )
     t.add_parameter(
-        Parameter("HttpsListenerArn", Type="String", Description="ARN of the ALB HTTPS listener.")
+        Parameter(
+            "OtelHttpListenerArn",
+            Type="String",
+            Description="ARN of the ALB OTel listener (plain HTTP on port 4318).",
+        )
     )
     t.add_parameter(
         Parameter(
@@ -244,7 +252,7 @@ def build() -> Template:
                     "BucketName",
                     "QueueArn",
                     "LicenseSecretArn",
-                    "HttpsListenerArn",
+                    "OtelHttpListenerArn",
                     "AlbDnsName",
                     "VpcId",
                     "ServiceNamespaceId",
@@ -336,7 +344,7 @@ def build() -> Template:
     listener_rule = services_common.build_listener_rule(
         service_key=_SERVICE_KEY,
         target_group_ref=target_group,
-        listener_arn_param="HttpsListenerArn",
+        listener_arn_param="OtelHttpListenerArn",
         path_patterns=["/v1/*"],
     )
     t.add_resource(listener_rule)
@@ -402,17 +410,8 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     # Outputs
     # ---------------------------------------------------------------------
-    # Endpoint is a coarse summary string; consumers typically discover the
-    # service via ECS service-name + service-discovery, not this output.
-    t.add_output(
-        Output(
-            "OtelEndpoint",
-            Value=Sub(f"alb:${{HttpsListenerArn}}:{_OTLP_HTTP_PORT}"),
-        )
-    )
-    # In-cluster OTLP/HTTP URL via Cloud Map service discovery. Consumers that
-    # want a directly-dialable endpoint (instead of building one themselves
-    # from the service name and namespace) read this output.
+    # In-cluster OTLP/HTTP URL via Cloud Map service discovery. Reaches the
+    # task ENI directly, bypassing the ALB.
     t.add_output(
         Output(
             "OtelInternalUrl",
@@ -423,12 +422,12 @@ def build() -> Template:
     )
     # AWS-assigned ALB DNS name -- publicly resolvable but resolves to private
     # IPs (the ALB is internal-scheme). Useful for callers with VPC reachability
-    # that prefer the ALB path (HTTPS, /v1/* listener rule) over Cloud Map.
+    # (peering / TGW / VPN) that arrive via the ALB plain-HTTP OTel listener.
     t.add_output(Output("OtelAlbDnsName", Value=Ref("AlbDnsName")))
     t.add_output(
         Output(
             "OtelExternalUrl",
-            Value=Sub("https://${AlbDnsName}"),
+            Value=Sub(f"http://${{AlbDnsName}}:{_OTLP_HTTP_PORT}"),
         )
     )
     t.add_output(Output("OtelServiceName", Value=GetAtt(service, "Name")))

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -565,7 +565,7 @@ def build() -> Template:
         "BucketName": Ref("IngestBucketName"),
         "QueueArn": Ref("IngestQueueArn"),
         "LicenseSecretArn": Ref("LicenseSecretArn"),
-        "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
+        "OtelHttpListenerArn": GetAtt(alb_stack, "Outputs.OtelHttpListenerArn"),
         "AlbDnsName": GetAtt(alb_stack, "Outputs.AlbDnsName"),
         "VpcId": Ref("VpcId"),
         "ServiceNamespaceId": Ref("ServiceNamespaceId"),

--- a/tests/templates/test_alb.py
+++ b/tests/templates/test_alb.py
@@ -48,12 +48,12 @@ def test_creates_load_balancer(template_dict):
     assert len(lbs) == 1
 
 
-def test_creates_https_listeners_on_443_and_9443(template_dict):
+def test_creates_listeners_on_443_9443_and_4318(template_dict):
     listeners = [r for r in template_dict["Resources"].values()
                  if r["Type"] == "AWS::ElasticLoadBalancingV2::Listener"]
-    assert len(listeners) == 2
-    ports = sorted(l["Properties"]["Port"] for l in listeners)
-    assert ports == [443, 9443]
+    assert len(listeners) == 3
+    by_port = {l["Properties"]["Port"]: l["Properties"]["Protocol"] for l in listeners}
+    assert by_port == {443: "HTTPS", 9443: "HTTPS", 4318: "HTTP"}
 
 
 def test_no_ingress_resources_internally_managed(template_dict):
@@ -77,6 +77,7 @@ def test_outputs_required(template_dict):
         "AlbDnsName",
         "HttpsListenerArn",
         "AdminHttpsListenerArn",
+        "OtelHttpListenerArn",
     ):
         assert n in template_dict["Outputs"]
 

--- a/tests/templates/test_otel.py
+++ b/tests/templates/test_otel.py
@@ -29,7 +29,8 @@ def test_required_cross_stack_parameters(td):
         "BucketName",
         "QueueArn",
         "LicenseSecretArn",
-        "HttpsListenerArn",
+        "OtelHttpListenerArn",
+        "AlbDnsName",
         "VpcId",
     ):
         assert n in td["Parameters"], f"missing parameter: {n}"
@@ -168,8 +169,16 @@ def test_container_has_collector_config_env(td):
 # ---------------------------------------------------------------------------
 
 
-def test_outputs_endpoint(td):
-    assert "OtelEndpoint" in td["Outputs"]
+def test_outputs_endpoints(td):
+    for n in ("OtelInternalUrl", "OtelExternalUrl", "OtelAlbDnsName"):
+        assert n in td["Outputs"], f"missing output: {n}"
+
+
+def test_external_url_is_plain_http_on_4318(td):
+    """The OTel ALB listener is HTTP (not HTTPS); the URL must match."""
+    assert td["Outputs"]["OtelExternalUrl"]["Value"] == {
+        "Fn::Sub": "http://${AlbDnsName}:4318"
+    }
 
 
 def test_outputs_service_name(td):


### PR DESCRIPTION
## Summary

- The OTel collector now lands on a new \`OtelHttpListener\` (port 4318, protocol HTTP) on the ALB instead of sharing the HTTPS:443 listener.
- The ALB is \`Scheme=internal\`; deployments rely on caller-side VPC reachability (peering / TGW / VPN). TLS termination at the ALB only forced external senders to install the ALB cert -- plain HTTP at the listener removes that friction and matches the target group's protocol.
- Clients send \`http://<alb-dns>:4318/v1/{traces,metrics,logs}\`. The Cloud Map path (\`OtelInternalUrl\`) is unchanged.

## Changes

- \`alb.yaml\`: adds \`OtelHttpListener\` (4318/HTTP, fixed-response 404 default) and \`OtelHttpListenerArn\` output.
- \`otel.yaml\`: parameter \`HttpsListenerArn\` -> \`OtelHttpListenerArn\`; the \`/v1/*\` rule (priority 300) moves to the new listener.
- \`OtelExternalUrl\` is now \`http://\${AlbDnsName}:4318\` (was \`https://\${AlbDnsName}\`). \`OtelEndpoint\` (the synthetic \`alb:<arn>:4318\` descriptor) is removed -- superseded by the URL outputs added in v0.0.75/v0.0.76.
- Root \`OtelStack\` parameter wiring updated.
- Test updates for both stacks.

## Operator note

Customers will need to allow inbound 4318 on the ALB SG (\`cardinal-alb-sg\`) from the peer-VPC CIDR(s) they ingest from. The cert installed by \`cert.yaml\` is unaffected -- still used by the 443 / 9443 HTTPS listeners.

## Test plan

- [x] \`make test\` -- 350 passed
- [x] \`make build\` -- cfn-lint clean
- [x] Verified generated \`alb.yaml\` has 3 listeners (443/HTTPS, 9443/HTTPS, 4318/HTTP) and \`otel.yaml\` \`OtelExternalUrl\` is \`http://\${AlbDnsName}:4318\`