### PR TITLE
Fix ExecutionRole secret access for CFN-named DBMaster

### DIFF
--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -375,10 +375,14 @@ def build() -> Template:
                                 "secretsmanager:GetSecretValue",
                                 "secretsmanager:DescribeSecret",
                             ],
-                            "Resource": Sub(
-                                "arn:${AWS::Partition}:secretsmanager:"
-                                "${AWS::Region}:${AWS::AccountId}:secret:cardinal-*"
-                            ),
+                            # The DBMaster secret is CFN-generated and does NOT match
+                            # the cardinal-* prefix, so list the actual ARNs the
+                            # infrastructure stack hands us instead of a wildcard.
+                            "Resource": [
+                                Ref("DbMasterSecretArn"),
+                                Ref("LicenseSecretArn"),
+                                Ref("AdminKeySecretArn"),
+                            ],
                         },
                         {
                             "Sid": "ResolveCardinalSsm",

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -84,6 +84,40 @@ def test_execution_role_uses_managed_ecs_policy(td):
     )
 
 
+def test_execution_role_can_read_each_infra_secret_arn(td):
+    """The execution role pulls task `secrets:` env vars at container start.
+
+    DBMasterSecret is CFN-generated and does NOT match a `cardinal-*` prefix,
+    so its ARN must be granted explicitly via Ref(DbMasterSecretArn). Same
+    for License and AdminKey (they happen to have cardinal-* names but the
+    template should rely on the parameter ARNs, not a wildcard).
+    """
+    role = td["Resources"]["ExecutionRole"]["Properties"]
+    policies = role.get("Policies", [])
+    assert policies, "ExecutionRole must declare inline policies"
+
+    secret_stmts = []
+    for p in policies:
+        for s in p.get("PolicyDocument", {}).get("Statement", []):
+            if s.get("Sid") == "ResolveCardinalSecrets":
+                secret_stmts.append(s)
+    assert len(secret_stmts) == 1, "expected exactly one ResolveCardinalSecrets statement"
+
+    stmt = secret_stmts[0]
+    resources = stmt["Resource"]
+    assert isinstance(resources, list), (
+        "ResolveCardinalSecrets.Resource must be a list of specific secret ARNs, "
+        "not a wildcard -- DBMasterSecret has a CFN-generated name and the "
+        "cardinal-* wildcard does not match it"
+    )
+    refs = {tuple(sorted(r.items())) if isinstance(r, dict) else r for r in resources}
+    for param in ("DbMasterSecretArn", "LicenseSecretArn", "AdminKeySecretArn"):
+        assert (("Ref", param),) in refs, (
+            f"ExecutionRole must grant secrets:GetSecretValue on Ref({param}); "
+            f"got resources={resources}"
+        )
+
+
 def test_all_task_roles_trust_ecs_tasks(td):
     for role_id in (
         "MigrationRole", "QueryRole", "ProcessRole",


### PR DESCRIPTION
## Summary

- The Security child's ExecutionRole granted `secretsmanager:GetSecretValue` only on the `cardinal-*` secret prefix.
- The DBMaster secret created by `cardinal-infrastructure` has a CFN-generated name (`DBMasterSecret-<hash>-<random>`), which does not match that prefix.
- Every task that mounts the DB password via `secrets:` failed at container start with `AccessDeniedException`. Migration's deployment circuit breaker fired, taking the whole `cardinal-lakerunner` stack to `ROLLBACK_COMPLETE`.
- Switch `ResolveCardinalSecrets.Resource` to the three secret-ARN parameter refs (`DbMasterSecretArn`, `LicenseSecretArn`, `AdminKeySecretArn`) the infra stack hands us. The per-tier task roles already do the right thing via `_stmt_secrets_read([...])`; this brings the ExecutionRole into line.
- Add `test_execution_role_can_read_each_infra_secret_arn` that fails if the Resource is a wildcard or is missing any of the three Refs.

## Repro

Hit during the v0.0.79 redeploy of `cardinal-lakerunner` into the lrdev test env. Migration's MigratorService stopped tasks with:

```
ResourceInitializationError: unable to pull secrets ... arn:...:secret:DBMasterSecret-MvZwV3EFWfwh-GtEjf0 ...
AccessDeniedException: ... is not authorized to perform: secretsmanager:GetSecretValue ...
```

## Test plan

- [x] `make test` -- 431 passed, 5 skipped (1 new assertion in `tests/templates/test_security.py`)
- [x] `make build` + cfn-lint clean
- [ ] Redeploy `cardinal-lakerunner` from v0.0.80 and confirm Migration's keepalive container reaches RUNNING (the only essential container; only starts after migrator exits 0)