### PR TITLE
fix: reopen 8081 for query-worker artifact fetch

### DIFF
--- a/src/cardinal_cfn/children/security.py
+++ b/src/cardinal_cfn/children/security.py
@@ -65,9 +65,14 @@ def _tags(*, component: str) -> Tags:
 # --------------------------------------------------------------------------
 _ALB_INGRESS = [443, 9443, 4318]
 _QUERY_API_PORT = 8080
-# query-worker's gRPC control-stream port. v1.32.0 of the lakerunner image
-# moved the worker port from 8081 to 8082; bumping this also bumps the
-# QueryWorkerFromQuery SG ingress rule below so query-api can connect.
+# query-worker exposes TWO ports:
+#   8081 - HTTP REST artifact fetch (query-api -> worker via
+#          GET /api/v1/artifacts/<id>; segments stream Parquet back)
+#   8082 - gRPC control stream / Discovery bridge (query-api -> worker
+#          long-lived bidi RPC for work assignment)
+# Both must be open in the QuerySG self-referential ingress or queries
+# dispatch but artifact fetches time out with "context deadline exceeded".
+_QUERY_WORKER_ARTIFACT_PORT = 8081
 _QUERY_WORKER_PORT = 8082
 _ADMIN_API_PORT = 9091
 _OTLP_HTTP_PORT = 4318
@@ -299,7 +304,11 @@ def build() -> Template:
         ToPort=_QUERY_API_PORT,
         Description="ALB to query-api",
     ))
-    # query-api -> query-worker on 8081 (self-referential within the tier SG)
+    # query-api -> query-worker (self-referential within the tier SG).
+    # Two ports: 8081 for HTTP REST artifact fetch, 8082 for gRPC control
+    # stream / Discovery bridge. Missing either one produces
+    # "context deadline exceeded" on artifact fetch (8081) or
+    # "no available workers" on dispatch (8082).
     t.add_resource(SecurityGroupIngress(
         "QueryWorkerFromQuery",
         GroupId=Ref(query_sg),
@@ -307,7 +316,16 @@ def build() -> Template:
         IpProtocol="tcp",
         FromPort=_QUERY_WORKER_PORT,
         ToPort=_QUERY_WORKER_PORT,
-        Description="query-api to query-worker (same tier SG)",
+        Description="query-api to query-worker gRPC control stream (same tier SG)",
+    ))
+    t.add_resource(SecurityGroupIngress(
+        "QueryWorkerArtifactFromQuery",
+        GroupId=Ref(query_sg),
+        SourceSecurityGroupId=Ref(query_sg),
+        IpProtocol="tcp",
+        FromPort=_QUERY_WORKER_ARTIFACT_PORT,
+        ToPort=_QUERY_WORKER_ARTIFACT_PORT,
+        Description="query-api to query-worker HTTP artifact fetch (same tier SG)",
     ))
 
     # ALB -> admin-api on 9091

--- a/tests/templates/test_security.py
+++ b/tests/templates/test_security.py
@@ -203,6 +203,19 @@ def test_query_self_ingress_to_worker(td):
     assert rule["GroupId"] == {"Ref": "QuerySecurityGroup"}
 
 
+def test_query_self_ingress_for_artifact_fetch(td):
+    """query-api fetches Parquet artifacts from workers over plain HTTP on
+    8081 (separate from the 8082 gRPC control stream). Without this rule
+    queries dispatch successfully but fail with
+    "context deadline exceeded" at the artifact-fetch step and Maestro
+    shows no data."""
+    rule = td["Resources"]["QueryWorkerArtifactFromQuery"]["Properties"]
+    assert rule["FromPort"] == 8081
+    assert rule["ToPort"] == 8081
+    assert rule["SourceSecurityGroupId"] == {"Ref": "QuerySecurityGroup"}
+    assert rule["GroupId"] == {"Ref": "QuerySecurityGroup"}
+
+
 def test_alb_to_admin_api(td):
     rule = td["Resources"]["ControlAdminApiFromAlb"]["Properties"]
     assert rule["FromPort"] == 9091


### PR DESCRIPTION
## Why

PR #144 moved `QueryWorkerFromQuery` from 8081 to 8082 to track the gRPC control-stream port the v1.32.0 lakerunner image uses. That fixed `"no available workers"` on dispatch. But the worker also serves a plain-HTTP artifact endpoint at 8081 -- query-api fetches Parquet results via `GET /api/v1/artifacts/<id>` on 8081 -- and we removed that hole at the same time.

## Symptom (live)

Dispatch succeeds, every worker is healthy, query-worker logs report normal `COPY TO` operations (~10ms each), but query-api logs:

```
fetch artifact: Get "http://ip-10-0-3-194.ec2.internal:8081/api/v1/artifacts/...":
  context deadline exceeded (Client.Timeout exceeded while awaiting headers)
...
metrics query complete ... status=error result_points_emitted=0 total_elapsed_ms=30019
```

Maestro receives a 200 with empty results (15s) and renders "no data".

## Fix

- Split the port constants in `security.py`:
  - `_QUERY_WORKER_ARTIFACT_PORT = 8081` (HTTP REST)
  - `_QUERY_WORKER_PORT = 8082` (gRPC control stream)
- Add `QueryWorkerArtifactFromQuery` alongside `QueryWorkerFromQuery` so both ports are open in the QuerySG self-referential ingress.
- Regression test pins the 8081 rule and keeps the 8082 rule.

## Test plan

- [x] `make test` -- 451 passed, 5 skipped
- [x] `make build` + cfn-lint clean
- [ ] In-place update to v0.0.90, query Explore from Maestro, confirm query-api artifact fetches succeed and time-series data renders.