### PR TITLE
cleanup: sweep the Retain'd RDS security group + audit guard

### DIFF
--- a/src/cardinal_cfn/cleanup_script.py
+++ b/src/cardinal_cfn/cleanup_script.py
@@ -77,6 +77,7 @@ log "cleanup_stack=$CLEANUP_STACK_NAME cluster=$CLUSTER_NAME"
 INGEST_BUCKET=""
 DB_INSTANCE_ID=""
 DB_SUBNET_GROUP=""
+RDS_SG_ID=""
 INGEST_QUEUE_URL=""
 SECRET_IDS=""   # space-separated ARNs / names
 SSM_PARAMS=""   # space-separated names
@@ -91,7 +92,7 @@ if aws cloudformation describe-stacks --stack-name "$INFRA_STACK_NAME" >/dev/nul
 import json, sys
 data = json.load(sys.stdin)
 out = {
-    "bucket": "", "db_instance": "", "db_subnet_group": "",
+    "bucket": "", "db_instance": "", "db_subnet_group": "", "rds_sg": "",
     "queue_url": "", "secrets": [], "ssm_params": [],
 }
 for r in data.get("StackResourceSummaries", []):
@@ -102,6 +103,7 @@ for r in data.get("StackResourceSummaries", []):
     if   t == "AWS::S3::Bucket":               out["bucket"] = pid
     elif t == "AWS::RDS::DBInstance":          out["db_instance"] = pid
     elif t == "AWS::RDS::DBSubnetGroup":       out["db_subnet_group"] = pid
+    elif t == "AWS::EC2::SecurityGroup":       out["rds_sg"] = pid
     elif t == "AWS::SQS::Queue":               out["queue_url"] = pid
     elif t == "AWS::SecretsManager::Secret":   out["secrets"].append(pid)
     elif t == "AWS::SSM::Parameter":           out["ssm_params"].append(pid)
@@ -110,6 +112,7 @@ print(json.dumps(out))
     INGEST_BUCKET=$(printf '%s' "$discovered"    | python3 -c 'import json,sys; print(json.load(sys.stdin)["bucket"])')
     DB_INSTANCE_ID=$(printf '%s' "$discovered"   | python3 -c 'import json,sys; print(json.load(sys.stdin)["db_instance"])')
     DB_SUBNET_GROUP=$(printf '%s' "$discovered"  | python3 -c 'import json,sys; print(json.load(sys.stdin)["db_subnet_group"])')
+    RDS_SG_ID=$(printf '%s' "$discovered"        | python3 -c 'import json,sys; print(json.load(sys.stdin)["rds_sg"])')
     INGEST_QUEUE_URL=$(printf '%s' "$discovered" | python3 -c 'import json,sys; print(json.load(sys.stdin)["queue_url"])')
     SECRET_IDS=$(printf '%s' "$discovered"       | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin)["secrets"]))')
     SSM_PARAMS=$(printf '%s' "$discovered"       | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin)["ssm_params"]))')
@@ -117,6 +120,7 @@ print(json.dumps(out))
     log "  bucket           = $INGEST_BUCKET"
     log "  db_instance      = $DB_INSTANCE_ID"
     log "  db_subnet_group  = $DB_SUBNET_GROUP"
+    log "  rds_sg           = $RDS_SG_ID"
     log "  queue_url        = $INGEST_QUEUE_URL"
     log "  secrets          = $SECRET_IDS"
     log "  ssm_params       = $SSM_PARAMS"
@@ -402,7 +406,20 @@ delete_db_subnet_group() {
     aws rds delete-db-subnet-group --db-subnet-group-name "$DB_SUBNET_GROUP"
 }
 
-# 4f -- RDS snapshots produced by step 3 (Snapshot DeletionPolicy)
+# 4f -- RDS security group (DeletionPolicy: Retain on the infra stack so it
+# survives lakerunner stack deletes; cleanup must wipe it or the customer's
+# VPC delete is blocked by this dependency).
+delete_rds_security_group() {
+    if [ -z "$RDS_SG_ID" ]; then return 0; fi
+    if ! aws ec2 describe-security-groups --group-ids "$RDS_SG_ID" >/dev/null 2>&1; then
+        log "RDS security group $RDS_SG_ID already absent"
+        return 0
+    fi
+    log "deleting RDS security group $RDS_SG_ID"
+    aws ec2 delete-security-group --group-id "$RDS_SG_ID"
+}
+
+# 4g -- RDS snapshots produced by step 3 (Snapshot DeletionPolicy)
 delete_rds_snapshots() {
     if [ -z "$DB_INSTANCE_ID" ]; then return 0; fi
     snaps=$(aws rds describe-db-snapshots \
@@ -421,6 +438,7 @@ delete_secrets
 delete_ssm
 delete_sqs
 delete_db_subnet_group
+delete_rds_security_group
 delete_rds_snapshots
 
 # ===========================================================================

--- a/tests/templates/test_cleanup_covers_retained_resources.py
+++ b/tests/templates/test_cleanup_covers_retained_resources.py
@@ -1,0 +1,85 @@
+"""Regression: every resource that cardinal-infrastructure marks Retain (or
+Snapshot) must have a corresponding sweep step in cleanup_script.SCRIPT.
+
+Without this, adding a new Retain'd resource type to the infra stack would
+silently leave that resource behind after a cleanup run -- exactly the bug
+that left the RdsSecurityGroup blocking `lrdev-vpc` delete the first time
+the rewritten cleanup ran end-to-end.
+
+The test does not enforce naming; it just checks that for each Retain'd
+resource type, the cleanup script:
+
+1. discovers the physical ID into a known variable, AND
+2. references that variable in a delete function
+
+A new Retain'd resource type forces the author to extend
+``_RETAINED_TYPE_DISCOVERY`` here, which surfaces the missing sweep in CI.
+"""
+
+import json
+
+import pytest
+
+from cardinal_cfn import cardinal_infrastructure
+from cardinal_cfn.cleanup_script import SCRIPT
+
+
+# CloudFormation resource type -> (discovery line marker in SCRIPT,
+#                                  sweep function name / call in SCRIPT).
+#
+# When a new resource type with Retain (or Snapshot) policy lands in
+# cardinal-infrastructure, add it here and add the corresponding discovery
+# + delete-function in cleanup_script.py.
+_RETAINED_TYPE_DISCOVERY = {
+    "AWS::S3::Bucket":              ("INGEST_BUCKET=",   "delete_ingest_bucket"),
+    "AWS::SecretsManager::Secret":  ("SECRET_IDS=",      "delete_secrets"),
+    "AWS::SSM::Parameter":          ("SSM_PARAMS=",      "delete_ssm"),
+    "AWS::SQS::Queue":              ("INGEST_QUEUE_URL=", "delete_sqs"),
+    "AWS::RDS::DBSubnetGroup":      ("DB_SUBNET_GROUP=", "delete_db_subnet_group"),
+    "AWS::EC2::SecurityGroup":      ("RDS_SG_ID=",       "delete_rds_security_group"),
+    # DBInstance has DeletionPolicy: Snapshot; CFN handles the snapshot+delete
+    # itself during step 3, then step 4 cleans up the leftover snapshots.
+    "AWS::RDS::DBInstance":         ("DB_INSTANCE_ID=",  "delete_rds_snapshots"),
+}
+
+
+def _retained_resource_types() -> set[str]:
+    td = json.loads(cardinal_infrastructure.build().to_json())
+    return {
+        r["Type"]
+        for r in td["Resources"].values()
+        if r.get("DeletionPolicy") in ("Retain", "Snapshot")
+    }
+
+
+def test_every_retained_type_is_in_the_audit_table():
+    """If this fails, a new Retain'd resource type was added to
+    cardinal-infrastructure without a corresponding sweep entry below.
+    Add it to ``_RETAINED_TYPE_DISCOVERY`` and add a discovery + delete
+    function in ``cleanup_script.SCRIPT``."""
+    declared = _retained_resource_types()
+    covered = set(_RETAINED_TYPE_DISCOVERY.keys())
+    new = declared - covered
+    assert not new, (
+        f"new Retain'd resource type(s) in cardinal-infrastructure: {sorted(new)!r}. "
+        f"Add a discovery + sweep step in cleanup_script.py and an entry in "
+        f"tests/templates/test_cleanup_covers_retained_resources.py."
+    )
+    stale = covered - declared
+    assert not stale, (
+        f"entries in _RETAINED_TYPE_DISCOVERY no longer exist in "
+        f"cardinal-infrastructure: {sorted(stale)!r}"
+    )
+
+
+@pytest.mark.parametrize("resource_type", sorted(_RETAINED_TYPE_DISCOVERY.keys()))
+def test_cleanup_script_discovers_and_sweeps_retained_type(resource_type):
+    discovery_marker, sweep_marker = _RETAINED_TYPE_DISCOVERY[resource_type]
+    assert discovery_marker in SCRIPT, (
+        f"cleanup_script.SCRIPT does not assign discovery variable matching "
+        f"{discovery_marker!r} for {resource_type}"
+    )
+    assert sweep_marker in SCRIPT, (
+        f"cleanup_script.SCRIPT does not contain sweep function "
+        f"{sweep_marker!r} for {resource_type}"
+    )


### PR DESCRIPTION
## Summary

Why lrdev-vpc delete failed after PR #139's cleanup ran: the four-step cleanup didn't include the `RdsSecurityGroup` in its step-4 sweep. The SG has `DeletionPolicy: Retain` on `cardinal-infrastructure` (intentional -- a customer rebuild reuses the SG's history), so step 3's `delete-stack cardinal-infrastructure` left it behind, and step 4 never touched it. The SG stays attached to the customer's VPC and blocks any subsequent VPC delete with `"vpc has dependencies"`.

- Add `delete_rds_security_group` to step 4 of `cleanup_script.SCRIPT`.
- Add an `RDS_SG_ID` discovery slot populated from `AWS::EC2::SecurityGroup` resources in the infra stack.

### Regression guard

`tests/templates/test_cleanup_covers_retained_resources.py` walks every Retain/Snapshot resource type in `cardinal-infrastructure` and asserts `cleanup_script.SCRIPT` both discovers a physical-ID variable and references a delete function for that type. A new Retain'd resource type forces the author to extend the audit table in the test (which lives at the top of the file in 7 lines), which surfaces the missing sweep immediately. This is the contract that would have caught the SG miss in PR #139.

## Test plan

- [x] `make test` -- 445 passed, 5 skipped (8 new parametrised assertions: 1 audit-table guard + 7 per-type discover-and-sweep checks)
- [x] `make build` + cfn-lint clean
- [x] Manual recovery already done in the lrdev account; the VPC delete that was blocking is now clean.