### PR TITLE
fix: query-worker port 8081 -> 8082 (lakerunner v1.32.0 moved it)

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -131,8 +131,8 @@ services:
     memory_mib: 8192
     replicas: 8
     ingress:
-      port: 8081
-      description: "From Query API"
+      port: 8082
+      description: "From Query API (gRPC control stream)"
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]

--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -65,7 +65,10 @@ def _tags(*, component: str) -> Tags:
 # --------------------------------------------------------------------------
 _ALB_INGRESS = [443, 9443, 4318]
 _QUERY_API_PORT = 8080
-_QUERY_WORKER_PORT = 8081
+# query-worker's gRPC control-stream port. v1.32.0 of the lakerunner image
+# moved the worker port from 8081 to 8082; bumping this also bumps the
+# QueryWorkerFromQuery SG ingress rule below so query-api can connect.
+_QUERY_WORKER_PORT = 8082
 _ADMIN_API_PORT = 9091
 _OTLP_HTTP_PORT = 4318
 _OTEL_HEALTH_PORT = 13133  # otel.py's target group sets HealthCheckPort=13133

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -193,9 +193,14 @@ def test_alb_to_query_ingress(td):
 
 
 def test_query_self_ingress_to_worker(td):
+    """query-api uses a gRPC control stream to talk to query-workers; the
+    v1.32.0 image moved that port from 8081 to 8082. The ingress rule must
+    track the image's actual listener."""
     rule = td["Resources"]["QueryWorkerFromQuery"]["Properties"]
-    assert rule["FromPort"] == 8081
+    assert rule["FromPort"] == 8082
+    assert rule["ToPort"] == 8082
     assert rule["SourceSecurityGroupId"] == {"Ref": "QuerySecurityGroup"}
+    assert rule["GroupId"] == {"Ref": "QuerySecurityGroup"}
 
 
 def test_alb_to_admin_api(td):


### PR DESCRIPTION
## Root cause

The v1.32.0 lakerunner image (PR #142) moved query-worker's gRPC control-stream port from 8081 to 8082. The `QueryWorkerFromQuery` SG ingress rule and the `cardinal-defaults.yaml` `ingress.port` both still said 8081, so query-api's Discovery bridge logged on every reconnect:

```
Discovery bridge: failed to connect worker ... dial tcp <ip>:8082: i/o timeout
segment failures in logs query ... assign work: no available workers
```

User-visible: Explore queries succeeded but returned empty. The "list of services" comes from RDS index (which query-api answers directly) and survives. Actual time-series fetch needs the query-worker fan-out, which was silently producing no results.

## Fix

- `security.py` `_QUERY_WORKER_PORT` 8081 -> 8082
- `cardinal-defaults.yaml` `lakerunner-query-worker.ingress.port` 8081 -> 8082
- Regression test pins `QueryWorkerFromQuery` at 8082

## Test plan

- [x] `make test` -- 450 passed, 5 skipped
- [x] `make build` + cfn-lint clean
- [ ] In-place update to v0.0.88 against the running stack and confirm: query-api logs stop showing "failed to connect worker", "no available workers" disappears, Explore returns real data.