### PR TITLE
security: open Maestro -> query-api/admin-api cross-tier ingress

### DIFF
--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -357,6 +357,32 @@ def build() -> Template:
             Description=f"{tier_title} to otel-collector self-telemetry",
         ))
 
+    # Maestro -> lakerunner cross-tier calls via Cloud Map service discovery.
+    # The Maestro and mcp-gateway containers call query-api (8080) and
+    # admin-api (9091) directly at their cardinal.local DNS names, bypassing
+    # the ALB. Without these SG rules, the "Lakerunner provisioning worker"
+    # in maestro hangs on a headers-timeout when trying to register a new org
+    # against admin-api, leaving the maestro_integrations row in 'error'
+    # status and the org disconnected from its lakerunner deployment.
+    t.add_resource(SecurityGroupIngress(
+        "QueryFromMaestro",
+        GroupId=Ref(query_sg),
+        SourceSecurityGroupId=Ref(maestro_sg),
+        IpProtocol="tcp",
+        FromPort=_QUERY_API_PORT,
+        ToPort=_QUERY_API_PORT,
+        Description="Maestro to query-api Cloud Map",
+    ))
+    t.add_resource(SecurityGroupIngress(
+        "ControlAdminApiFromMaestro",
+        GroupId=Ref(control_sg),
+        SourceSecurityGroupId=Ref(maestro_sg),
+        IpProtocol="tcp",
+        FromPort=_ADMIN_API_PORT,
+        ToPort=_ADMIN_API_PORT,
+        Description="Maestro to admin-api Cloud Map",
+    ))
+
     # ALB -> maestro UI on 4200 and dex on 5556
     t.add_resource(SecurityGroupIngress(
         "MaestroUiFromAlb",

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -267,6 +267,22 @@ def test_alb_to_maestro_ports(td):
     assert dex["FromPort"] == 5556
 
 
+def test_maestro_to_lakerunner_cross_tier_ingress(td):
+    """Maestro reaches query-api (8080) and admin-api (9091) via Cloud Map
+    bypassing the ALB. Without these per-tier SG rules, the lakerunner
+    provisioning worker hangs with a headers-timeout and the
+    maestro_integrations row stays in 'error' status."""
+    q = td["Resources"]["QueryFromMaestro"]["Properties"]
+    assert q["FromPort"] == 8080
+    assert q["GroupId"] == {"Ref": "QuerySecurityGroup"}
+    assert q["SourceSecurityGroupId"] == {"Ref": "MaestroSecurityGroup"}
+
+    a = td["Resources"]["ControlAdminApiFromMaestro"]["Properties"]
+    assert a["FromPort"] == 9091
+    assert a["GroupId"] == {"Ref": "ControlSecurityGroup"}
+    assert a["SourceSecurityGroupId"] == {"Ref": "MaestroSecurityGroup"}
+
+
 def test_outputs(td):
     expected = {
         "AlbSecurityGroupId",


### PR DESCRIPTION
## Why

Live test in account 493746473138 / us-east-1 with maestro v1.45.9 (PR #142) now:

- Successfully inserts a `maestro_integrations` row joining the canonical org (12340000-...) to the shared lakerunner deployment.
- The in-process "Lakerunner provisioning worker" then runs a `provision_org` sync job that calls lakerunner admin-api at `http://admin-api.cardinal.local:9091`.
- That call times out (headers-timeout, 6 attempts, all `failed`).
- The integration row stays in `status='error'` and the UI shows "no lakerunner associated".

Root cause: there were **no SG rules between `MaestroSecurityGroup` and `QuerySecurityGroup` / `ControlSecurityGroup`** on the Cloud Map service ports (8080 / 9091). Maestro reaches both via `cardinal.local` DNS bypassing the ALB; the SGs blocked it.

## What

Two new `SecurityGroupIngress` rules:

- `QueryFromMaestro` -- MaestroSG -> QuerySG on 8080
- `ControlAdminApiFromMaestro` -- MaestroSG -> ControlSG on 9091

Plus a regression assertion in `test_security.py`.

## Test plan

- [x] `make test` -- 450 passed, 5 skipped (1 new assertion)
- [x] `make build` + cfn-lint clean
- [ ] In-place update the running cardinal-lakerunner stack to v0.0.87. Image versions stay; only SG rules added. After the update, re-probe `maestro_lakerunner_sync_jobs` and confirm `provision_org` completes (status='succeeded' instead of 'failed'); confirm `maestro_integrations` status flips to `connected`.