### PR TITLE
Add lrdev-baseinfra stack with ECS cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,7 @@ When in doubt, the design spec wins.
 Two customer-facing CloudFormation root templates:
 
 - `lrdev-vpc.yaml` — internal test-env VPC scaffolding (not customer-facing; we use it to simulate a customer-supplied VPC in our test account)
+- `lrdev-baseinfra.yaml` — internal test-env base-infrastructure scaffolding (ECS Fargate cluster; simulates a customer-supplied cluster)
 - `cardinal-lakerunner.yaml` — application root, composed of eight nested children
 
 Plus a single shell driver:
@@ -55,6 +56,7 @@ src/
     children/                # one module per nested-stack child
     root.py                  # parent template generator
     lrdev_vpc.py             # internal test-env VPC generator (lrdev-vpc.yaml)
+    lrdev_baseinfra.py       # internal test-env ECS cluster generator (lrdev-baseinfra.yaml)
 scripts/
   data-setup.sh              # infra provisioner (raw AWS CLI; idempotent)
   deploy-lakerunner.sh       # CFN deploy driver
@@ -74,6 +76,7 @@ Generated templates go to `generated-templates/`, mirroring the S3 key layout:
 ```
 generated-templates/
   lrdev-vpc.yaml
+  lrdev-baseinfra.yaml
   cardinal-lakerunner.yaml             # the root
   cardinal-lakerunner/                 # the children, mirrors S3 prefix
     alb.yaml
@@ -173,6 +176,7 @@ For debugging a single template, generators can be invoked directly (PYTHONPATH=
 python3 -m cardinal_cfn.children.<child>   # emits child YAML to stdout
 python3 -m cardinal_cfn.root               # emits root YAML
 python3 -m cardinal_cfn.lrdev_vpc          # emits internal lrdev VPC YAML
+python3 -m cardinal_cfn.lrdev_baseinfra    # emits internal lrdev base-infra (ECS cluster) YAML
 ```
 
 All templates must pass cfn-lint with no errors. Warnings are tolerable when explainable; `.cfnlintrc` carries the project-wide ignores.

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ check: test	## Pre-push gate (alias for test)
 lint:	## Run cfn-lint on every generated template
 	source $(VENV_DIR)/bin/activate && cfn-lint \
 	  generated-templates/lrdev-vpc.yaml \
+	  generated-templates/lrdev-baseinfra.yaml \
 	  generated-templates/cardinal-infrastructure.yaml \
 	  generated-templates/cardinal-cleanup.yaml \
 	  generated-templates/cardinal-lakerunner.yaml \

--- a/README-BUILDING.md
+++ b/README-BUILDING.md
@@ -29,6 +29,7 @@ The suite uses pytest + cloud-radar; offline, no AWS credentials needed.
 - `src/cardinal_cfn/` — generator package
   - `root.py` — root template (`cardinal-lakerunner.yaml`)
   - `lrdev_vpc.py` — internal test-env VPC scaffolding (`lrdev-vpc.yaml`)
+  - `lrdev_baseinfra.py` — internal test-env ECS cluster scaffolding (`lrdev-baseinfra.yaml`)
   - `children/` — eleven nested stack generators
   - `defaults.py`, `naming.py`, `parameters.py`, `images.py`, `policies.py`, `install_id.py`, `listener_priorities.py` — shared helpers
 - `cardinal-defaults.yaml` — service definitions, image references, API keys seed, storage profile defaults

--- a/build.sh
+++ b/build.sh
@@ -21,6 +21,9 @@ export PYTHONPATH="$(pwd)/src${PYTHONPATH:+:$PYTHONPATH}"
 echo "Generating lrdev-vpc.yaml..."
 python3 -m cardinal_cfn.lrdev_vpc > generated-templates/lrdev-vpc.yaml
 
+echo "Generating lrdev-baseinfra.yaml..."
+python3 -m cardinal_cfn.lrdev_baseinfra > generated-templates/lrdev-baseinfra.yaml
+
 echo "Generating cardinal-infrastructure.yaml..."
 python3 -m cardinal_cfn.cardinal_infrastructure > generated-templates/cardinal-infrastructure.yaml
 
@@ -45,6 +48,7 @@ done
 echo
 echo "Linting CFN templates..."
 cfn-lint generated-templates/lrdev-vpc.yaml \
+         generated-templates/lrdev-baseinfra.yaml \
          generated-templates/cardinal-infrastructure.yaml \
          generated-templates/cardinal-cleanup.yaml \
          generated-templates/cardinal-lakerunner.yaml \

--- a/src/cardinal_cfn/lrdev_baseinfra.py
+++ b/src/cardinal_cfn/lrdev_baseinfra.py
@@ -1,0 +1,91 @@
+"""lrdev-baseinfra: standalone base-infrastructure template for our internal test environment.
+
+Stands in for the IT-owned prerequisites a customer would normally bring
+to a Cardinal install. Currently provisions:
+
+- An ECS (Fargate) cluster with Container Insights enabled
+
+Customers do not deploy this stack -- it is scaffolding for our test
+account, parallel to ``lrdev-vpc``.
+"""
+
+from troposphere import (
+    GetAtt,
+    Output,
+    Parameter,
+    Ref,
+    Sub,
+    Tags,
+    Template,
+)
+from troposphere.ecs import (
+    Cluster,
+    ClusterConfiguration,
+    ClusterSetting,
+    ExecuteCommandConfiguration,
+)
+
+
+def _baseinfra_tags(*, role: str) -> Tags:
+    return Tags(
+        Name=Sub(f"${{EnvironmentName}}-{role}"),
+        Project="lrdev",
+        Component="compute",
+        Role=role,
+        ManagedBy="lrdev-cfn",
+    )
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "lrdev base infra: ECS Fargate cluster for our internal lakerunner "
+        "test environment. Stands in for a customer-supplied cluster. "
+        "Not a customer-facing stack."
+    )
+
+    t.add_parameter(
+        Parameter(
+            "EnvironmentName",
+            Type="String",
+            Default="lrdev",
+            Description="Environment name used in resource Name tags.",
+            AllowedPattern=r"^[a-zA-Z][a-zA-Z0-9-]*$",
+        )
+    )
+
+    cluster = t.add_resource(
+        Cluster(
+            "EcsCluster",
+            ClusterSettings=[
+                ClusterSetting(Name="containerInsights", Value="enabled"),
+            ],
+            Configuration=ClusterConfiguration(
+                ExecuteCommandConfiguration=ExecuteCommandConfiguration(
+                    Logging="DEFAULT",
+                ),
+            ),
+            Tags=_baseinfra_tags(role="cluster"),
+        )
+    )
+
+    t.add_output(
+        Output(
+            "ClusterName",
+            Description="ECS cluster name (feed to cardinal-lakerunner ClusterName parameter).",
+            Value=Ref(cluster),
+        )
+    )
+    t.add_output(
+        Output(
+            "ClusterArn",
+            Description="ECS cluster ARN (feed to cardinal-lakerunner ClusterArn parameter).",
+            Value=GetAtt(cluster, "Arn"),
+        )
+    )
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")

--- a/tests/templates/test_lrdev_baseinfra.py
+++ b/tests/templates/test_lrdev_baseinfra.py
@@ -1,0 +1,52 @@
+"""Tests for the lrdev-baseinfra standalone template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import lrdev_baseinfra
+
+
+@pytest.fixture
+def td():
+    return json.loads(lrdev_baseinfra.build().to_json())
+
+
+def test_environment_parameter_defaults_to_lrdev(td):
+    assert "EnvironmentName" in td["Parameters"]
+    assert td["Parameters"]["EnvironmentName"]["Default"] == "lrdev"
+
+
+def test_creates_a_single_ecs_cluster(td):
+    clusters = [r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Cluster"]
+    assert len(clusters) == 1
+
+
+def test_no_explicit_cluster_name(td):
+    """ECS cluster names block in-place updates; rely on CFN-generated name."""
+    cluster = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Cluster")
+    assert "ClusterName" not in cluster.get("Properties", {})
+
+
+def test_container_insights_enabled(td):
+    cluster = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Cluster")
+    settings = cluster["Properties"]["ClusterSettings"]
+    assert any(s["Name"] == "containerInsights" and s["Value"] == "enabled" for s in settings)
+
+
+def test_outputs(td):
+    for n in ("ClusterName", "ClusterArn"):
+        assert n in td["Outputs"], f"missing output: {n}"
+
+
+def test_outputs_have_no_export(td):
+    for name, out in td["Outputs"].items():
+        assert "Export" not in out, f"output {name} should not have an Export"
+
+
+def test_cluster_tagged_for_lrdev(td):
+    cluster = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Cluster")
+    tags = {t["Key"]: t["Value"] for t in cluster["Properties"]["Tags"]}
+    assert tags["Project"] == "lrdev"
+    assert tags["ManagedBy"] == "lrdev-cfn"
+    assert tags["Role"] == "cluster"

--- a/tests/templates/test_no_lambda.py
+++ b/tests/templates/test_no_lambda.py
@@ -7,7 +7,7 @@ import json
 
 import pytest
 
-from cardinal_cfn import cardinal_infrastructure, lrdev_vpc, root
+from cardinal_cfn import cardinal_infrastructure, lrdev_baseinfra, lrdev_vpc, root
 from cardinal_cfn.children import (
     alb, cert, migration,
     services_query, services_process, services_control, otel, maestro,
@@ -15,6 +15,7 @@ from cardinal_cfn.children import (
 
 _TEMPLATES = [
     ("lrdev-vpc", lrdev_vpc),
+    ("lrdev-baseinfra", lrdev_baseinfra),
     ("cardinal-infrastructure", cardinal_infrastructure),
     ("cardinal-lakerunner (root)", root),
     ("alb", alb),


### PR DESCRIPTION
## Summary

- Add a new internal-only stack, `lrdev-baseinfra`, parallel to `lrdev-vpc`. It synthesises a customer-equivalent ECS Fargate cluster in our test account so we can deploy `cardinal-infrastructure` + `cardinal-lakerunner` against it end-to-end.
- Container Insights enabled and ExecuteCommand logging set to DEFAULT. No explicit cluster name (per the CLAUDE.md rule against naming ECS clusters); CFN generates one and we expose it via the `ClusterName` output.
- Outputs are shaped to drop into `cardinal-lakerunner`'s `ClusterName` / `ClusterArn` parameters.
- Not customer-facing; not added to the GitHub release notes.

## Test plan

- [x] `make build` regenerates all templates and cfn-lint is clean
- [x] `make test` -- 417 passed, 5 skipped (8 new assertions for the new template + 1 new entry in `test_no_lambda`)
- [ ] Manually deploy `lrdev-baseinfra.yaml` once into the test account and confirm a Fargate-capable cluster comes up with the expected tags