### PR TITLE
Bump images: lakerunner v1.32.0, maestro v1.45.9, otel v1.8.0 + deploy-scripts ALB scheme env vars

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,9 +33,9 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.24.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.43.11"
-  otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.7.0"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.32.0"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.45.9"
+  otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"

--- a/deploy-scripts/deploy-cardinal-lakerunner.sh
+++ b/deploy-scripts/deploy-cardinal-lakerunner.sh
@@ -43,6 +43,17 @@ fi
 SERVICE_NAMESPACE_NAME="${SERVICE_NAMESPACE_NAME:-cardinal.local}"
 ORGANIZATION_ID="${ORGANIZATION_ID:-12340000-0000-4000-8000-000000000000}"
 
+# ALB scheme. Default 'internal' (production posture). Set 'internet-facing'
+# in test environments where browser access from outside the VPC is required.
+# When internet-facing, PUBLIC_SUBNETS is mandatory and the operator should
+# also set ALB_ALLOWED_CIDR1=0.0.0.0/0 to accept world traffic.
+ALB_SCHEME="${ALB_SCHEME:-internal}"
+PUBLIC_SUBNETS="${PUBLIC_SUBNETS:-}"
+ALB_ALLOWED_CIDR1="${ALB_ALLOWED_CIDR1:-}"
+if [ "$ALB_SCHEME" = "internet-facing" ] && [ -z "$PUBLIC_SUBNETS" ]; then
+  die "PUBLIC_SUBNETS is required when ALB_SCHEME=internet-facing"
+fi
+
 TEMPLATE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-lakerunner.yaml"
 TEMPLATE_BASE_URL="https://${TEMPLATE_BUCKET}.s3.${REGION}.amazonaws.com/lakerunner/${VERSION}/cardinal-lakerunner/"
 
@@ -102,7 +113,8 @@ python3 - "$PARAMS_FILE" \
   "$CLUSTER_NAME" "$CLUSTER_ARN" \
   "$CERTIFICATE_ARN" \
   "$DEX_ADMIN_EMAIL" "$DEX_ADMIN_PASSWORD_HASH" "$OIDC_SUPERADMIN_EMAILS" \
-  "$TEMPLATE_BASE_URL" "$ORGANIZATION_ID" "$SERVICE_NAMESPACE_NAME" <<'PY'
+  "$TEMPLATE_BASE_URL" "$ORGANIZATION_ID" "$SERVICE_NAMESPACE_NAME" \
+  "$ALB_SCHEME" "$PUBLIC_SUBNETS" "$ALB_ALLOWED_CIDR1" <<'PY'
 import json, os, sys
 
 (out_path,
@@ -114,7 +126,8 @@ import json, os, sys
  cluster_name, cluster_arn,
  cert_arn,
  dex_email, dex_hash, oidc_admins,
- tmpl_base, org_id, ns_name) = sys.argv[1:]
+ tmpl_base, org_id, ns_name,
+ alb_scheme, public_subnets, alb_allowed_cidr1) = sys.argv[1:]
 
 cert_body  = os.environ.get("CERT_BODY", "")
 cert_key   = os.environ.get("CERT_KEY", "")
@@ -146,7 +159,11 @@ params = [
     {"ParameterKey": "OrganizationId",            "ParameterValue": org_id},
     {"ParameterKey": "ServiceNamespaceName",      "ParameterValue": ns_name},
     {"ParameterKey": "OtelConfigYaml",            "ParameterValue": ""},
+    {"ParameterKey": "AlbScheme",                 "ParameterValue": alb_scheme},
+    {"ParameterKey": "PublicSubnets",             "ParameterValue": public_subnets},
 ]
+if alb_allowed_cidr1:
+    params.append({"ParameterKey": "AlbAllowedCidr1", "ParameterValue": alb_allowed_cidr1})
 with open(out_path, "w") as f:
     json.dump(params, f, indent=2)
 PY


### PR DESCRIPTION
## Summary

Two bundled changes both used by tonight's live test:

### Image bumps (cardinal-defaults.yaml)

- `lakerunner` v1.24.0 -> **v1.32.0**
- `maestro` v1.43.11 -> **v1.45.9**
- `otel` (cardinalhq-otel-collector) v1.7.0 -> **v1.8.0**
- `dex` v0.1.0 unchanged (already the latest clean tag)

Driven by: the running v1.43.11 maestro created the canonical org and the shared lakerunner deployment but never inserted the `maestro_integrations` row that joins them, so the org sees "no lakerunner attached". `maestro_lakerunner_sync_jobs` is empty too -- the in-process "Lakerunner provisioning worker" never queued anything. Likely fixed in v1.45.x.

### deploy-cardinal-lakerunner.sh: ALB scheme env vars

Carry the AlbScheme / PublicSubnets / AlbAllowedCidr1 parameters from PR #141 into the wrapper. Validates that PUBLIC_SUBNETS is set when ALB_SCHEME=internet-facing. Default behavior unchanged (internal).

## Test plan

- [x] `make test` -- 449 passed, 5 skipped (no template-shape changes from the image bump)
- [x] `make build` + cfn-lint clean
- [ ] After v0.0.86 release: in-place update the running cardinal-lakerunner in account 493746473138 / us-east-1 to v0.0.86. Image bumps trigger ECS service deployments (rolling) -- no ALB replacement, no listener cascade. Validate that the new maestro v1.45.9 inserts the missing `maestro_integrations` row so the canonical org sees the lakerunner.