### PR TITLE
maestro: pass bucket coordinates as MAESTRO_BOOTSTRAP_BUCKET_*

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -138,6 +138,19 @@ def build() -> Template:
             ),
         )
     )
+    t.add_parameter(Parameter(
+        "BucketName",
+        Type="String",
+        Description=(
+            "Ingest S3 bucket name (the cardinal-infrastructure stack's "
+            "IngestBucketName output). Maestro consumes this only to seed "
+            "the MAESTRO_BOOTSTRAP_BUCKET_* env vars so its in-process "
+            "Lakerunner provisioning worker can recreate the "
+            "organization_buckets join row that it currently wipes on "
+            "every provision_org cycle. No S3 IAM is granted to the "
+            "maestro task role -- the bucket name is metadata only."
+        ),
+    ))
     t.add_parameter(Parameter("DbEndpoint", Type="String", Description="RDS endpoint hostname."))
     t.add_parameter(Parameter("DbPort", Type="String", Default="5432", Description="RDS port."))
     t.add_parameter(
@@ -525,6 +538,15 @@ def build() -> Template:
             Environment(Name="MAESTRO_BOOTSTRAP_ORG_ID", Value=Ref("OrganizationId")),
             Environment(Name="MAESTRO_BOOTSTRAP_ORG_NAME", Value=Ref("OrgName")),
             Environment(Name="MAESTRO_BOOTSTRAP_OWNER_EMAIL", Value=Ref("DexAdminEmail")),
+            # Bucket coordinates so a maestro version newer than the broken
+            # v1.45.9 can re-populate organization_buckets after
+            # provision_org instead of leaving the join row absent (which
+            # broke every Explore query until the migration task force-ran
+            # ensure-storage-profile).
+            Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_NAME", Value=Ref("BucketName")),
+            Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_REGION", Value=Ref("AWS::Region")),
+            Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_CLOUD_PROVIDER", Value="aws"),
+            Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_COLLECTOR_NAME", Value="lakerunner"),
             Environment(
                 Name="MAESTRO_BOOTSTRAP_LAKERUNNER_QUERY_API_URL",
                 Value=Sub("http://query-api.${ServiceNamespaceName}:8080"),

--- a/src/cardinal_cfn/root.py
+++ b/src/cardinal_cfn/root.py
@@ -705,6 +705,7 @@ def build() -> Template:
         "DbEndpoint": Ref("DbEndpoint"),
         "DbPort": Ref("DbPort"),
         "DbSecretArn": Ref("DbMasterSecretArn"),
+        "BucketName": Ref("IngestBucketName"),
         "LicenseSecretArn": Ref("LicenseSecretArn"),
         "MigrationComplete": migration_complete,
         "MaestroImage": maestro_image,

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -263,6 +263,19 @@ def test_maestro_container_has_bootstrap_env(td):
     )
 
 
+def test_maestro_container_has_bootstrap_bucket_env(td):
+    """Bucket coordinates so a fixed maestro version can re-insert the
+    organization_buckets join row after provision_org (v1.45.9 wipes it
+    without re-inserting; deploy-time ensure-storage-profile only runs
+    on stack-image change)."""
+    maestro_c = _container(td, "maestro")
+    env = {e["Name"]: e["Value"] for e in maestro_c.get("Environment", [])}
+    assert env["MAESTRO_BOOTSTRAP_BUCKET_NAME"] == {"Ref": "BucketName"}
+    assert env["MAESTRO_BOOTSTRAP_BUCKET_REGION"] == {"Ref": "AWS::Region"}
+    assert env["MAESTRO_BOOTSTRAP_BUCKET_CLOUD_PROVIDER"] == "aws"
+    assert env["MAESTRO_BOOTSTRAP_BUCKET_COLLECTOR_NAME"] == "lakerunner"
+
+
 def test_maestro_container_admin_api_key_from_secret(td):
     """The seeded datasource's admin key is the same cardinal-admin-key secret
     that admin-api validates via ADMIN_INITIAL_API_KEY."""

--- a/tests/templates/test_root.py
+++ b/tests/templates/test_root.py
@@ -187,6 +187,14 @@ def test_maestro_stack_depends_on_migration(td):
     assert "Migration" in deps
 
 
+def test_maestro_stack_receives_bucket_name(td):
+    """Root must forward the ingest bucket name to the Maestro child so its
+    MAESTRO_BOOTSTRAP_BUCKET_* env vars can drive the post-fix maestro
+    image to recreate the organization_buckets join row."""
+    params = td["Resources"]["Maestro"]["Properties"]["Parameters"]
+    assert params["BucketName"] == {"Ref": "IngestBucketName"}
+
+
 def test_template_url_uses_kebab_case_filenames(td):
     """Module names like services_query map to services-query.yaml."""
     migration_url = td["Resources"]["Migration"]["Properties"]["TemplateURL"]


### PR DESCRIPTION
## Why

Maestro v1.45.9's in-process Lakerunner provisioning worker runs `provision_org` on every reprovision / restart and **deletes `configdb.organization_buckets` without re-creating it**. Observed live tonight: every reprovision wipes the org/bucket join and Explore returns no data until the migration ECS task re-runs `ensure-storage-profile` (which only fires automatically when the migration task definition changes -- i.e., on a stack-image bump).

A future maestro will use four new env vars to restore the join row itself.

## What

Four new env vars on the maestro container, next to the existing `MAESTRO_BOOTSTRAP_*` block:

| Env var | Value |
|---|---|
| `MAESTRO_BOOTSTRAP_BUCKET_NAME` | `Ref(BucketName)` |
| `MAESTRO_BOOTSTRAP_BUCKET_REGION` | `Ref(AWS::Region)` |
| `MAESTRO_BOOTSTRAP_BUCKET_CLOUD_PROVIDER` | `"aws"` |
| `MAESTRO_BOOTSTRAP_BUCKET_COLLECTOR_NAME` | `"lakerunner"` |

Plumbing:
- `maestro.py` adds a `BucketName` Parameter (string only -- maestro does not need S3 IAM; the value is metadata).
- `root.py` forwards `Ref(IngestBucketName)` to the Maestro child.

## Test plan

- [x] `make test` -- 453 passed, 5 skipped (2 new assertions: maestro env wiring + root forwarding)
- [x] `make build` + cfn-lint clean
- [ ] Once a maestro build that honors the new vars lands, redeploy and verify reprovision no longer empties `organization_buckets`.

## Operator notes

No behavior change on the current maestro image (v1.45.9) -- the new env vars are silently ignored. Takes effect when the maestro image is bumped to a version that reads them.