### PR TITLE
AlbScheme: internal vs internet-facing toggle

### DIFF
--- a/src/cardinal_cfn/children/alb.py
+++ b/src/cardinal_cfn/children/alb.py
@@ -4,10 +4,16 @@ The ALB security group and the ALB-to-task ingress rules are customer-owned
 (see ``docs/operations/required-roles.md``); this stack consumes the SG ID
 and never creates or mutates security groups.
 
-The OTel listener is HTTP (not HTTPS): the ALB is internal-scheme and the
+The OTel listener is HTTP (not HTTPS): when the ALB is internal-scheme the
 deployment model assumes the caller has VPC-layer reachability (peering /
-TGW / VPN). Plain OTLP/HTTP on 4318 matches the target group's protocol
-and removes the need to install the ALB cert on external senders.
+TGW / VPN). Plain OTLP/HTTP on 4318 matches the target group's protocol and
+removes the need to install the ALB cert on external senders.
+
+The ``Scheme`` parameter selects between internal (default; production) and
+internet-facing (for test/dev environments where browser access from outside
+the VPC is required -- e.g. so OIDC redirects to the ALB's DNS resolve from
+a developer's laptop). When internet-facing, the operator must supply public
+subnets via the root's ``PublicSubnets`` parameter.
 """
 
 from troposphere import (
@@ -48,9 +54,28 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
-            "PrivateSubnetsCsv",
+            "AlbSubnetsCsv",
             Type="String",
-            Description="Comma-separated private subnet IDs.",
+            Description=(
+                "Comma-separated subnet IDs the ALB is attached to. Must be "
+                "private subnets when Scheme=internal; public subnets when "
+                "Scheme=internet-facing. Wired by the root template."
+            ),
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "Scheme",
+            Type="String",
+            Default="internal",
+            AllowedValues=["internal", "internet-facing"],
+            Description=(
+                "ALB scheme. Default 'internal' keeps the ALB private and "
+                "requires VPC-layer reachability (peering / TGW / VPN / SSM "
+                "port-forward). Set 'internet-facing' for dev/test "
+                "environments where browser access from outside the VPC is "
+                "needed -- e.g. OIDC redirect-back-to-ALB flows."
+            ),
         )
     )
     t.add_parameter(
@@ -71,8 +96,8 @@ def build() -> Template:
     alb = t.add_resource(
         LoadBalancer(
             "Alb",
-            Scheme="internal",
-            Subnets=Split(",", Ref("PrivateSubnetsCsv")),
+            Scheme=Ref("Scheme"),
+            Subnets=Split(",", Ref("AlbSubnetsCsv")),
             SecurityGroups=[Ref("AlbSgId")],
             Type="application",
             Tags=cardinal_tags(component="networking", role="alb"),

--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -114,6 +114,18 @@ def build() -> Template:
         Description="Third CIDR block allowed inbound to the ALB. Blank to skip.",
     ))
     t.add_parameter(Parameter(
+        "AlbScheme",
+        Type="String",
+        Default="internal",
+        AllowedValues=["internal", "internet-facing"],
+        Description=(
+            "ALB scheme. When 'internet-facing', the Security child "
+            "automatically adds a 0.0.0.0/0 ingress rule on each ALB port "
+            "in addition to the AlbAllowedCidr1/2/3 rules. Pure convenience "
+            "so the operator doesn't have to remember to flip the CIDRs."
+        ),
+    ))
+    t.add_parameter(Parameter(
         "RdsSecurityGroupId",
         Type="AWS::EC2::SecurityGroup::Id",
         Description=(
@@ -203,6 +215,26 @@ def build() -> Template:
                 CidrIp=Ref(f"AlbAllowedCidr{cidr_idx}"),
                 Description=f"ALB inbound on {port} from AlbAllowedCidr{cidr_idx}",
             ))
+
+    # When Scheme=internet-facing, layer a 0.0.0.0/0 rule on every ALB port
+    # on top of the AlbAllowedCidr1/2/3 rules above. Gated by an explicit
+    # condition so deploying with the default (internal) doesn't surprise
+    # the operator by exposing the ALB.
+    t.add_condition(
+        "AlbIsInternetFacing",
+        Equals(Ref("AlbScheme"), "internet-facing"),
+    )
+    for port in _ALB_INGRESS:
+        t.add_resource(SecurityGroupIngress(
+            f"AlbIngress{port}FromInternet",
+            Condition="AlbIsInternetFacing",
+            GroupId=Ref(alb_sg),
+            IpProtocol="tcp",
+            FromPort=port,
+            ToPort=port,
+            CidrIp="0.0.0.0/0",
+            Description=f"ALB inbound on {port} from 0.0.0.0/0 (internet-facing)",
+        ))
 
     # ----------------------------------------------------------------------
     # Task SGs (per tier)

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -199,7 +199,37 @@ def build() -> Template:
     t.add_parameter(Parameter(
         "PrivateSubnets",
         Type="List<AWS::EC2::Subnet::Id>",
-        Description="Private subnet IDs (>=2 across different AZs).",
+        Description=(
+            "Private subnet IDs (>=2 across different AZs). All ECS tasks "
+            "run here. When AlbScheme=internal (default), the ALB also "
+            "lives in these subnets."
+        ),
+    ))
+    t.add_parameter(Parameter(
+        "AlbScheme",
+        Type="String",
+        Default="internal",
+        AllowedValues=["internal", "internet-facing"],
+        Description=(
+            "ALB scheme. Default 'internal': ALB is private and reachable "
+            "only from inside the VPC (production posture). "
+            "'internet-facing' exposes the ALB to the public internet -- "
+            "useful in test/dev environments where OIDC redirect URLs "
+            "need to resolve from a developer's browser. When set to "
+            "'internet-facing' you MUST supply PublicSubnets and SHOULD "
+            "set AlbAllowedCidr1=0.0.0.0/0 to actually accept world "
+            "traffic."
+        ),
+    ))
+    t.add_parameter(Parameter(
+        "PublicSubnets",
+        Type="CommaDelimitedList",
+        Default="",
+        Description=(
+            "Public subnet IDs (>=2 across different AZs). Required when "
+            "AlbScheme=internet-facing; ignored otherwise. The ALB attaches "
+            "to these so its DNS resolves to internet-routable IPs."
+        ),
     ))
     t.add_parameter(Parameter(
         "CertificateArn",
@@ -406,6 +436,7 @@ def build() -> Template:
         groups=[
             {"label": "Networking",
              "parameters": ["VpcId", "PrivateSubnets",
+                            "AlbScheme", "PublicSubnets",
                             "AlbAllowedCidr1", "AlbAllowedCidr2", "AlbAllowedCidr3",
                             "ServiceNamespaceName",
                             "CertificateArn",
@@ -449,6 +480,16 @@ def build() -> Template:
     install_long = install_id_long()
     private_subnets_csv = Join(",", Ref("PrivateSubnets"))
 
+    # ALB subnet selection. When AlbScheme=internet-facing, the ALB attaches
+    # to the public subnets so its DNS resolves to internet-routable IPs;
+    # otherwise it stays in the private subnets the rest of the tier uses.
+    t.add_condition("AlbIsInternetFacing", Equals(Ref("AlbScheme"), "internet-facing"))
+    alb_subnets_csv = If(
+        "AlbIsInternetFacing",
+        Join(",", Ref("PublicSubnets")),
+        private_subnets_csv,
+    )
+
     # ---------------------------------------------------------------------
     # Cloud Map private DNS namespace (created by the root, not a child)
     # ---------------------------------------------------------------------
@@ -470,6 +511,7 @@ def build() -> Template:
         "AlbAllowedCidr1": Ref("AlbAllowedCidr1"),
         "AlbAllowedCidr2": Ref("AlbAllowedCidr2"),
         "AlbAllowedCidr3": Ref("AlbAllowedCidr3"),
+        "AlbScheme": Ref("AlbScheme"),
         "RdsSecurityGroupId": Ref("RdsSecurityGroupId"),
         "ClusterArn": Ref("ClusterArn"),
         "BucketName": Ref("IngestBucketName"),
@@ -513,7 +555,8 @@ def build() -> Template:
         "InstallIdShort": install_short,
         "InstallIdLong": install_long,
         "VpcId": Ref("VpcId"),
-        "PrivateSubnetsCsv": private_subnets_csv,
+        "AlbSubnetsCsv": alb_subnets_csv,
+        "Scheme": Ref("AlbScheme"),
         "AlbSgId": sec_alb_sg,
         "CertificateArn": GetAtt(cert_stack, "Outputs.EffectiveCertificateArn"),
     }, depends_on=["Cert"])

--- a/tests/templates/test_alb.py
+++ b/tests/templates/test_alb.py
@@ -14,7 +14,7 @@ def template_dict():
 
 def test_required_parameters(template_dict):
     for n in ("InstallIdShort", "InstallIdLong", "VpcId",
-              "PrivateSubnetsCsv", "AlbSgId"):
+              "AlbSubnetsCsv", "AlbSgId", "Scheme"):
         assert n in template_dict["Parameters"], f"missing parameter: {n}"
 
 
@@ -25,21 +25,20 @@ def test_no_internally_managed_security_group(template_dict):
     assert len(sgs) == 0
 
 
-def test_no_public_subnet_or_alb_scheme_parameters(template_dict):
-    for n in ("PublicSubnetsCsv", "AlbScheme"):
-        assert n not in template_dict["Parameters"], (
-            f"parameter {n} should have been removed"
-        )
+def test_scheme_parameter_defaults_internal(template_dict):
+    p = template_dict["Parameters"]["Scheme"]
+    assert p["Default"] == "internal"
+    assert set(p["AllowedValues"]) == {"internal", "internet-facing"}
 
 
-def test_alb_is_internal(template_dict):
+def test_alb_scheme_is_parameter_driven(template_dict):
     alb_def = next(
         v for v in template_dict["Resources"].values()
         if v["Type"] == "AWS::ElasticLoadBalancingV2::LoadBalancer"
     )
-    assert alb_def["Properties"]["Scheme"] == "internal"
+    assert alb_def["Properties"]["Scheme"] == {"Ref": "Scheme"}
     subnets = alb_def["Properties"]["Subnets"]
-    assert subnets == {"Fn::Split": [",", {"Ref": "PrivateSubnetsCsv"}]}
+    assert subnets == {"Fn::Split": [",", {"Ref": "AlbSubnetsCsv"}]}
 
 
 def test_creates_load_balancer(template_dict):

--- a/tests/templates/test_root.py
+++ b/tests/templates/test_root.py
@@ -58,19 +58,34 @@ def test_no_customer_supplied_iam_or_sg_parameters(td):
         )
 
 
-def test_no_public_subnet_or_alb_scheme_parameters(td):
-    for n in ("PublicSubnets", "AlbScheme"):
-        assert n not in td["Parameters"], (
-            f"parameter {n} should have been removed"
-        )
+def test_alb_scheme_defaults_to_internal(td):
+    p = td["Parameters"]["AlbScheme"]
+    assert p["Default"] == "internal"
+    assert set(p["AllowedValues"]) == {"internal", "internet-facing"}
 
 
-def test_alb_stack_does_not_receive_public_subnets_or_scheme(td):
+def test_public_subnets_parameter_defaults_to_empty(td):
+    """PublicSubnets is optional -- only required when AlbScheme=internet-facing,
+    ignored otherwise. Default empty so internal-scheme installs don't have to
+    fabricate placeholder subnets."""
+    p = td["Parameters"]["PublicSubnets"]
+    assert p["Type"] == "CommaDelimitedList"
+    assert p["Default"] == ""
+
+
+def test_alb_child_receives_scheme_and_subnets_conditional(td):
     params = td["Resources"]["Alb"]["Properties"]["Parameters"]
-    for n in ("PublicSubnetsCsv", "AlbScheme"):
-        assert n not in params, (
-            f"Alb should no longer be passed {n}"
-        )
+    assert params["Scheme"] == {"Ref": "AlbScheme"}
+    # AlbSubnetsCsv picks between PublicSubnets and PrivateSubnets via an If.
+    sub_param = params["AlbSubnetsCsv"]
+    assert "Fn::If" in sub_param
+    if_args = sub_param["Fn::If"]
+    assert if_args[0] == "AlbIsInternetFacing"
+
+
+def test_security_child_receives_alb_scheme(td):
+    sec_params = td["Resources"]["Security"]["Properties"]["Parameters"]
+    assert sec_params["AlbScheme"] == {"Ref": "AlbScheme"}
 
 
 def test_template_base_url_default_pattern(td):
@@ -191,8 +206,15 @@ def test_outputs(td):
         assert n in td["Outputs"], f"missing output: {n}"
 
 
-def test_no_public_subnets_condition(td):
-    assert "HasPublicSubnets" not in td.get("Conditions", {})
+def test_alb_is_internet_facing_condition(td):
+    """The condition controls which subnet list the ALB attaches to. Root
+    declares it; the Security child has its own equivalent condition for
+    its 0.0.0.0/0 ingress rules."""
+    conditions = td.get("Conditions", {})
+    assert "AlbIsInternetFacing" in conditions
+    assert conditions["AlbIsInternetFacing"] == {
+        "Fn::Equals": [{"Ref": "AlbScheme"}, "internet-facing"]
+    }
 
 
 def test_service_namespace_created_in_root(td):

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -210,6 +210,33 @@ def test_alb_to_otel_4318(td):
     assert rule["SourceSecurityGroupId"] == {"Ref": "AlbSecurityGroup"}
 
 
+def test_internet_facing_ingress_rules_per_alb_port(td):
+    """When AlbScheme=internet-facing, the Security child adds a 0.0.0.0/0
+    ingress rule on every ALB port (443, 9443, 4318) gated by the
+    AlbIsInternetFacing condition. Operators who leave AlbScheme=internal
+    don't get these rules (the resource is conditional)."""
+    expected_ports = {443, 9443, 4318}
+    rules = {}
+    for r in td["Resources"].values():
+        if r["Type"] == "AWS::EC2::SecurityGroupIngress" and \
+           r.get("Condition") == "AlbIsInternetFacing":
+            rules[r["Properties"]["FromPort"]] = r["Properties"]
+    assert set(rules.keys()) == expected_ports, (
+        f"missing internet-facing ALB ingress rule on ports "
+        f"{expected_ports - set(rules.keys())!r}"
+    )
+    for port, props in rules.items():
+        assert props["CidrIp"] == "0.0.0.0/0", (
+            f"internet-facing ingress on {port} must be 0.0.0.0/0; "
+            f"got {props['CidrIp']!r}"
+        )
+        assert props["GroupId"] == {"Ref": "AlbSecurityGroup"}
+
+
+def test_alb_scheme_condition_present(td):
+    assert "AlbIsInternetFacing" in td.get("Conditions", {})
+
+
 def test_alb_to_otel_health_13133(td):
     """The OTel target group health-checks on port 13133, not 4318. Without
     an ALB-SG -> OTel-SG rule on 13133 the ECS task is marked unhealthy by


### PR DESCRIPTION
## Why

Internal ALB is right for production (callers reach it through peering/TGW/VPN). It's wrong for dev/test where a developer needs to browse the ALB from a laptop -- the DEX OIDC issuer is the ALB DNS, the SPA redirects there to start the OIDC flow, the browser can't resolve the internal hostname, and the page hangs at "Loading...".

## What

- **`root.py`** -- new `AlbScheme` parameter (default `internal`, allowed `internal`/`internet-facing`) and a new optional `PublicSubnets` parameter. An `AlbIsInternetFacing` condition picks the right subnet list for the ALB.
- **`alb.py`** -- takes `Scheme` as a parameter and forwards it verbatim to the LoadBalancer resource. `PrivateSubnetsCsv` renamed to `AlbSubnetsCsv` (the child no longer cares whether the subnets are private or public; root makes that call).
- **`security.py`** -- takes `AlbScheme`; when `internet-facing`, layers a `0.0.0.0/0` ingress rule on every ALB port (443 / 9443 / 4318) on top of the existing `AlbAllowedCidr1/2/3` rules. Gated by an explicit `AlbIsInternetFacing` condition so internal-scheme deploys are unchanged.

## Defaults

- Default everywhere is `internal`. No behavior change for existing installs.
- Switching to `internet-facing` requires the operator to set `PublicSubnets` explicitly. There is no implicit fallback that could surprise a customer.

## Test plan

- [x] `make test` -- 449 passed, 5 skipped (5 new assertions: ALB-child param + scheme wiring, root condition + PublicSubnets shape + ALB child param forwarding + Security child receives AlbScheme, Security child 0.0.0.0/0 ingress per port)
- [x] `make build` + cfn-lint clean
- [ ] Update the running cardinal-lakerunner test install (account 493746473138 / us-east-1) to v0.0.85 with `AlbScheme=internet-facing` + `PublicSubnets=<lrdev-vpc public CSV>` + `AlbAllowedCidr1=0.0.0.0/0`. Confirm the ALB DNS resolves publicly, the OIDC redirect from `localhost`-style browsing works, and Maestro login completes.