### PR TITLE
Add deploy-scripts/ -- Jenkins-friendly stack wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ for the layered teardown procedure.
   -- `cardinal-cleanup` task for wiping a test install
 - [`end-to-end-test-plan.md`](docs/operations/end-to-end-test-plan.md)
   -- pre-pivot acceptance test plan (Jenkins-driven)
+- [`deploy-scripts/README.md`](deploy-scripts/README.md)
+  -- env-var-driven wrappers for the four product stacks + the cleanup
+  driver (intended for Jenkins job invocation)
 
 ## Development
 

--- a/deploy-scripts/README.md
+++ b/deploy-scripts/README.md
@@ -1,0 +1,150 @@
+# deploy-scripts/
+
+Jenkins-friendly wrappers for the four product stacks plus the cleanup driver.
+Each wrapper is parameterised entirely through environment variables, with no
+customer-specific identifiers baked into the defaults; an operator points a
+Jenkins job at the script and supplies the env block.
+
+These are thin wrappers. The actual deploy logic lives in
+`scripts/deploy-lakerunner.sh` and `scripts/cleanup-lakerunner.sh` (the
+self-contained drivers), or in straight `aws cloudformation` calls for the
+infrastructure / lrdev tiers. The wrappers here exist to make the input shape
+uniform and to keep customer values out of the repo.
+
+## Order of operations
+
+For a fresh install in an empty account:
+
+1. **VPC** -- customer brings their own. The test environment uses the
+   internal `lrdev-vpc` stack (`deploy-lrdev-vpc.sh`); production installs
+   skip this step.
+2. **ECS cluster** -- customer brings their own. The test environment uses
+   `lrdev-baseinfra` (`deploy-lrdev-baseinfra.sh`); production installs skip
+   this step.
+3. **`cardinal-infrastructure`** -- creates the RDS / S3 / SQS / Secrets /
+   SSM data layer (`deploy-cardinal-infrastructure.sh`).
+4. **`cardinal-lakerunner`** -- creates the application tier; reads the
+   infrastructure stack's outputs at runtime
+   (`deploy-cardinal-lakerunner.sh`).
+
+To tear an install down end-to-end, run `run-cleanup.sh`. It launches the
+cardinal-cleanup Fargate task, which drains ECS services, deletes the
+lakerunner stack, wipes the cardinal-* data layer with ownership-tag
+enforcement, then self-deletes its own stack.
+
+## Scripts
+
+| Script | Purpose | Customer-facing? |
+|---|---|---|
+| `deploy-lrdev-vpc.sh` | Stand up a test-only VPC (NAT GW + 2 AZs). | No -- internal test scaffolding. |
+| `deploy-lrdev-baseinfra.sh` | Stand up a test-only ECS Fargate cluster. | No -- internal test scaffolding. |
+| `deploy-cardinal-infrastructure.sh` | Stand up RDS + S3 ingest + SQS + secrets + SSM. | Yes. |
+| `deploy-cardinal-lakerunner.sh` | Stand up the application tier (ALB + 12 ECS services + DB migration). | Yes. |
+| `run-cleanup.sh` | Run the cleanup task; wipe data layer + tear down stacks. | Yes. |
+| `lib.sh` | Shared helpers (logging, preflight, deploy + monitor). | Sourced; do not execute. |
+
+## Env vars per script
+
+### deploy-lrdev-vpc.sh
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `VERSION` | yes | -- | Published template tag (e.g. `v0.0.80`). |
+| `REGION` | no | `us-east-1` | |
+| `STACK_NAME` | no | `lrdev-vpc` | |
+| `TEMPLATE_BUCKET` | no | `cardinal-cfn-${REGION}` | |
+| `ENVIRONMENT_NAME` | no | `lrdev` | Used in resource Name tags. |
+| `VPC_CIDR` | no | `10.0.0.0/16` | |
+| `CREATE_NAT_GATEWAY` | no | `Yes` | `No` saves ~$30/mo but blocks private-subnet egress. |
+| `CREATE_INTERFACE_ENDPOINTS` | no | `No` | `Yes` adds ~$7/endpoint/month per AZ. |
+
+### deploy-lrdev-baseinfra.sh
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `VERSION` | yes | -- | Published template tag. |
+| `REGION` | no | `us-east-1` | |
+| `STACK_NAME` | no | `lrdev-baseinfra` | |
+| `TEMPLATE_BUCKET` | no | `cardinal-cfn-${REGION}` | |
+| `ENVIRONMENT_NAME` | no | `lrdev` | |
+
+### deploy-cardinal-infrastructure.sh
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `VERSION` | yes | -- | |
+| `VPC_ID` | yes | -- | Customer VPC, must contain `PRIVATE_SUBNETS`. |
+| `PRIVATE_SUBNETS` | yes | -- | CSV of >=2 subnet IDs in distinct AZs. |
+| `LICENSE_DATA` | yes | -- | Cardinal license token (`z64:...`). Marked NoEcho in the template. |
+| `REGION` | no | `us-east-1` | |
+| `STACK_NAME` | no | `cardinal-infrastructure` | |
+| `TEMPLATE_BUCKET` | no | `cardinal-cfn-${REGION}` | |
+| `DB_ENGINE_VERSION` | no | `18.3` | PostgreSQL engine version. |
+| `DB_INSTANCE_CLASS` | no | `db.t3.medium` | |
+| `DB_ALLOCATED_STORAGE` | no | `100` | GiB. |
+| `INGEST_BUCKET_LIFECYCLE_DAYS` | no | `7` | Auto-delete S3 objects after N days. |
+| `ORGANIZATION_ID` | no | canonical UUID | Match across infra and lakerunner. |
+
+### deploy-cardinal-lakerunner.sh
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `VERSION` | yes | -- | |
+| `VPC_ID` | yes | -- | Same VPC as cardinal-infrastructure. |
+| `PRIVATE_SUBNETS` | yes | -- | Same CSV as cardinal-infrastructure. |
+| `CLUSTER_NAME` | yes | -- | Customer's ECS Fargate cluster. |
+| `CLUSTER_ARN` | yes | -- | Full ARN of the cluster. |
+| `DEX_ADMIN_EMAIL` | yes | -- | DEX local-admin login email. |
+| `DEX_ADMIN_PASSWORD_HASH` | yes | -- | bcrypt hash (`$2a$`/`$2b$`/`$2y$`). |
+| `CERTIFICATE_ARN` | one-of | -- | ACM/IAM-server-cert ARN. Use **either** this **or** the PEM trio. |
+| `CERTIFICATE_BODY` | one-of | -- | PEM body. Use with `CERTIFICATE_PRIVATE_KEY`. |
+| `CERTIFICATE_PRIVATE_KEY` | one-of | -- | PEM key. |
+| `CERTIFICATE_CHAIN` | no | empty | Optional intermediate-cert chain (PEM). |
+| `OIDC_SUPERADMIN_EMAILS` | no | `$DEX_ADMIN_EMAIL` | CSV of emails granted superadmin on first login. |
+| `REGION` | no | `us-east-1` | |
+| `STACK_NAME` | no | `cardinal-lakerunner` | |
+| `INFRA_STACK_NAME` | no | `cardinal-infrastructure` | Outputs are read live from here. |
+| `SERVICE_NAMESPACE_NAME` | no | `cardinal.local` | Cloud Map private DNS namespace. |
+| `ORGANIZATION_ID` | no | canonical UUID | Must match the infra stack. |
+
+### run-cleanup.sh
+
+Destructive. Refuses to run unless `CONFIRM=DELETE` is set. Delegates to
+`scripts/cleanup-lakerunner.sh`.
+
+| Var | Required | Default | Notes |
+|---|---|---|---|
+| `CONFIRM` | yes | -- | Must be the literal string `DELETE`. |
+| `VERSION` | yes | -- | |
+| `CLUSTER_NAME` | yes | -- | |
+| `PRIVATE_SUBNETS` | yes | -- | Subnets for the cleanup task ENI. |
+| `TASK_SG_ID` | yes | -- | Security group for the cleanup task ENI. |
+| `CLEANUP_TASK_ROLE_ARN` | yes | -- | Privileged role the cleanup task assumes. |
+| `CLEANUP_EXECUTION_ROLE_ARN` | yes | -- | Fargate execution role. |
+| `DEPLOYER_ROLE_ARN` | yes | -- | CFN service role used to delete the lakerunner stack. |
+| `LAKERUNNER_STACK_NAME` | no | `cardinal-lakerunner` | |
+| `CLEANUP_STACK_NAME` | no | `cardinal-cleanup` | |
+| `WAIT_SELF_DELETE` | no | `false` | Set to `true` to block until cleanup stack self-deletes. |
+
+## Jenkins job topology (recommended)
+
+- One job per script. The job's "Inject environment variables" step supplies
+  the required vars; the script is the build step.
+- All four deploy scripts are idempotent (auto-detect create vs update), so a
+  Jenkins job can deploy the same version repeatedly without operator
+  intervention.
+- Pin every job to a specific `VERSION` -- there is no `latest` tag.
+- For the cleanup job, gate the `CONFIRM=DELETE` env var on a Jenkins
+  password-style parameter so an accidental run is impossible.
+- Capture each script's stdout/stderr (the wrapper streams stack events as
+  they happen; the log is the source of truth).
+
+## Sanity checks performed by every script
+
+1. `aws sts get-caller-identity` succeeds in the requested region.
+2. The published template URL HEAD-200s before the stack call is issued.
+3. The stack is in a state we can act on (`DOES_NOT_EXIST`,
+   `ROLLBACK_COMPLETE`, `*_COMPLETE`); abort on anything else.
+4. For `deploy-cardinal-lakerunner.sh`: the infra stack must be in a
+   `*_COMPLETE` state and every required output must be non-empty.
+5. For `run-cleanup.sh`: `CONFIRM=DELETE` must be set explicitly.

--- a/deploy-scripts/deploy-cardinal-infrastructure.sh
+++ b/deploy-scripts/deploy-cardinal-infrastructure.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Deploy the cardinal-infrastructure stack. Creates RDS, S3 ingest bucket,
+# SQS queue, the cardinal-* Secrets Manager secrets, and the /cardinal/* SSM
+# parameters.
+#
+# The data layer carries DeletionPolicy: Retain / Snapshot; deleting this
+# stack will leave behind the RDS snapshot, the S3 bucket, and the
+# license/admin secrets. Use deploy-scripts/run-cleanup.sh to actually wipe.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib.sh"
+LOG_TAG="cardinal-infra"
+
+REGION="${REGION:-us-east-1}"
+VERSION="${VERSION:?VERSION is required (e.g. v0.0.80)}"
+STACK_NAME="${STACK_NAME:-cardinal-infrastructure}"
+TEMPLATE_BUCKET="${TEMPLATE_BUCKET:-cardinal-cfn-${REGION}}"
+
+# Required networking (no defaults -- customer-specific).
+require_env VPC_ID
+require_env PRIVATE_SUBNETS
+
+# Required customer-specific values.
+require_env LICENSE_DATA
+
+# Optional sizing knobs (have sane defaults).
+DB_ENGINE_VERSION="${DB_ENGINE_VERSION:-18.3}"
+DB_INSTANCE_CLASS="${DB_INSTANCE_CLASS:-db.t3.medium}"
+DB_ALLOCATED_STORAGE="${DB_ALLOCATED_STORAGE:-100}"
+INGEST_BUCKET_LIFECYCLE_DAYS="${INGEST_BUCKET_LIFECYCLE_DAYS:-7}"
+ORGANIZATION_ID="${ORGANIZATION_ID:-12340000-0000-4000-8000-000000000000}"
+
+TEMPLATE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-infrastructure.yaml"
+
+preflight_aws "$REGION"
+verify_template_published "$TEMPLATE_URL"
+
+PARAMS_FILE="$(mktemp "${TMPDIR:-/tmp}/cardinal-infra-params.XXXXXX.json")"
+trap 'rm -f "$PARAMS_FILE"' EXIT
+
+write_params_file "$PARAMS_FILE" \
+  "VpcId=$VPC_ID" \
+  "PrivateSubnets=$PRIVATE_SUBNETS" \
+  "LicenseData=$LICENSE_DATA" \
+  "DBEngineVersion=$DB_ENGINE_VERSION" \
+  "DBInstanceClass=$DB_INSTANCE_CLASS" \
+  "DBAllocatedStorage=$DB_ALLOCATED_STORAGE" \
+  "IngestBucketLifecycleDays=$INGEST_BUCKET_LIFECYCLE_DAYS" \
+  "OrganizationId=$ORGANIZATION_ID"
+
+deploy_stack "$REGION" "$STACK_NAME" "$TEMPLATE_URL" "$PARAMS_FILE" "CAPABILITY_NAMED_IAM"
+
+log "outputs:"
+dump_outputs_as_env "$REGION" "$STACK_NAME"

--- a/deploy-scripts/deploy-cardinal-lakerunner.sh
+++ b/deploy-scripts/deploy-cardinal-lakerunner.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# Deploy the cardinal-lakerunner application stack. Reads the
+# cardinal-infrastructure stack's outputs at runtime and wires them into the
+# lakerunner parameters; the operator only supplies the customer-side
+# identifiers (ECS cluster, VPC, subnets, cert, DEX admin login).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib.sh"
+LOG_TAG="cardinal-lakerunner"
+
+REGION="${REGION:-us-east-1}"
+VERSION="${VERSION:?VERSION is required (e.g. v0.0.80)}"
+STACK_NAME="${STACK_NAME:-cardinal-lakerunner}"
+INFRA_STACK_NAME="${INFRA_STACK_NAME:-cardinal-infrastructure}"
+TEMPLATE_BUCKET="${TEMPLATE_BUCKET:-cardinal-cfn-${REGION}}"
+
+# Required customer-supplied identifiers.
+require_env VPC_ID
+require_env PRIVATE_SUBNETS
+require_env CLUSTER_NAME
+require_env CLUSTER_ARN
+
+# DEX admin login.
+require_env DEX_ADMIN_EMAIL
+require_env DEX_ADMIN_PASSWORD_HASH
+OIDC_SUPERADMIN_EMAILS="${OIDC_SUPERADMIN_EMAILS:-$DEX_ADMIN_EMAIL}"
+
+# TLS for the ALB 443 listener. Provide ONE of:
+#   - CERTIFICATE_ARN (existing ACM or IAM-server-cert ARN), OR
+#   - CERTIFICATE_BODY + CERTIFICATE_PRIVATE_KEY (PEM material -- the cert
+#     child stack builds an AWS::IAM::ServerCertificate from them).
+CERTIFICATE_ARN="${CERTIFICATE_ARN:-}"
+CERTIFICATE_BODY="${CERTIFICATE_BODY:-}"
+CERTIFICATE_PRIVATE_KEY="${CERTIFICATE_PRIVATE_KEY:-}"
+CERTIFICATE_CHAIN="${CERTIFICATE_CHAIN:-}"
+
+if [ -z "$CERTIFICATE_ARN" ] && { [ -z "$CERTIFICATE_BODY" ] || [ -z "$CERTIFICATE_PRIVATE_KEY" ]; }; then
+  die "either CERTIFICATE_ARN, or both CERTIFICATE_BODY and CERTIFICATE_PRIVATE_KEY, must be set"
+fi
+
+# Optional knobs.
+SERVICE_NAMESPACE_NAME="${SERVICE_NAMESPACE_NAME:-cardinal.local}"
+ORGANIZATION_ID="${ORGANIZATION_ID:-12340000-0000-4000-8000-000000000000}"
+
+TEMPLATE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-lakerunner.yaml"
+TEMPLATE_BASE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-lakerunner/"
+
+preflight_aws "$REGION"
+verify_template_published "$TEMPLATE_URL"
+
+# ---------------------------------------------------------------------------
+# Read infra-stack outputs (the lakerunner parameters that "really live" on
+# cardinal-infrastructure).
+# ---------------------------------------------------------------------------
+log "reading $INFRA_STACK_NAME outputs from $REGION"
+status="$(describe_stack_status "$REGION" "$INFRA_STACK_NAME")"
+case "$status" in
+  *_COMPLETE) ;;
+  *) die "$INFRA_STACK_NAME is $status; must be *_COMPLETE before deploying $STACK_NAME" ;;
+esac
+
+infra_out() {
+  aws cloudformation describe-stacks --region "$REGION" --stack-name "$INFRA_STACK_NAME" \
+    --query "Stacks[0].Outputs[?OutputKey=='$1'].OutputValue | [0]" --output text
+}
+
+DB_ENDPOINT="$(infra_out DbEndpoint)"
+DB_MASTER_SECRET_ARN="$(infra_out DbMasterSecretArn)"
+INGEST_BUCKET_NAME="$(infra_out IngestBucketName)"
+INGEST_QUEUE_URL="$(infra_out IngestQueueUrl)"
+INGEST_QUEUE_ARN="$(infra_out IngestQueueArn)"
+LICENSE_SECRET_ARN="$(infra_out LicenseSecretArn)"
+ADMIN_KEY_SECRET_ARN="$(infra_out AdminKeySecretArn)"
+STORAGE_PROFILES_PARAM_NAME="$(infra_out StorageProfilesParamName)"
+API_KEYS_PARAM_NAME="$(infra_out ApiKeysParamName)"
+RDS_SECURITY_GROUP_ID="$(infra_out RdsSecurityGroupId)"
+
+for v in DB_ENDPOINT DB_MASTER_SECRET_ARN INGEST_BUCKET_NAME INGEST_QUEUE_URL \
+         INGEST_QUEUE_ARN LICENSE_SECRET_ARN ADMIN_KEY_SECRET_ARN \
+         STORAGE_PROFILES_PARAM_NAME API_KEYS_PARAM_NAME RDS_SECURITY_GROUP_ID; do
+  if [ -z "${!v}" ] || [ "${!v}" = "None" ]; then
+    die "$INFRA_STACK_NAME output for $v is empty"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Build params file. PEM material is multi-line; use Python for safe JSON.
+# ---------------------------------------------------------------------------
+PARAMS_FILE="$(mktemp "${TMPDIR:-/tmp}/cardinal-lakerunner-params.XXXXXX.json")"
+trap 'rm -f "$PARAMS_FILE"' EXIT
+
+CERT_BODY="$CERTIFICATE_BODY" \
+CERT_KEY="$CERTIFICATE_PRIVATE_KEY" \
+CERT_CHAIN="$CERTIFICATE_CHAIN" \
+python3 - "$PARAMS_FILE" \
+  "$DB_ENDPOINT" "$DB_MASTER_SECRET_ARN" \
+  "$INGEST_BUCKET_NAME" "$INGEST_QUEUE_URL" "$INGEST_QUEUE_ARN" \
+  "$LICENSE_SECRET_ARN" "$ADMIN_KEY_SECRET_ARN" \
+  "$STORAGE_PROFILES_PARAM_NAME" "$API_KEYS_PARAM_NAME" "$RDS_SECURITY_GROUP_ID" \
+  "$VPC_ID" "$PRIVATE_SUBNETS" \
+  "$CLUSTER_NAME" "$CLUSTER_ARN" \
+  "$CERTIFICATE_ARN" \
+  "$DEX_ADMIN_EMAIL" "$DEX_ADMIN_PASSWORD_HASH" "$OIDC_SUPERADMIN_EMAILS" \
+  "$TEMPLATE_BASE_URL" "$ORGANIZATION_ID" "$SERVICE_NAMESPACE_NAME" <<'PY'
+import json, os, sys
+
+(out_path,
+ db_endpoint, db_master_secret_arn,
+ ingest_bucket, ingest_queue_url, ingest_queue_arn,
+ license_secret_arn, admin_key_secret_arn,
+ storage_profiles_param, api_keys_param, rds_sg_id,
+ vpc_id, private_subnets,
+ cluster_name, cluster_arn,
+ cert_arn,
+ dex_email, dex_hash, oidc_admins,
+ tmpl_base, org_id, ns_name) = sys.argv[1:]
+
+cert_body  = os.environ.get("CERT_BODY", "")
+cert_key   = os.environ.get("CERT_KEY", "")
+cert_chain = os.environ.get("CERT_CHAIN", "")
+
+params = [
+    {"ParameterKey": "DbEndpoint",                "ParameterValue": db_endpoint},
+    {"ParameterKey": "DbMasterSecretArn",         "ParameterValue": db_master_secret_arn},
+    {"ParameterKey": "IngestBucketName",          "ParameterValue": ingest_bucket},
+    {"ParameterKey": "IngestQueueUrl",            "ParameterValue": ingest_queue_url},
+    {"ParameterKey": "IngestQueueArn",            "ParameterValue": ingest_queue_arn},
+    {"ParameterKey": "LicenseSecretArn",          "ParameterValue": license_secret_arn},
+    {"ParameterKey": "AdminKeySecretArn",         "ParameterValue": admin_key_secret_arn},
+    {"ParameterKey": "StorageProfilesParamName",  "ParameterValue": storage_profiles_param},
+    {"ParameterKey": "ApiKeysParamName",          "ParameterValue": api_keys_param},
+    {"ParameterKey": "RdsSecurityGroupId",        "ParameterValue": rds_sg_id},
+    {"ParameterKey": "VpcId",                     "ParameterValue": vpc_id},
+    {"ParameterKey": "PrivateSubnets",            "ParameterValue": private_subnets},
+    {"ParameterKey": "ClusterName",               "ParameterValue": cluster_name},
+    {"ParameterKey": "ClusterArn",                "ParameterValue": cluster_arn},
+    {"ParameterKey": "CertificateArn",            "ParameterValue": cert_arn},
+    {"ParameterKey": "CertificateBody",           "ParameterValue": cert_body},
+    {"ParameterKey": "CertificatePrivateKey",     "ParameterValue": cert_key},
+    {"ParameterKey": "CertificateChain",          "ParameterValue": cert_chain},
+    {"ParameterKey": "DexAdminEmail",             "ParameterValue": dex_email},
+    {"ParameterKey": "DexAdminPasswordHash",      "ParameterValue": dex_hash},
+    {"ParameterKey": "OidcSuperadminEmails",      "ParameterValue": oidc_admins},
+    {"ParameterKey": "TemplateBaseUrl",           "ParameterValue": tmpl_base},
+    {"ParameterKey": "OrganizationId",            "ParameterValue": org_id},
+    {"ParameterKey": "ServiceNamespaceName",      "ParameterValue": ns_name},
+    {"ParameterKey": "OtelConfigYaml",            "ParameterValue": ""},
+]
+with open(out_path, "w") as f:
+    json.dump(params, f, indent=2)
+PY
+
+log "parameter file ready ($(wc -c <"$PARAMS_FILE") bytes, $(jq '. | length' "$PARAMS_FILE") params)"
+
+deploy_stack "$REGION" "$STACK_NAME" "$TEMPLATE_URL" "$PARAMS_FILE" \
+  "CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND"
+
+log "outputs:"
+dump_outputs_as_env "$REGION" "$STACK_NAME"

--- a/deploy-scripts/deploy-lrdev-baseinfra.sh
+++ b/deploy-scripts/deploy-lrdev-baseinfra.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Deploy the lrdev-baseinfra stack -- internal test scaffolding that stands up
+# a Fargate-capable ECS cluster (customer-equivalent). NOT a customer-facing
+# artifact. Production installs always bring their own ECS cluster.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib.sh"
+LOG_TAG="lrdev-baseinfra"
+
+REGION="${REGION:-us-east-1}"
+VERSION="${VERSION:?VERSION is required (e.g. v0.0.80)}"
+STACK_NAME="${STACK_NAME:-lrdev-baseinfra}"
+TEMPLATE_BUCKET="${TEMPLATE_BUCKET:-cardinal-cfn-${REGION}}"
+
+ENVIRONMENT_NAME="${ENVIRONMENT_NAME:-lrdev}"
+
+TEMPLATE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/lrdev-baseinfra.yaml"
+
+preflight_aws "$REGION"
+verify_template_published "$TEMPLATE_URL"
+
+PARAMS_FILE="$(mktemp "${TMPDIR:-/tmp}/lrdev-baseinfra-params.XXXXXX.json")"
+trap 'rm -f "$PARAMS_FILE"' EXIT
+
+write_params_file "$PARAMS_FILE" "EnvironmentName=$ENVIRONMENT_NAME"
+
+deploy_stack "$REGION" "$STACK_NAME" "$TEMPLATE_URL" "$PARAMS_FILE" ""
+
+log "outputs:"
+dump_outputs_as_env "$REGION" "$STACK_NAME"

--- a/deploy-scripts/deploy-lrdev-vpc.sh
+++ b/deploy-scripts/deploy-lrdev-vpc.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Deploy the lrdev-vpc stack -- internal test scaffolding that stands up
+# customer-equivalent networking. NOT a customer-facing artifact. Use this in
+# the lakerunner test account; production installs always bring their own VPC.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+. "$SCRIPT_DIR/lib.sh"
+LOG_TAG="lrdev-vpc"
+
+REGION="${REGION:-us-east-1}"
+VERSION="${VERSION:?VERSION is required (e.g. v0.0.80)}"
+STACK_NAME="${STACK_NAME:-lrdev-vpc}"
+TEMPLATE_BUCKET="${TEMPLATE_BUCKET:-cardinal-cfn-${REGION}}"
+
+ENVIRONMENT_NAME="${ENVIRONMENT_NAME:-lrdev}"
+VPC_CIDR="${VPC_CIDR:-10.0.0.0/16}"
+CREATE_NAT_GATEWAY="${CREATE_NAT_GATEWAY:-Yes}"
+CREATE_INTERFACE_ENDPOINTS="${CREATE_INTERFACE_ENDPOINTS:-No}"
+
+TEMPLATE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/lrdev-vpc.yaml"
+
+preflight_aws "$REGION"
+verify_template_published "$TEMPLATE_URL"
+
+PARAMS_FILE="$(mktemp "${TMPDIR:-/tmp}/lrdev-vpc-params.XXXXXX.json")"
+trap 'rm -f "$PARAMS_FILE"' EXIT
+
+write_params_file "$PARAMS_FILE" \
+  "EnvironmentName=$ENVIRONMENT_NAME" \
+  "VpcCidr=$VPC_CIDR" \
+  "CreateNatGateway=$CREATE_NAT_GATEWAY" \
+  "CreateInterfaceEndpoints=$CREATE_INTERFACE_ENDPOINTS"
+
+deploy_stack "$REGION" "$STACK_NAME" "$TEMPLATE_URL" "$PARAMS_FILE" ""
+
+log "outputs:"
+dump_outputs_as_env "$REGION" "$STACK_NAME"

--- a/deploy-scripts/lib.sh
+++ b/deploy-scripts/lib.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# Shared helpers for the deploy-scripts/*.sh family.
+# Source this from a script; do not execute it directly.
+#
+# Conventions
+# -----------
+# - Every deploy script accepts inputs via environment variables only. The
+#   defaults in each script never bake in customer-specific identifiers.
+# - Stdout is structured for Jenkins log readability: timestamped lines with a
+#   tag prefix that the operator can grep.
+# - Exit non-zero on any failure; Jenkins will mark the job red.
+# - Long-running waits stream stack events so the operator can see what AWS is
+#   actually doing instead of watching a static "WAITING..." line.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+LOG_TAG="${LOG_TAG:-deploy}"
+
+log()  { printf '[%s] [%s] %s\n' "$(date -u +%H:%M:%SZ)" "$LOG_TAG" "$*" >&2; }
+die()  { log "FATAL: $*"; exit 1; }
+warn() { log "WARN:  $*"; }
+
+# ---------------------------------------------------------------------------
+# Sanity checks
+# ---------------------------------------------------------------------------
+require_env() {
+  local name="$1"
+  local val="${!name:-}"
+  if [ -z "$val" ]; then
+    die "required env var $name is unset or empty"
+  fi
+}
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "required command '$1' not on PATH"
+}
+
+# Verify the runner can talk to AWS in the requested region and has a usable
+# identity. Prints the account + identity so the Jenkins log shows who deployed.
+preflight_aws() {
+  local region="$1"
+  need_cmd aws
+  need_cmd jq
+  local who
+  who="$(aws sts get-caller-identity --output json 2>&1)" || \
+    die "sts:GetCallerIdentity failed in $region: $who"
+  log "deployer: $(echo "$who" | jq -r '"\(.Account) as \(.Arn)"')"
+  aws --region "$region" ec2 describe-regions --region-names "$region" \
+    >/dev/null 2>&1 || die "region $region is not reachable from this identity"
+}
+
+# HEAD the template URL so we fail loudly if the operator picked a non-existent
+# version instead of producing a confusing CFN "ValidationError" later.
+verify_template_published() {
+  local url="$1"
+  need_cmd curl
+  local code
+  code="$(curl -sI -o /dev/null -w '%{http_code}' "$url")"
+  if [ "$code" != "200" ]; then
+    die "template not reachable at $url (HTTP $code)"
+  fi
+  log "template OK: $url"
+}
+
+# ---------------------------------------------------------------------------
+# Stack lifecycle
+# ---------------------------------------------------------------------------
+describe_stack_status() {
+  local region="$1" stack="$2"
+  aws cloudformation describe-stacks --region "$region" --stack-name "$stack" \
+    --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "DOES_NOT_EXIST"
+}
+
+# Idempotent deploy. Decides create-stack vs update-stack from current status.
+# Args: region, stack, template-url, parameters-file, capabilities-csv.
+deploy_stack() {
+  local region="$1" stack="$2" template_url="$3" params_file="$4" capabilities_csv="$5"
+  local capabilities_arr=()
+  if [ -n "$capabilities_csv" ]; then
+    IFS=',' read -r -a capabilities_arr <<< "$capabilities_csv"
+  fi
+
+  local status
+  status="$(describe_stack_status "$region" "$stack")"
+  log "$stack current state: $status"
+
+  local action waiter
+  case "$status" in
+    DOES_NOT_EXIST)
+      action=create-stack; waiter=stack-create-complete ;;
+    ROLLBACK_COMPLETE|REVIEW_IN_PROGRESS|CREATE_FAILED)
+      log "$stack is $status; deleting before recreating..."
+      aws cloudformation delete-stack --region "$region" --stack-name "$stack"
+      aws cloudformation wait stack-delete-complete --region "$region" --stack-name "$stack"
+      action=create-stack; waiter=stack-create-complete ;;
+    *_COMPLETE)
+      action=update-stack; waiter=stack-update-complete ;;
+    *)
+      die "$stack is in non-actionable state $status; refusing to touch it" ;;
+  esac
+
+  log "running $action on $stack"
+  set +e
+  local out rc
+  if [ "${#capabilities_arr[@]}" -gt 0 ]; then
+    out="$(aws cloudformation "$action" --region "$region" --stack-name "$stack" \
+            --template-url "$template_url" \
+            --parameters "file://$params_file" \
+            --capabilities "${capabilities_arr[@]}" 2>&1)"
+  else
+    out="$(aws cloudformation "$action" --region "$region" --stack-name "$stack" \
+            --template-url "$template_url" \
+            --parameters "file://$params_file" 2>&1)"
+  fi
+  rc=$?
+  set -e
+  if [ "$rc" -ne 0 ]; then
+    if echo "$out" | grep -q "No updates are to be performed"; then
+      log "$stack: no updates required"
+      return 0
+    fi
+    log "$out"
+    die "$action failed for $stack"
+  fi
+
+  log "waiting for $waiter; tailing events..."
+  follow_events_until_terminal "$region" "$stack" "$waiter"
+}
+
+# Stream stack events in real time while the waiter runs. Exits when the
+# waiter exits; on failure, prints the failed events so the operator does not
+# have to scroll through the AWS console.
+follow_events_until_terminal() {
+  local region="$1" stack="$2" waiter="$3"
+
+  aws cloudformation wait "$waiter" --region "$region" --stack-name "$stack" &
+  local wait_pid=$!
+
+  local last_event_ts=""
+  while kill -0 "$wait_pid" 2>/dev/null; do
+    local events
+    events="$(aws cloudformation describe-stack-events --region "$region" --stack-name "$stack" \
+                --query 'reverse(StackEvents[].[Timestamp,LogicalResourceId,ResourceStatus,ResourceStatusReason])' \
+                --output json 2>/dev/null || echo '[]')"
+    echo "$events" | jq -r --arg last "$last_event_ts" '
+      .[] | select(.[0] > $last) |
+      "[\(.[0])] \(.[2]) \(.[1]) \(.[3] // "")"
+    '
+    last_event_ts="$(echo "$events" | jq -r '.[-1][0] // ""')"
+    sleep 10
+  done
+
+  if wait "$wait_pid"; then
+    log "$stack reached terminal-success state"
+  else
+    log "$stack FAILED; recent CREATE_FAILED / UPDATE_FAILED events:"
+    aws cloudformation describe-stack-events --region "$region" --stack-name "$stack" \
+      --query 'StackEvents[?contains(ResourceStatus, `FAILED`)].[Timestamp,LogicalResourceId,ResourceStatus,ResourceStatusReason]' \
+      --output table >&2
+    return 1
+  fi
+}
+
+# Print stack outputs as `KEY=value` lines for downstream scripts to consume.
+dump_outputs_as_env() {
+  local region="$1" stack="$2"
+  aws cloudformation describe-stacks --region "$region" --stack-name "$stack" \
+    --query 'Stacks[0].Outputs[].[OutputKey,OutputValue]' --output text \
+    | awk '{print $1"="$2}'
+}
+
+# Build a parameters file from a sequence of KEY=VALUE pairs.
+write_params_file() {
+  local out="$1"; shift
+  python3 - "$out" "$@" <<'PY'
+import json, sys
+out_path, *kvs = sys.argv[1:]
+params = []
+for kv in kvs:
+    k, _, v = kv.partition("=")
+    params.append({"ParameterKey": k, "ParameterValue": v})
+with open(out_path, "w") as f:
+    json.dump(params, f, indent=2)
+PY
+}

--- a/deploy-scripts/run-cleanup.sh
+++ b/deploy-scripts/run-cleanup.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Jenkins-friendly wrapper around scripts/cleanup-lakerunner.sh.
+#
+# The underlying driver deploys the cardinal-cleanup stack, runs the privileged
+# Fargate task that drains ECS services, deletes the cardinal-lakerunner stack,
+# wipes the cardinal-* data layer (S3 / RDS / SQS / secrets / SSM) with
+# ownership-tag enforcement, and self-deletes the cleanup stack. This wrapper
+# only translates ENV vars -> CLI flags so a Jenkins job can run with a single
+# env block.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+. "$SCRIPT_DIR/lib.sh"
+LOG_TAG="run-cleanup"
+
+REGION="${REGION:-us-east-1}"
+VERSION="${VERSION:?VERSION is required (e.g. v0.0.80)}"
+
+# Required customer-side identifiers for the cleanup task ENI + IAM.
+require_env CLUSTER_NAME
+require_env PRIVATE_SUBNETS
+require_env TASK_SG_ID
+require_env CLEANUP_TASK_ROLE_ARN
+require_env CLEANUP_EXECUTION_ROLE_ARN
+require_env DEPLOYER_ROLE_ARN
+
+LAKERUNNER_STACK_NAME="${LAKERUNNER_STACK_NAME:-cardinal-lakerunner}"
+CLEANUP_STACK_NAME="${CLEANUP_STACK_NAME:-cardinal-cleanup}"
+TEMPLATE_BUCKET="${TEMPLATE_BUCKET:-cardinal-cfn-${REGION}}"
+TEMPLATE_BASE_URL="${TEMPLATE_BASE_URL:-https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner}"
+
+# Safety: cleanup is destructive. Refuse to run unless the operator explicitly
+# sets CONFIRM=DELETE in the environment (Jenkins job parameter).
+if [ "${CONFIRM:-}" != "DELETE" ]; then
+  die 'set CONFIRM=DELETE to confirm. This wipes RDS, S3, SQS, secrets, SSM.'
+fi
+
+preflight_aws "$REGION"
+
+WAIT_FLAG=()
+if [ "${WAIT_SELF_DELETE:-false}" = "true" ]; then
+  WAIT_FLAG+=("--wait-self-delete")
+fi
+
+log "delegating to $REPO_ROOT/scripts/cleanup-lakerunner.sh"
+exec "$REPO_ROOT/scripts/cleanup-lakerunner.sh" \
+  --region "$REGION" \
+  --version "$VERSION" \
+  --cluster-name "$CLUSTER_NAME" \
+  --private-subnets "$PRIVATE_SUBNETS" \
+  --task-sg-id "$TASK_SG_ID" \
+  --cleanup-task-role-arn "$CLEANUP_TASK_ROLE_ARN" \
+  --cleanup-execution-role-arn "$CLEANUP_EXECUTION_ROLE_ARN" \
+  --deployer-role-arn "$DEPLOYER_ROLE_ARN" \
+  --lakerunner-stack-name "$LAKERUNNER_STACK_NAME" \
+  --cleanup-stack-name "$CLEANUP_STACK_NAME" \
+  --template-base-url "$TEMPLATE_BASE_URL" \
+  "${WAIT_FLAG[@]}" \
+  --yes


### PR DESCRIPTION
## Summary

- Add `deploy-scripts/` with five env-var-driven wrappers (`lrdev-vpc`, `lrdev-baseinfra`, `cardinal-infrastructure`, `cardinal-lakerunner`, `run-cleanup`) plus a shared `lib.sh` of helpers (preflight, create/update auto-detect, event-tailing during waits, params-file builder).
- Defaults never bake in customer-specific identifiers; required values fail loudly when missing. The cleanup wrapper additionally refuses to run unless `CONFIRM=DELETE` is set.
- Replaces the `do-not-commit-*.sh` shape going forward; those local-only scripts are left in place for now (still gitignored, still customer-tuned).
- `deploy-scripts/README.md` documents per-script env var tables and the recommended Jenkins job topology.
- Top-level `README.md` cross-links the new dir under Operational docs.

## Test plan

- [x] `bash -n` clean across all five scripts + `lib.sh`
- [x] `lrdev-vpc`, `lrdev-baseinfra`, `cardinal-infrastructure` already deployed by hand in account 493746473138 / us-east-1 during the v0.0.80 bring-up; the wrappers reproduce the same parameter shape. Smoke-running them against the existing stacks is the next obvious validation step but is gated on the in-flight `cardinal-lakerunner` redeploy finishing.
- [ ] One full end-to-end Jenkins-style run (set env vars in a job, invoke the wrapper, watch the streamed events).