### PR TITLE
bump: maestro v1.45.9 -> v1.46.1

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,7 +34,7 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.32.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.45.9"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.46.1"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
v1.46.1 consumes the `MAESTRO_BOOTSTRAP_BUCKET_*` env vars added in PR #147 and repopulates the `configdb.organization_buckets` join row inside the in-process Lakerunner provisioning worker. v1.45.9 deleted that row on every `provision_org` cycle without re-creating it -- breaking Explore until `ensure-storage-profile` re-ran (which only fires when the migration task definition changes).

## Test plan

- [x] `make test` -- 453 passed
- [x] `make build` + cfn-lint clean
- [ ] Deploy lakerunner at v0.0.92 against the fresh cardinal-infrastructure rebuilt earlier tonight. Verify reprovision in Maestro UI no longer empties `configdb.organization_buckets`.