### PR TITLE
Fix SG rule descriptions rejected by EC2

### DIFF
--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -261,7 +261,7 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_QUERY_API_PORT,
         ToPort=_QUERY_API_PORT,
-        Description="ALB -> query-api",
+        Description="ALB to query-api",
     ))
     # query-api -> query-worker on 8081 (self-referential within the tier SG)
     t.add_resource(SecurityGroupIngress(
@@ -271,7 +271,7 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_QUERY_WORKER_PORT,
         ToPort=_QUERY_WORKER_PORT,
-        Description="query-api -> query-worker (same tier SG)",
+        Description="query-api to query-worker (same tier SG)",
     ))
 
     # ALB -> admin-api on 9091
@@ -282,7 +282,7 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_ADMIN_API_PORT,
         ToPort=_ADMIN_API_PORT,
-        Description="ALB -> admin-api",
+        Description="ALB to admin-api",
     ))
 
     # ALB -> otel on 4318
@@ -293,7 +293,7 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_OTLP_HTTP_PORT,
         ToPort=_OTLP_HTTP_PORT,
-        Description="ALB -> otel-collector",
+        Description="ALB to otel-collector",
     ))
     # Lakerunner tasks -> otel on 4318 (self-telemetry from each tier)
     for tier_title, tier_ref in [
@@ -309,7 +309,7 @@ def build() -> Template:
             IpProtocol="tcp",
             FromPort=_OTLP_HTTP_PORT,
             ToPort=_OTLP_HTTP_PORT,
-            Description=f"{tier_title} -> otel-collector self-telemetry",
+            Description=f"{tier_title} to otel-collector self-telemetry",
         ))
 
     # ALB -> maestro UI on 4200 and dex on 5556
@@ -320,7 +320,7 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_MAESTRO_PORT,
         ToPort=_MAESTRO_PORT,
-        Description="ALB -> maestro UI",
+        Description="ALB to maestro UI",
     ))
     t.add_resource(SecurityGroupIngress(
         "MaestroDexFromAlb",
@@ -329,7 +329,7 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_MAESTRO_DEX_PORT,
         ToPort=_MAESTRO_DEX_PORT,
-        Description="ALB -> maestro dex",
+        Description="ALB to maestro dex",
     ))
 
     # ----------------------------------------------------------------------
@@ -350,7 +350,7 @@ def build() -> Template:
             IpProtocol="tcp",
             FromPort=5432,
             ToPort=5432,
-            Description=f"{tier_title} -> RDS 5432",
+            Description=f"{tier_title} to RDS 5432",
         ))
 
     # ----------------------------------------------------------------------

--- a/tests/templates/test_sg_rule_descriptions.py
+++ b/tests/templates/test_sg_rule_descriptions.py
@@ -1,0 +1,69 @@
+"""Regression guard: SG ingress/egress rule descriptions must match AWS's
+allowed character set.
+
+EC2 rejects SecurityGroup{Ingress,Egress} (and inline rule) descriptions that
+contain characters outside ``a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*``. Notably ``->``
+fails because ``>`` is not in the set; we used to write ``"ALB -> query-api"``
+which crashed the Security child stack at create time.
+"""
+
+import json
+import re
+
+import pytest
+
+from cardinal_cfn import cardinal_infrastructure, lrdev_baseinfra, lrdev_vpc, root
+from cardinal_cfn.children import (
+    alb, cert, maestro, migration, otel, security,
+    services_control, services_process, services_query,
+)
+
+_MODULES = [
+    ("cardinal-infrastructure", cardinal_infrastructure),
+    ("lrdev-vpc", lrdev_vpc),
+    ("lrdev-baseinfra", lrdev_baseinfra),
+    ("cardinal-lakerunner (root)", root),
+    ("alb", alb),
+    ("cert", cert),
+    ("maestro", maestro),
+    ("migration", migration),
+    ("otel", otel),
+    ("security", security),
+    ("services-control", services_control),
+    ("services-process", services_process),
+    ("services-query", services_query),
+]
+
+# Per the EC2 API error: "Valid descriptions are strings less than 256
+# characters from the following set:  a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*"
+_VALID = re.compile(r"^[A-Za-z0-9. _\-:/()#,@\[\]+=&;{}!$*]*$")
+
+
+def _collect_descriptions(td: dict):
+    """Yield (logical_id, where, description) for every SG rule description in td."""
+    for logical_id, resource in td.get("Resources", {}).items():
+        rtype = resource.get("Type", "")
+        props = resource.get("Properties", {})
+        if rtype in ("AWS::EC2::SecurityGroupIngress", "AWS::EC2::SecurityGroupEgress"):
+            desc = props.get("Description")
+            if isinstance(desc, str):
+                yield logical_id, "Description", desc
+        elif rtype == "AWS::EC2::SecurityGroup":
+            for direction in ("SecurityGroupIngress", "SecurityGroupEgress"):
+                for i, rule in enumerate(props.get(direction, []) or []):
+                    desc = rule.get("Description") if isinstance(rule, dict) else None
+                    if isinstance(desc, str):
+                        yield logical_id, f"{direction}[{i}].Description", desc
+
+
+@pytest.mark.parametrize("label,module", _MODULES)
+def test_sg_rule_descriptions_use_only_aws_allowed_chars(label, module):
+    td = json.loads(module.build().to_json())
+    bad = []
+    for logical_id, where, desc in _collect_descriptions(td):
+        if not _VALID.match(desc) or len(desc) >= 256:
+            bad.append(f"{logical_id}.{where}={desc!r}")
+    assert not bad, (
+        f"{label}: SG rule descriptions outside AWS's allowed character set "
+        f"(a-zA-Z0-9. _-:/()#,@[]+=&;{{}}!$*):\n  " + "\n  ".join(bad)
+    )


### PR DESCRIPTION
## Summary

- The Security child stack uses descriptions like `"ALB -> query-api"` on its SecurityGroupIngress rules. EC2 rejects these at create time because `>` is not in the allowed set (`a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*`). All 15 per-tier SG ingress rules failed with `Invalid rule description`, taking the whole `cardinal-lakerunner` stack to ROLLBACK_COMPLETE.
- Replace `->` with `to` in all 8 Description strings in `src/cardinal_cfn/children/security.py`.
- Add `tests/templates/test_sg_rule_descriptions.py`: parametrized over every template, walks SecurityGroupIngress / SecurityGroupEgress + inline rules, asserts each Description matches the EC2 character set and is under 256 chars.

## Repro

```
aws cloudformation create-stack ... --stack-name cardinal-lakerunner ... v0.0.78/cardinal-lakerunner.yaml
```

fails in the Security child:

```
Resource handler returned message: "Invalid rule description. Valid descriptions are strings less than 256 characters from the following set:  a-zA-Z0-9. _-:/()#,@[]+=&;{}!$*"
```

Hit during the first end-to-end deploy of v0.0.78 against the test account today.

## Test plan

- [x] `make test` -- 430 passed, 5 skipped (13 new parametrized assertions in test_sg_rule_descriptions.py)
- [x] `make build` + cfn-lint clean
- [ ] Redeploy `cardinal-lakerunner` from v0.0.79 against the lrdev test environment and watch Security come up cleanly