### PR TITLE
Open OTel health-check port 13133 to the ALB SG

### DIFF
--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -68,6 +68,7 @@ _QUERY_API_PORT = 8080
 _QUERY_WORKER_PORT = 8081
 _ADMIN_API_PORT = 9091
 _OTLP_HTTP_PORT = 4318
+_OTEL_HEALTH_PORT = 13133  # otel.py's target group sets HealthCheckPort=13133
 _MAESTRO_PORT = 4200
 _MAESTRO_DEX_PORT = 5556
 
@@ -285,7 +286,10 @@ def build() -> Template:
         Description="ALB to admin-api",
     ))
 
-    # ALB -> otel on 4318
+    # ALB -> otel on 4318 (data plane) and 13133 (health check). The OTel
+    # target group routes traffic to 4318 but health-checks 13133, so both
+    # ports must be reachable from the ALB SG or the ECS task is marked
+    # unhealthy and the deployment circuit breaker rolls the stack back.
     t.add_resource(SecurityGroupIngress(
         "OtelFromAlb",
         GroupId=Ref(otel_sg),
@@ -293,7 +297,16 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_OTLP_HTTP_PORT,
         ToPort=_OTLP_HTTP_PORT,
-        Description="ALB to otel-collector",
+        Description="ALB to otel-collector data plane",
+    ))
+    t.add_resource(SecurityGroupIngress(
+        "OtelHealthFromAlb",
+        GroupId=Ref(otel_sg),
+        SourceSecurityGroupId=Ref(alb_sg),
+        IpProtocol="tcp",
+        FromPort=_OTEL_HEALTH_PORT,
+        ToPort=_OTEL_HEALTH_PORT,
+        Description="ALB health probe to otel-collector",
     ))
     # Lakerunner tasks -> otel on 4318 (self-telemetry from each tier)
     for tier_title, tier_ref in [

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -210,6 +210,21 @@ def test_alb_to_otel_4318(td):
     assert rule["SourceSecurityGroupId"] == {"Ref": "AlbSecurityGroup"}
 
 
+def test_alb_to_otel_health_13133(td):
+    """The OTel target group health-checks on port 13133, not 4318. Without
+    an ALB-SG -> OTel-SG rule on 13133 the ECS task is marked unhealthy by
+    the ALB and the deployment circuit breaker rolls the stack back.
+
+    OTel is the only tier that uses HealthCheckPort != traffic-port, so the
+    other tiers do not need a separate health-port ingress rule (the
+    data-plane rule already covers them)."""
+    rule = td["Resources"]["OtelHealthFromAlb"]["Properties"]
+    assert rule["FromPort"] == 13133
+    assert rule["ToPort"] == 13133
+    assert rule["SourceSecurityGroupId"] == {"Ref": "AlbSecurityGroup"}
+    assert rule["GroupId"] == {"Ref": "OtelSecurityGroup"}
+
+
 def test_self_telemetry_otel_ingress(td):
     """Query / process / control / maestro all reach the otel collector on 4318."""
     for source in ("Query", "Process", "Control", "Maestro"):


### PR DESCRIPTION
## Summary

- The OTel target group routes traffic to **4318** but health-checks the collector's `health_check` extension on **13133** (see `otel.py:_HEALTH_PORT`). The security child only authorised ALB -> OTel SG on 4318, so the ALB health probe was blocked at the SG, ECS marked every task unhealthy, and the deployment circuit breaker rolled the stack back.
- OTel is the only tier whose target group uses `HealthCheckPort != traffic-port`; every other tier (`QueryApi`, `AdminApi`, `Maestro`, `MaestroDex`) inherits `HealthCheckPort=traffic-port`, so the existing data-plane rules already cover them.
- Add `OtelHealthFromAlb` ingress (port 13133 from ALB SG to OTel SG) and a regression test (`test_alb_to_otel_health_13133`) pinning the exact rule.

## Repro

v0.0.81 redeploy of `cardinal-lakerunner` into the lrdev test env. OTel container starts cleanly with exitCode 0; ECS task is killed with:

```
Task failed ELB health checks in (target-group arn:...:targetgroup/cardin-OtelG-.../...)
```

after which the deployment circuit breaker fires and the Otel child rolls back.

## Test plan

- [x] `make test` -- 444 passed, 5 skipped (1 new assertion)
- [x] `make build` + cfn-lint clean
- [ ] Redeploy `cardinal-lakerunner` from v0.0.82 against the lrdev test env and watch OTel come up healthy