### PR TITLE
bump(dex): switch to cardinalhq.io/dex-customization v0.1.0

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -36,7 +36,7 @@ images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.24.0"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.43.11"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
-  dex:        "ghcr.io/dexidp/dex:v2.41.1"
+  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
 


### PR DESCRIPTION
## Summary
- Switches `images.dex` from upstream `ghcr.io/dexidp/dex:v2.41.1` to the Cardinal-branded image `public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0`.
- First release of the cardinalhq/dex-customization repo; image is built and pushed by that repo's release workflow on tag push.

## Test plan
- [ ] Deploy a maestro nested stack against this defaults file; confirm the dex task pulls the cardinal image and serves the themed login page.