### PR TITLE
Rename cardinal-vpc to lrdev-vpc

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,6 @@ jobs:
           PRERELEASE: ${{ steps.version.outputs.prerelease }}
         run: |
           ROOT_URL="https://${CARDINAL_BUCKET_NAME}.s3.${CARDINAL_BUCKET_REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-lakerunner.yaml"
-          VPC_URL="https://${CARDINAL_BUCKET_NAME}.s3.${CARDINAL_BUCKET_REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-vpc.yaml"
           PRERELEASE_FLAG=()
           if [[ "${PRERELEASE}" == "true" ]]; then
             PRERELEASE_FLAG=(--prerelease)
@@ -79,7 +78,5 @@ jobs:
             --title "$VERSION" \
             "${PRERELEASE_FLAG[@]}" \
             --notes "**Lakerunner root template:** $ROOT_URL
-
-          **Optional VPC template:** $VPC_URL
 
           Paste the root URL into the CloudFormation console to deploy."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ When in doubt, the design spec wins.
 
 Two customer-facing CloudFormation root templates:
 
-- `cardinal-vpc.yaml` — optional VPC (skipped by customers using their own VPC)
+- `lrdev-vpc.yaml` — internal test-env VPC scaffolding (not customer-facing; we use it to simulate a customer-supplied VPC in our test account)
 - `cardinal-lakerunner.yaml` — application root, composed of eight nested children
 
 Plus a single shell driver:
@@ -54,7 +54,7 @@ src/
     defaults.py              # cardinal-defaults.yaml loader
     children/                # one module per nested-stack child
     root.py                  # parent template generator
-    cardinal_vpc.py          # standalone VPC generator
+    lrdev_vpc.py             # internal test-env VPC generator (lrdev-vpc.yaml)
 scripts/
   data-setup.sh              # infra provisioner (raw AWS CLI; idempotent)
   deploy-lakerunner.sh       # CFN deploy driver
@@ -73,7 +73,7 @@ Generated templates go to `generated-templates/`, mirroring the S3 key layout:
 
 ```
 generated-templates/
-  cardinal-vpc.yaml
+  lrdev-vpc.yaml
   cardinal-lakerunner.yaml             # the root
   cardinal-lakerunner/                 # the children, mirrors S3 prefix
     alb.yaml
@@ -172,7 +172,7 @@ For debugging a single template, generators can be invoked directly (PYTHONPATH=
 ```sh
 python3 -m cardinal_cfn.children.<child>   # emits child YAML to stdout
 python3 -m cardinal_cfn.root               # emits root YAML
-python3 -m cardinal_cfn.cardinal_vpc       # emits VPC YAML
+python3 -m cardinal_cfn.lrdev_vpc          # emits internal lrdev VPC YAML
 ```
 
 All templates must pass cfn-lint with no errors. Warnings are tolerable when explainable; `.cfnlintrc` carries the project-wide ignores.

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ check: test	## Pre-push gate (alias for test)
 
 lint:	## Run cfn-lint on every generated template
 	source $(VENV_DIR)/bin/activate && cfn-lint \
-	  generated-templates/cardinal-vpc.yaml \
+	  generated-templates/lrdev-vpc.yaml \
 	  generated-templates/cardinal-infrastructure.yaml \
 	  generated-templates/cardinal-cleanup.yaml \
 	  generated-templates/cardinal-lakerunner.yaml \

--- a/README-BUILDING.md
+++ b/README-BUILDING.md
@@ -11,7 +11,7 @@
 make build
 ```
 
-Generates `generated-templates/cardinal-vpc.yaml`, `generated-templates/cardinal-lakerunner.yaml`, and the eleven nested children under `generated-templates/cardinal-lakerunner/`. Runs `cfn-lint` on the lot.
+Generates `generated-templates/lrdev-vpc.yaml`, `generated-templates/cardinal-lakerunner.yaml`, and the eleven nested children under `generated-templates/cardinal-lakerunner/`. Runs `cfn-lint` on the lot.
 
 ## Test
 
@@ -28,7 +28,7 @@ The suite uses pytest + cloud-radar; offline, no AWS credentials needed.
 
 - `src/cardinal_cfn/` — generator package
   - `root.py` — root template (`cardinal-lakerunner.yaml`)
-  - `cardinal_vpc.py` — standalone VPC template (`cardinal-vpc.yaml`)
+  - `lrdev_vpc.py` — internal test-env VPC scaffolding (`lrdev-vpc.yaml`)
   - `children/` — eleven nested stack generators
   - `defaults.py`, `naming.py`, `parameters.py`, `images.py`, `policies.py`, `install_id.py`, `listener_priorities.py` — shared helpers
 - `cardinal-defaults.yaml` — service definitions, image references, API keys seed, storage profile defaults

--- a/README.md
+++ b/README.md
@@ -34,8 +34,10 @@ VPC+subnets   | (RDS, S3, SQS,    |        | (application)   |
                                            +-----------------+
 ```
 
-The optional `cardinal-vpc` stack is for ephemeral test environments
-only -- production installs always bring their own VPC.
+Production installs always bring their own VPC. For our internal
+ephemeral test environments the repo ships an `lrdev-vpc` template that
+synthesises a customer-equivalent VPC; it is scaffolding for our test
+account, not a customer-facing artifact.
 
 ## Published templates
 
@@ -44,7 +46,7 @@ Per release tag at `https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/la
 - `cardinal-infrastructure.yaml`
 - `cardinal-lakerunner.yaml` (+ nested children under `cardinal-lakerunner/`)
 - `cardinal-cleanup.yaml` (optional teardown task)
-- `cardinal-vpc.yaml` (test only)
+- `lrdev-vpc.yaml` (internal test scaffolding; customers ignore)
 
 There is no `latest` tag -- pin to a specific release tag (e.g.
 `v0.0.41`) for reproducibility.

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,8 @@ mkdir -p generated-templates/cardinal-lakerunner
 
 export PYTHONPATH="$(pwd)/src${PYTHONPATH:+:$PYTHONPATH}"
 
-echo "Generating cardinal-vpc.yaml..."
-python3 -m cardinal_cfn.cardinal_vpc > generated-templates/cardinal-vpc.yaml
+echo "Generating lrdev-vpc.yaml..."
+python3 -m cardinal_cfn.lrdev_vpc > generated-templates/lrdev-vpc.yaml
 
 echo "Generating cardinal-infrastructure.yaml..."
 python3 -m cardinal_cfn.cardinal_infrastructure > generated-templates/cardinal-infrastructure.yaml
@@ -44,7 +44,7 @@ done
 
 echo
 echo "Linting CFN templates..."
-cfn-lint generated-templates/cardinal-vpc.yaml \
+cfn-lint generated-templates/lrdev-vpc.yaml \
          generated-templates/cardinal-infrastructure.yaml \
          generated-templates/cardinal-cleanup.yaml \
          generated-templates/cardinal-lakerunner.yaml \

--- a/docs/operations/end-to-end-test-plan.md
+++ b/docs/operations/end-to-end-test-plan.md
@@ -19,7 +19,7 @@ In scope:
 
 Out of scope (one-time setup, persists across trials):
 
-- VPC + subnets. Pre-existing in the test account; either deployed once from `cardinal-vpc.yaml` via Console / `aws cloudformation create-stack`, or a customer-supplied VPC. Customers will already have a working VPC -- this test mirrors that assumption.
+- VPC + subnets. Pre-existing in the test account; either deployed once from `lrdev-vpc.yaml` via Console / `aws cloudformation create-stack`, or a manually-supplied VPC. Customers will already have a working VPC -- this test mirrors that assumption by standing up customer-equivalent networking ahead of time.
 - Region: **us-east-1** in the test account. The published template bucket lives in us-east-2; cross-region template fetch is fine, leave `TemplateBaseUrl` at its default.
 
 Explicitly NOT in scope (intentional simplifications because there is no public DNS available for the test environment):
@@ -41,18 +41,18 @@ Capture the account ID and the IAM identity (user or assumed role) the Jenkins A
 Either:
 
 - **Use an existing VPC** in the account. Capture VpcId and at least two private subnet IDs in distinct AZs. The application stack runs entirely in private subnets behind an internal ALB; public subnets are not used by this stack.
-- **Or deploy the Cardinal VPC stack once** via the AWS Console or CLI (this stack survives all subsequent trials):
+- **Or deploy the lrdev VPC stack once** via the AWS Console or CLI (this stack survives all subsequent trials; it is internal test scaffolding, not a customer artifact):
 
     ```sh
     aws cloudformation create-stack \
         --region us-east-1 \
-        --stack-name cardinal-vpc \
-        --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/cardinal-vpc.yaml \
+        --stack-name lrdev-vpc \
+        --template-url https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner/<version>/lrdev-vpc.yaml \
         --capabilities CAPABILITY_NAMED_IAM
     aws cloudformation wait stack-create-complete \
-        --region us-east-1 --stack-name cardinal-vpc
+        --region us-east-1 --stack-name lrdev-vpc
     aws cloudformation describe-stacks \
-        --region us-east-1 --stack-name cardinal-vpc \
+        --region us-east-1 --stack-name lrdev-vpc \
         --query 'Stacks[0].Outputs' --output table
     ```
 
@@ -396,8 +396,8 @@ sh scripts/teardown-lakerunner.sh --stack-name cardinal-lakerunner-test --region
 
 # Tear down the VPC stack (only if you deployed it for this test session;
 # otherwise leave it for next time).
-aws cloudformation delete-stack --stack-name cardinal-vpc --region us-east-1
-aws cloudformation wait stack-delete-complete --stack-name cardinal-vpc --region us-east-1
+aws cloudformation delete-stack --stack-name lrdev-vpc --region us-east-1
+aws cloudformation wait stack-delete-complete --stack-name lrdev-vpc --region us-east-1
 
 # Delete Jenkins credentials staged in pre-flight D + E if no longer needed.
 ```

--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -20,7 +20,7 @@ this stack reaches `CREATE_COMPLETE`.
 | Layer | Owned by | Where it lives |
 |---|---|---|
 | ECS cluster | Customer's IT (out of band) | Pre-created; identifiers passed as `cardinal-lakerunner` parameters. |
-| VPC + private subnets | Customer's IT (or `cardinal-vpc.yaml`) | Passed as parameters into both stacks. |
+| VPC + private subnets | Customer's IT (out of band) | Passed as parameters into both stacks. |
 | Data layer (RDS + RDS SG, S3, SQS, secrets, SSM) | `cardinal-infrastructure` stack | All resources retained on stack delete. **This document.** |
 | Application layer (ALB, ECS services, migration, cert, *all SGs and IAM roles*) | `cardinal-lakerunner` stack | Stateless. **Next document.** |
 
@@ -31,8 +31,6 @@ The customer's IT team must pre-create:
 - **An ECS cluster.** Any name is fine; capture the cluster name and
   the cluster ARN.
 - **A VPC** with **at least two private subnets in distinct AZs**.
-  (`cardinal-vpc.yaml` is offered as an optional helper for customers
-  who want a VPC stood up alongside Cardinal.)
 
 That is the entire IT prereq surface. **No IAM roles, no security
 groups, and no Cloud Map namespace are required from IT.** The

--- a/docs/operations/installing.md
+++ b/docs/operations/installing.md
@@ -14,8 +14,9 @@ Install is two CloudFormation stacks:
    infrastructure stack's outputs as parameters along with the
    customer-supplied VPC + ECS cluster identifiers.
 
-The optional `cardinal-vpc` stack is a convenience for ephemeral test
-environments only -- production installs always bring their own VPC.
+Production installs always bring their own VPC. The repo also ships an
+`lrdev-vpc` template that we use internally to stand up customer-equivalent
+networking in our test account; it is not part of the customer install.
 
 For the broader operational topics:
 

--- a/docs/operations/permissions-infrastructure.md
+++ b/docs/operations/permissions-infrastructure.md
@@ -47,7 +47,7 @@ child stack.
 ## What the deployer does **not** need
 
 - VPC / subnet / route table / IGW / NAT / TGW write actions. VPC is
-  bring-your-own (or use the optional `cardinal-vpc.yaml`).
+  bring-your-own.
 - ECS cluster create/delete. Cluster is bring-your-own.
 - `kms:*` — no customer-managed keys are provisioned.
 - `bedrock:*` — Bedrock is runtime-only on the process-tier task role.

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -1,7 +1,8 @@
 """cardinal-infrastructure: standalone data-plane template.
 
-Customer-deployable peer to ``cardinal-vpc``. Creates the resources that
-``cardinal-lakerunner`` needs as inputs but does not manage itself:
+Customer-deployable prerequisite for ``cardinal-lakerunner``. Creates the
+resources that ``cardinal-lakerunner`` needs as inputs but does not manage
+itself:
 
 - RDS PostgreSQL instance + DB subnet group + master secret
 - S3 ingest bucket + lifecycle policy + S3 -> SQS notification

--- a/src/cardinal_cfn/lrdev_vpc.py
+++ b/src/cardinal_cfn/lrdev_vpc.py
@@ -1,8 +1,9 @@
-"""cardinal-vpc: standalone VPC template.
+"""lrdev-vpc: standalone VPC template for our internal lakerunner test environment.
 
-Optional pre-step a customer can deploy if they don't already have a VPC.
-The resulting VpcId / subnet CSVs / endpoint SG are then fed as inputs to
-the cardinal-lakerunner root template.
+Stands in for a VPC the customer would normally bring. Used to spin up the
+prerequisite networking our test account needs before deploying the real
+cardinal-* product stacks against it. The resulting VpcId / subnet CSVs /
+endpoint SG feed into cardinal-infrastructure and cardinal-lakerunner.
 
 Layout (minimum viable):
 - 1 VPC, 2 public + 2 private subnets across 2 AZs
@@ -50,18 +51,19 @@ def _vpc_tags(*, role: str) -> Tags:
     """
     return Tags(
         Name=Sub(f"${{EnvironmentName}}-{role}"),
-        Project="cardinal",
+        Project="lrdev",
         Component="networking",
         Role=role,
-        ManagedBy="cardinal-cfn",
+        ManagedBy="lrdev-cfn",
     )
 
 
 def build() -> Template:
     t = Template()
     t.set_description(
-        "Cardinal VPC: standalone VPC with public/private subnets across 2 AZs, "
-        "optional NAT Gateway, S3 gateway endpoint, and optional interface endpoints."
+        "lrdev VPC: standalone VPC for our internal lakerunner test environment "
+        "(public/private subnets across 2 AZs, optional NAT Gateway, S3 gateway "
+        "endpoint, and optional interface endpoints). Not a customer-facing stack."
     )
 
     # Parameters
@@ -69,7 +71,7 @@ def build() -> Template:
         Parameter(
             "EnvironmentName",
             Type="String",
-            Default="cardinal",
+            Default="lrdev",
             Description="Environment name used in resource Name tags.",
             AllowedPattern=r"^[a-zA-Z][a-zA-Z0-9-]*$",
         )
@@ -268,7 +270,7 @@ def build() -> Template:
     vpce_sg = t.add_resource(
         SecurityGroup(
             "VpcEndpointSecurityGroup",
-            GroupDescription="Cardinal VPC endpoints security group (HTTPS from VPC)",
+            GroupDescription="lrdev VPC endpoints security group (HTTPS from VPC)",
             VpcId=Ref(vpc),
             SecurityGroupIngress=[
                 SecurityGroupRule(

--- a/tests/templates/test_lrdev_vpc.py
+++ b/tests/templates/test_lrdev_vpc.py
@@ -1,15 +1,15 @@
-"""Tests for the cardinal-vpc standalone template."""
+"""Tests for the lrdev-vpc standalone template."""
 
 import json
 
 import pytest
 
-from cardinal_cfn import cardinal_vpc
+from cardinal_cfn import lrdev_vpc
 
 
 @pytest.fixture
 def td():
-    return json.loads(cardinal_vpc.build().to_json())
+    return json.loads(lrdev_vpc.build().to_json())
 
 
 def test_required_parameters(td):
@@ -17,8 +17,8 @@ def test_required_parameters(td):
         assert n in td["Parameters"], f"missing parameter: {n}"
 
 
-def test_environment_default_is_cardinal(td):
-    assert td["Parameters"]["EnvironmentName"]["Default"] == "cardinal"
+def test_environment_default_is_lrdev(td):
+    assert td["Parameters"]["EnvironmentName"]["Default"] == "lrdev"
 
 
 def test_create_nat_gateway_default_yes(td):

--- a/tests/templates/test_no_lambda.py
+++ b/tests/templates/test_no_lambda.py
@@ -7,14 +7,14 @@ import json
 
 import pytest
 
-from cardinal_cfn import cardinal_infrastructure, cardinal_vpc, root
+from cardinal_cfn import cardinal_infrastructure, lrdev_vpc, root
 from cardinal_cfn.children import (
     alb, cert, migration,
     services_query, services_process, services_control, otel, maestro,
 )
 
 _TEMPLATES = [
-    ("cardinal-vpc", cardinal_vpc),
+    ("lrdev-vpc", lrdev_vpc),
     ("cardinal-infrastructure", cardinal_infrastructure),
     ("cardinal-lakerunner (root)", root),
     ("alb", alb),


### PR DESCRIPTION
## Summary

- The standalone VPC template only ever stands up customer-equivalent networking in our internal test account -- production installs always bring their own VPC. Rename it `lrdev-vpc` to make that distinction visible and stop implying it is a customer-facing artifact.
- Module/file/test renamed; `EnvironmentName` default and resource tags flipped from `cardinal` to `lrdev`. The template description now states it is internal scaffolding.
- README, README-BUILDING, CLAUDE.md, and `docs/operations/*` updated; the VPC URL is dropped from the GitHub release notes since it is no longer a customer-facing artifact.
- Historical specs and plans under `docs/superpowers/` left untouched (point-in-time records).

## Test plan

- [x] `make build` regenerates all templates and cfn-lint passes
- [x] `make test` -- 409 passed, 5 skipped
- [x] Verified `lrdev-vpc.yaml` is the only renamed artifact and no live references to `cardinal-vpc` / `cardinal_vpc` remain (`grep -rn 'cardinal[-_]vpc' --include='*.{sh,py,yaml,yml,md}' --include=Makefile` returns nothing outside `docs/superpowers/`)
- [ ] On the next release tag, confirm the GitHub release notes show only the root template URL (no VPC URL)