### PR TITLE
iam-roles audit: doc + test-enforced per-tier contract; OtelRole s3:PutObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ for the layered teardown procedure.
   -- what the deployer principal needs
 - [`permissions-lakerunner.md`](docs/operations/permissions-lakerunner.md)
   -- what the running application has access to
+- [`iam-roles.md`](docs/operations/iam-roles.md)
+  -- per-tier IAM role contract (what each container needs and why); test-enforced
 - [`deploying.md`](docs/operations/deploying.md)
   -- using a CloudFormation service role
 - [`tearing-down.md`](docs/operations/tearing-down.md)

--- a/docs/operations/iam-roles.md
+++ b/docs/operations/iam-roles.md
@@ -1,0 +1,261 @@
+# IAM roles in `cardinal-lakerunner`
+
+This document is the source of truth for **what each ECS task role and the
+shared execution role need, and why.** When a future container needs new
+AWS APIs, edit this doc first, then update `src/cardinal_cfn/children/security.py`
+to match. Every entry below is enforced by an assertion in
+`tests/templates/test_security.py` -- if you add a permission to the code
+without updating this doc + the matching test, the build is wrong.
+
+The Security child stack
+(`src/cardinal_cfn/children/security.py`) creates **one shared
+ExecutionRole and one TaskRole per service tier**. The root stack
+(`src/cardinal_cfn/root.py`) wires each TaskRole to the child template
+that owns the service(s) using it. There are no per-container roles --
+every container in a tier shares that tier's role.
+
+## Role inventory
+
+| Role | Defined at | Used as TaskRoleArn by | Used as ExecutionRoleArn by |
+|---|---|---|---|
+| `ExecutionRole` | security.py | -- | **all 13 services** (one per task definition) |
+| `MigrationRole` | security.py | migration.py (`MigratorService`) | -- |
+| `QueryRole` | security.py | services_query.py (`QueryApiService`, `QueryWorkerService`) | -- |
+| `ProcessRole` | security.py | services_process.py (`ProcessLogsService`, `ProcessMetricsService`, `ProcessTracesService`, `PubsubSqsService`) | -- |
+| `ControlRole` | security.py | services_control.py (`SweeperService`, `MonitoringService`, `AdminApiService`, `AlertEvaluatorService`) | -- |
+| `OtelRole` | security.py | otel.py (`OtelGrpcService`) | -- |
+| `MaestroRole` | security.py | maestro.py (`MaestroService`) | -- |
+
+## ExecutionRole
+
+The execution role is what **Fargate uses on the agent side** to:
+
+1. Pull the container image from ECR.
+2. Resolve every `Secrets:` entry in the TaskDefinition by calling
+   `secretsmanager:GetSecretValue` or `ssm:GetParameters` *before* the
+   container starts and injecting the value as an env var.
+3. Create the CloudWatch log group + put log events.
+
+A missing perm here surfaces as `ResourceInitializationError: unable to
+pull secrets ... AccessDeniedException` and the deployment circuit
+breaker rolls the stack back. Items 1 and 3 come from the
+AWS-managed `AmazonECSTaskExecutionRolePolicy`; item 2 we own.
+
+### Containers that pull from Secrets Manager
+
+Walk: each TaskDefinition's `secrets:` block lists which Secrets Manager
+ARNs the ExecutionRole must read. Aggregated:
+
+| Secret ARN (parameter Ref) | Pulled by containers in tiers |
+|---|---|
+| `DbMasterSecretArn` | migration (configdb-init, migrator, ensure-storage-profile), query (query-api, query-worker), process (process-{logs,metrics,traces}, pubsub-sqs), control (admin-api, alert-evaluator, monitoring, sweeper), maestro (db-init, mcp-gateway, maestro) |
+| `LicenseSecretArn` | query, process, control, otel, maestro (every container that pulls LICENSE_DATA) |
+| `AdminKeySecretArn` | control (admin-api), maestro (maestro) |
+
+### Containers that pull from SSM Parameter Store
+
+| SSM parameter (parameter Ref) | Pulled by containers in tiers |
+|---|---|
+| `StorageProfilesParamName` | migration (migrator container injects as `STORAGE_PROFILES_YAML`) |
+| `ApiKeysParamName` | migration (migrator container injects as `API_KEYS_YAML`) |
+
+### ExecutionRole policy
+
+```text
+ResolveCardinalSecrets:  secretsmanager:GetSecretValue,DescribeSecret
+                         on [DbMasterSecretArn, LicenseSecretArn, AdminKeySecretArn]
+
+ResolveCardinalSsm:      ssm:GetParameter,GetParameters
+                         on arn:aws:ssm:<region>:<acct>:parameter/cardinal/*
+                         (matches /cardinal/storage-profiles and /cardinal/api-keys)
+
+Managed: arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+         (ECR pull + CloudWatch Logs CreateLogStream/PutLogEvents)
+```
+
+**Why explicit ARN refs, not `cardinal-*` wildcard?** The DBMaster secret has a
+CFN-generated physical name (`DBMasterSecret-<hash>-<random>`) and does not
+match `cardinal-*`. License and Admin secrets do have `cardinal-` names but
+are listed by ARN for consistency and so a wildcard tightening never breaks
+the contract again. See PR #135 for the regression.
+
+## MigrationRole
+
+| Service(s) | Containers |
+|---|---|
+| `MigratorService` | configdb-init, migrator, ensure-storage-profile, keepalive |
+
+**What the containers do at runtime:**
+- `configdb-init`: connects to RDS with username/password (no AWS API).
+- `migrator`: `lakerunner migrate --databases=lrdb,configdb`. Connects to
+  RDS with username/password; reads storage-profiles + api-keys YAML
+  passed in via env var; may re-fetch Secrets / SSM on hot-reload.
+- `ensure-storage-profile`: seeds canonical storage profile into
+  configdb via SQL.
+- `keepalive`: sleeps.
+
+**Required policy:**
+```text
+ReadSecrets:    secretsmanager:Get/DescribeSecret on [DbMasterSecretArn]
+ReadSsmParams:  ssm:GetParameter,GetParameters on [StorageProfilesParamName, ApiKeysParamName]
+CloudWatchLogs: logs:CreateLogStream,PutLogEvents on the tier log groups
+```
+
+**Must NOT have:** S3 (no data plane), SQS, Bedrock, ECS API.
+
+## QueryRole
+
+| Service(s) | Containers |
+|---|---|
+| `QueryApiService` | query-api |
+| `QueryWorkerService` | query-worker |
+
+**What the containers do at runtime:**
+- `query-api`: receives queries from the ALB; reads cooked Parquet from
+  `s3://<ingest-bucket>/db/...`; queries lrdb for index/metadata;
+  fans out to query-workers discovered via `ecs:DescribeTasks` on the
+  cluster.
+- `query-worker`: receives subqueries from query-api; reads cooked
+  Parquet from S3.
+
+**Required policy:**
+```text
+ReadSecrets:    secretsmanager:Get/DescribeSecret on [DbMasterSecretArn, LicenseSecretArn]
+ReadSsmParams:  ssm:GetParameter,GetParameters on [StorageProfilesParamName, ApiKeysParamName]
+IngestBucketRead: s3:GetObject,ListBucket,GetBucketLocation on ${BucketName}[/*]
+CloudWatchLogs: logs:CreateLogStream,PutLogEvents on tier log groups
+DescribeWorkerTasks: ecs:DescribeServices,DescribeTasks,ListTasks
+                    restricted by Condition ArnEquals ecs:cluster=${ClusterArn}
+```
+
+**Must NOT have:** S3 write/delete (read-only on the query path), SQS,
+Bedrock, ECS UpdateService.
+
+## ProcessRole
+
+| Service(s) | Containers |
+|---|---|
+| `ProcessLogsService` | process-logs |
+| `ProcessMetricsService` | process-metrics |
+| `ProcessTracesService` | process-traces |
+| `PubsubSqsService` | pubsub-sqs |
+
+**What the containers do at runtime:**
+- `process-{logs,metrics,traces}`: consume SQS notifications about new
+  `otel-raw/` uploads; download the raw OTLP files from S3; transform
+  to cooked Parquet; write back to S3 under `db/`. May call Bedrock
+  foundation models for enrichment (see PR -- per-tier roles spec).
+- `pubsub-sqs`: keeps the S3 → SQS notification queue drained / forwards
+  events; reads SQS, may write back acknowledgements.
+
+**Required policy:**
+```text
+ReadSecrets:    secretsmanager:Get/DescribeSecret on [DbMasterSecretArn, LicenseSecretArn]
+ReadSsmParams:  ssm:GetParameter,GetParameters on [StorageProfilesParamName, ApiKeysParamName]
+IngestBucketReadWrite: s3:GetObject,PutObject,DeleteObject,ListBucket,GetBucketLocation on ${BucketName}[/*]
+IngestQueueConsume: sqs:ReceiveMessage,DeleteMessage,GetQueueAttributes on ${QueueArn}
+InvokeBedrockFoundationModels:
+    bedrock:InvokeModel,InvokeModelWithResponseStream on arn:aws:bedrock:*::foundation-model/*
+CloudWatchLogs: logs:CreateLogStream,PutLogEvents on tier log groups
+```
+
+**Must NOT have:** ECS API.
+
+## ControlRole
+
+| Service(s) | Containers |
+|---|---|
+| `SweeperService` | sweeper |
+| `MonitoringService` | monitoring |
+| `AdminApiService` | admin-api |
+| `AlertEvaluatorService` | alert-evaluator |
+
+**What the containers do at runtime:**
+- `sweeper`: deletes objects from the ingest bucket past the lifecycle
+  cutoff (after S3 lifecycle has tagged them) and houses-keeps lrdb.
+- `monitoring`: autoscales `process-{logs,metrics,traces}` by calling
+  `ecs:UpdateService` on the cluster (uses the `Process*Replicas`
+  parameters as the ceiling).
+- `admin-api`: admin REST API. Bcrypts the bootstrap admin key from
+  Secrets Manager, writes initial state into lrdb.
+- `alert-evaluator`: runs alert queries against lrdb + S3 cooked data;
+  delivers webhooks (no AWS API for the delivery path).
+
+**Required policy:**
+```text
+ReadSecrets:    secretsmanager:Get/DescribeSecret on [DbMasterSecretArn, LicenseSecretArn, AdminKeySecretArn]
+ReadSsmParams:  ssm:GetParameter,GetParameters on [StorageProfilesParamName, ApiKeysParamName]
+SweeperS3Cleanup: s3:GetObject,ListBucket,DeleteObject on ${BucketName}[/*]
+                  (alert-evaluator also reads under this statement)
+MonitoringEcsScale: ecs:UpdateService,DescribeServices
+                    restricted by Condition ArnEquals ecs:cluster=${ClusterArn}
+CloudWatchLogs: logs:CreateLogStream,PutLogEvents on tier log groups
+```
+
+**Must NOT have:** S3 write to `otel-raw/` or `db/` (sweeper only deletes
+expired files; writes are reserved for OTel + process tier), SQS consume,
+Bedrock, ALB API.
+
+## OtelRole
+
+| Service(s) | Containers |
+|---|---|
+| `OtelGrpcService` | otel-grpc |
+
+**What the container does at runtime:**
+- `otel-grpc`: terminates inbound OTLP gRPC/HTTP (4317 / 4318) from
+  customer collectors; passes through the cardinalhq `chq` processors;
+  writes raw protobuf signal batches under `s3://<ingest-bucket>/otel-raw/...`
+  via the `awss3` exporter.
+
+**Required policy:**
+```text
+ReadSecrets:    secretsmanager:Get/DescribeSecret on [LicenseSecretArn]
+OtelRawWrite:   s3:PutObject on arn:aws:s3:::${BucketName}/otel-raw/*
+                (scoped to the write prefix; OTel never reads or deletes)
+CloudWatchLogs: logs:CreateLogStream,PutLogEvents on tier log groups
+```
+
+**Must NOT have:** S3 GetObject / ListBucket / DeleteObject (write-only
+on `otel-raw/`), SQS, Bedrock, ECS API.
+
+## MaestroRole
+
+| Service(s) | Containers |
+|---|---|
+| `MaestroService` | db-init, mcp-gateway, wait-for-mcp, maestro, dex-init, dex |
+
+**What the containers do at runtime:**
+- `db-init`: runs Maestro's SQL migrations.
+- `mcp-gateway`: serves MCP protocol on an internal port; talks to
+  lakerunner query-api via Cloud Map.
+- `wait-for-mcp`: localhost poll.
+- `maestro`: web UI + REST API. Talks to lrdb, calls lakerunner via
+  internal endpoints (Cloud Map), bootstrap admin key passed in via env.
+- `dex-init`: bootstraps DEX storage in lrdb.
+- `dex`: DEX OIDC IDP. Stores state in lrdb.
+
+**Required policy:**
+```text
+ReadSecrets:    secretsmanager:Get/DescribeSecret on [DbMasterSecretArn, LicenseSecretArn, AdminKeySecretArn]
+ReadSsmParams:  ssm:GetParameter,GetParameters on [StorageProfilesParamName, ApiKeysParamName]
+CloudWatchLogs: logs:CreateLogStream,PutLogEvents on tier log groups
+```
+
+**Must NOT have:** S3, SQS, Bedrock, ECS API.
+
+## Rule for adding new permissions
+
+1. State the **container + AWS API call** in plain English in this doc
+   first.
+2. Add the IAM statement to the appropriate tier role in
+   `src/cardinal_cfn/children/security.py`.
+3. Add a regression assertion to `tests/templates/test_security.py`.
+4. If the new perm changes the ExecutionRole's expected
+   `ResolveCardinalSecrets` / `ResolveCardinalSsm` shape, also update
+   the matching assertion in `test_execution_role_can_read_each_infra_secret_arn`.
+
+Resource scoping is mandatory wherever AWS allows it (ECS cluster condition,
+S3 prefix, Bedrock partition). `Resource: "*"` is only acceptable for
+APIs that AWS does not allow resource scoping on (e.g.
+`ecs:ListTasks`).

--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -566,6 +566,19 @@ def build() -> Template:
                     "Version": "2012-10-17",
                     "Statement": [
                         _stmt_secrets_read(["LicenseSecretArn"]),
+                        # OTel writes raw OTLP signals under otel-raw/ in the
+                        # ingest bucket via the awss3 exporter; the
+                        # process-{logs,metrics,traces} tier reads them and
+                        # writes cooked output under db/. Restrict to the
+                        # write-side prefix only.
+                        {
+                            "Sid": "OtelRawWrite",
+                            "Effect": "Allow",
+                            "Action": ["s3:PutObject"],
+                            "Resource": Sub(
+                                "arn:${AWS::Partition}:s3:::${BucketName}/otel-raw/*"
+                            ),
+                        },
                         _stmt_cw_logs(),
                     ],
                 },

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -282,17 +282,159 @@ def test_query_role_has_ecs_describe_tasks(td):
     assert "ecs:ListTasks" in actions
 
 
+# ---------------------------------------------------------------------------
+# Per-tier role contract -- the source-of-truth audit lives in
+# docs/operations/iam-roles.md. Each tier role is asserted both *positively*
+# (must have these actions, scoped where AWS permits) and *negatively* (must
+# NOT have these actions, to keep blast radius tight). If you add a new
+# permission to a tier role, update the doc + this table + the matching
+# helper below in the same change.
+# ---------------------------------------------------------------------------
+
+# Set of forbidden actions used by `test_otel_role_is_minimal` below.
+_FORBIDDEN_FOR_OTEL = {
+    "s3:GetObject", "s3:ListBucket", "s3:DeleteObject",
+    "sqs:ReceiveMessage", "bedrock:InvokeModel",
+    "ecs:UpdateService", "ecs:DescribeTasks",
+}
+
+
+def _role_actions(td: dict, role_id: str) -> set[str]:
+    role = td["Resources"][role_id]["Properties"]
+    actions: list[str] = []
+    for p in role.get("Policies", []) or []:
+        for s in p.get("PolicyDocument", {}).get("Statement", []):
+            a = s.get("Action", [])
+            actions.extend(a if isinstance(a, list) else [a])
+    return set(actions)
+
+
+# Per-role (required-actions, forbidden-actions) contract derived from the
+# IAM-roles doc. Adjust both this table and the doc when permissions change.
+_TIER_ROLE_CONTRACT = {
+    "MigrationRole": (
+        {  # required
+            "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+            "ssm:GetParameter", "ssm:GetParameters",
+            "logs:CreateLogStream", "logs:PutLogEvents",
+        },
+        {  # forbidden
+            "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket",
+            "sqs:ReceiveMessage", "bedrock:InvokeModel",
+            "ecs:UpdateService", "ecs:DescribeTasks",
+        },
+    ),
+    "QueryRole": (
+        {
+            "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+            "ssm:GetParameter", "ssm:GetParameters",
+            "s3:GetObject", "s3:ListBucket", "s3:GetBucketLocation",
+            "logs:CreateLogStream", "logs:PutLogEvents",
+            "ecs:DescribeTasks", "ecs:ListTasks", "ecs:DescribeServices",
+        },
+        {
+            "s3:PutObject", "s3:DeleteObject",
+            "sqs:ReceiveMessage", "bedrock:InvokeModel",
+            "ecs:UpdateService",
+        },
+    ),
+    "ProcessRole": (
+        {
+            "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+            "ssm:GetParameter", "ssm:GetParameters",
+            "s3:GetObject", "s3:PutObject", "s3:DeleteObject",
+            "s3:ListBucket", "s3:GetBucketLocation",
+            "sqs:ReceiveMessage", "sqs:DeleteMessage", "sqs:GetQueueAttributes",
+            "bedrock:InvokeModel", "bedrock:InvokeModelWithResponseStream",
+            "logs:CreateLogStream", "logs:PutLogEvents",
+        },
+        {
+            "ecs:UpdateService", "ecs:DescribeTasks",
+        },
+    ),
+    "ControlRole": (
+        {
+            "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+            "ssm:GetParameter", "ssm:GetParameters",
+            "s3:GetObject", "s3:ListBucket", "s3:DeleteObject",
+            "ecs:UpdateService", "ecs:DescribeServices",
+            "logs:CreateLogStream", "logs:PutLogEvents",
+        },
+        {
+            "s3:PutObject",  # sweeper/alert-evaluator never write to S3
+            "sqs:ReceiveMessage", "bedrock:InvokeModel",
+        },
+    ),
+    "OtelRole": (
+        {
+            "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+            "s3:PutObject",
+            "logs:CreateLogStream", "logs:PutLogEvents",
+        },
+        _FORBIDDEN_FOR_OTEL,
+    ),
+    "MaestroRole": (
+        {
+            "secretsmanager:GetSecretValue", "secretsmanager:DescribeSecret",
+            "ssm:GetParameter", "ssm:GetParameters",
+            "logs:CreateLogStream", "logs:PutLogEvents",
+        },
+        {
+            "s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket",
+            "sqs:ReceiveMessage", "bedrock:InvokeModel",
+            "ecs:UpdateService", "ecs:DescribeTasks",
+        },
+    ),
+}
+
+
+@pytest.mark.parametrize("role_id", sorted(_TIER_ROLE_CONTRACT.keys()))
+def test_tier_role_required_actions_present(td, role_id):
+    required, _ = _TIER_ROLE_CONTRACT[role_id]
+    actions = _role_actions(td, role_id)
+    missing = required - actions
+    assert not missing, (
+        f"{role_id} is missing required actions: {sorted(missing)!r}. "
+        f"See docs/operations/iam-roles.md for the contract."
+    )
+
+
+@pytest.mark.parametrize("role_id", sorted(_TIER_ROLE_CONTRACT.keys()))
+def test_tier_role_forbidden_actions_absent(td, role_id):
+    _, forbidden = _TIER_ROLE_CONTRACT[role_id]
+    actions = _role_actions(td, role_id)
+    overreach = forbidden & actions
+    assert not overreach, (
+        f"{role_id} overreaches with actions it should not have: "
+        f"{sorted(overreach)!r}. See docs/operations/iam-roles.md."
+    )
+
+
 def test_otel_role_is_minimal(td):
-    """OTel role only reads the license + writes CW logs."""
+    """OTel role only reads the license, writes CW logs, and puts raw OTLP
+    signals into the ``otel-raw/`` prefix of the ingest bucket. It must NOT
+    have read/list/delete on the bucket, SQS consume, Bedrock, or ECS API."""
     role = td["Resources"]["OtelRole"]["Properties"]
     statements = role["Policies"][0]["PolicyDocument"]["Statement"]
     actions = []
     for s in statements:
         a = s["Action"]
         actions.extend(a if isinstance(a, list) else [a])
-    # No S3, no SQS, no Bedrock, no ECS.
-    forbidden = {"s3:GetObject", "sqs:ReceiveMessage", "bedrock:InvokeModel",
-                 "ecs:UpdateService", "ecs:DescribeTasks"}
-    assert not (forbidden & set(actions)), (
-        f"otel role overreaches: {forbidden & set(actions)!r}"
+    assert not (_FORBIDDEN_FOR_OTEL & set(actions)), (
+        f"otel role overreaches: {_FORBIDDEN_FOR_OTEL & set(actions)!r}"
     )
+    # Must be able to PutObject into otel-raw/ (the awss3 exporter target).
+    put_stmts = [s for s in statements if "s3:PutObject" in (
+        s["Action"] if isinstance(s["Action"], list) else [s["Action"]]
+    )]
+    assert put_stmts, "OtelRole must grant s3:PutObject (for awss3 exporter)"
+    for s in put_stmts:
+        res = s["Resource"]
+        res_strs = res if isinstance(res, list) else [res]
+        for r in res_strs:
+            if isinstance(r, dict) and "Fn::Sub" in r:
+                template = r["Fn::Sub"]
+                assert template.endswith("/otel-raw/*"), (
+                    f"OtelRole PutObject resource must be scoped to otel-raw/* "
+                    f"prefix; got: {template}"
+                )


### PR DESCRIPTION
## Summary

We hit two IAM gaps at deploy time in one session (ExecutionRole missing DBMaster secret access in PR #135, and OtelRole missing `s3:PutObject` for the `awss3` exporter). Both existed because there was no canonical per-role contract and no parametrised regression test. This PR closes the loop.

### docs/operations/iam-roles.md

Per role, documents:
- which ECS services use it as `TaskRoleArn`
- the containers in those services and what each does at runtime
- the required IAM statements with reasoning
- the forbidden actions (blast-radius shrink)

Includes the same audit for the shared `ExecutionRole` -- which containers pull which secrets/SSM params via the TaskDefinition `secrets:` block, and why that drives the policy shape.

### src/cardinal_cfn/children/security.py

Adds the missing `s3:PutObject` on `arn:aws:s3:::${BucketName}/otel-raw/*` to `OtelRole`. Without it the OTel collector starts, accepts traffic, then the `awss3` exporter rejects every batch with `AccessDenied`. The deployment circuit breaker eventually rolls the stack back.

### tests/templates/test_security.py

Adds `_TIER_ROLE_CONTRACT`, a single table mirroring the doc (required actions + forbidden actions per tier role). Parametrised assertions:
- `test_tier_role_required_actions_present[<role>]` -- one per role; fails loudly listing the missing actions and pointing at the doc
- `test_tier_role_forbidden_actions_absent[<role>]` -- same shape on the negative side

12 new parametrised cases.

### Rule going forward

To add a new permission: edit `docs/operations/iam-roles.md` first, then add the IAM statement in `security.py`, then update `_TIER_ROLE_CONTRACT`. If you skip the doc the test will pass but the audit drifts; if you skip the test the doc drifts. Both is the contract.

## Test plan

- [x] `make test` -- 443 passed, 5 skipped (12 new parametrised assertions)
- [x] `make build` + cfn-lint clean
- [ ] Redeploy `cardinal-lakerunner` from v0.0.81 against the lrdev test env and watch every tier come up cleanly past Migration