### PR TITLE
Cross-account remote ingest (bucket in main account, collector assumes writer role)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,8 @@ lint:	## Run cfn-lint on every generated template
 	  generated-templates/lrdev-baseinfra.yaml \
 	  generated-templates/cardinal-infrastructure.yaml \
 	  generated-templates/cardinal-cleanup.yaml \
+	  generated-templates/cardinal-remote-ingest.yaml \
+	  generated-templates/cardinal-remote-collector.yaml \
 	  generated-templates/cardinal-lakerunner.yaml \
 	  generated-templates/cardinal-lakerunner/*.yaml
 

--- a/build.sh
+++ b/build.sh
@@ -30,6 +30,12 @@ python3 -m cardinal_cfn.cardinal_infrastructure > generated-templates/cardinal-i
 echo "Generating cardinal-cleanup.yaml..."
 python3 -m cardinal_cfn.cardinal_cleanup > generated-templates/cardinal-cleanup.yaml
 
+echo "Generating cardinal-remote-ingest.yaml..."
+python3 -m cardinal_cfn.remote_ingest > generated-templates/cardinal-remote-ingest.yaml
+
+echo "Generating cardinal-remote-collector.yaml..."
+python3 -m cardinal_cfn.remote_collector > generated-templates/cardinal-remote-collector.yaml
+
 # ---------------------------------------------------------------------------
 # Lakerunner stack (root + 9 nested children). The Security child owns all
 # SGs and IAM roles; other children take SG IDs and role ARNs from it
@@ -51,6 +57,8 @@ cfn-lint generated-templates/lrdev-vpc.yaml \
          generated-templates/lrdev-baseinfra.yaml \
          generated-templates/cardinal-infrastructure.yaml \
          generated-templates/cardinal-cleanup.yaml \
+         generated-templates/cardinal-remote-ingest.yaml \
+         generated-templates/cardinal-remote-collector.yaml \
          generated-templates/cardinal-lakerunner.yaml \
          generated-templates/cardinal-lakerunner/*.yaml || \
   echo "cfn-lint completed with warnings"

--- a/cardinal-remote-otel-config.yaml
+++ b/cardinal-remote-otel-config.yaml
@@ -1,0 +1,84 @@
+# Remote-account cardinalhq-otel-collector config. Identical to
+# cardinal-otel-config.yaml except each awss3 exporter assumes the
+# cross-account writer role (LRDB_S3_ROLE_ARN) before writing to the
+# main-account ingest bucket. Used by cardinal-remote-collector.yaml.
+#
+# Env-var contract (set by the remote collector stack):
+#   LRDB_S3_BUCKET    - main-account remote-ingest bucket
+#   LRDB_S3_REGION    - bucket region (the main/lakerunner region, NOT the
+#                       remote account's region)
+#   LRDB_S3_ROLE_ARN  - writer role ARN to assume for the cross-account write
+#   ORG               - organization UUID for the s3_prefix path
+#   COLLECTOR         - collector name (defaults to "lakerunner")
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    limit_mib: 1024
+    check_interval: 1s
+  batch:
+    timeout: 10s
+    send_batch_max_size: 2000
+    send_batch_size: 1000
+
+exporters:
+  awss3/logs:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    role_arn: ${env:LRDB_S3_ROLE_ARN}
+    marshaler: otlp_proto
+
+  awss3/metrics:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    role_arn: ${env:LRDB_S3_ROLE_ARN}
+    marshaler: otlp_proto
+
+  awss3/traces:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    role_arn: ${env:LRDB_S3_ROLE_ARN}
+    marshaler: otlp_proto
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions:
+    - health_check
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/metrics]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/traces]

--- a/docs/operations/installing.md
+++ b/docs/operations/installing.md
@@ -34,3 +34,5 @@ For the broader operational topics:
   for the lakerunner stack (legacy installs).
 - [`end-to-end-test-plan.md`](end-to-end-test-plan.md) -- runtime
   verification checklist.
+- [`remote-ingest.md`](remote-ingest.md) -- adding telemetry from a
+  second AWS account via cross-account remote ingest.

--- a/docs/operations/remote-ingest.md
+++ b/docs/operations/remote-ingest.md
@@ -1,0 +1,116 @@
+# Cross-account remote ingest
+
+This document is for operators adding telemetry from a **second AWS account** to
+an existing Cardinal lakerunner install. It covers two templates:
+
+- `cardinal-remote-ingest.yaml` — deployed in the **main** (lakerunner) account.
+  Creates an S3 bucket, a cross-account writer IAM role, and the bucket-to-SQS
+  notification.
+- `cardinal-remote-collector.yaml` — deployed in the **second** account. An
+  ALB-fronted otel collector that assumes the writer role and writes telemetry
+  to the main-account bucket.
+
+Design: `docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md`.
+
+## How it works
+
+The bucket lives in the main account, in the **same region as the lakerunner
+SQS queue** (S3-to-SQS notifications must be same-region). The remote collector
+assumes a main-account writer role and writes objects into that bucket; because
+it writes as a main-account principal, the objects are owned by the main account
+and lakerunner reads them with no special permission. The bucket notifies the
+existing lakerunner SQS queue, and the normal `pubsub-sqs` -> `process-*`
+pipeline ingests each object.
+
+Only the **write** crosses the account boundary, via STS assume-role.
+
+```
+remote app --OTLP--> remote ALB :4318 --> remote otel collector
+   --(assume main writer role)--> PutObject  main-account bucket
+   --> S3 ObjectCreated --> main SQS --> lakerunner ingest (under the bucket's org)
+```
+
+## Prerequisites
+
+- `cardinal-infrastructure` and `cardinal-lakerunner` are already deployed in the
+  main account.
+- The infrastructure stack is on a template version that includes the broadened
+  queue policy (the `cardinal-remote-ingest-*` notification grant). If your
+  install predates this, update the `cardinal-infrastructure` stack first.
+- You have both account IDs and the main-account SQS ingest queue ARN
+  (the `cardinal-infrastructure` stack's `IngestQueueArn` output).
+- The second account already has a VPC, private subnets (2+ AZs), and an ECS
+  Fargate cluster. This template does not create those.
+
+## Step 1: Deploy `cardinal-remote-ingest` in the main account
+
+1. Open the CloudFormation console in the **main** account, same region as the
+   lakerunner install.
+1. Create a stack from `cardinal-remote-ingest.yaml`.
+1. Parameters:
+   - `RemoteAccountId`: the 12-digit second account ID.
+   - `OrgId`: the lakerunner organization this account's telemetry belongs to.
+     One org per remote bucket.
+   - `QueueArn`: the `cardinal-infrastructure` stack's `IngestQueueArn` output.
+   - `BucketName`: leave blank to use `cardinal-remote-ingest-<RemoteAccountId>`.
+     Any override **must** keep the `cardinal-remote-ingest-` prefix or the
+     bucket notification will be rejected (the infra queue policy grants by that
+     prefix).
+   - `CollectorName`: leave as `lakerunner` unless you have a reason to change it
+     (it must match the remote collector's `CollectorName`).
+   - `IngestBucketLifecycleDays`: object GC backstop (default 7).
+1. This stack creates an IAM role; acknowledge the IAM capability when prompted.
+1. After it completes, record the outputs: `BucketName`, `BucketRegion`,
+   `WriterRoleArn`, and `StorageProfileSnippet`.
+
+## Step 2: Deploy `cardinal-remote-collector` in the second account
+
+1. Open the CloudFormation console in the **second** account.
+1. Create a stack from `cardinal-remote-collector.yaml`.
+1. Parameters:
+   - `VpcId`, `PrivateSubnetsCsv`, `ClusterArn`: the second account's existing
+     VPC, private subnets, and ECS cluster.
+   - `WriterRoleArn`, `BucketName`, `BucketRegion`: paste from Step 1's outputs.
+     `BucketRegion` is the main/lakerunner region — not the second account's
+     region.
+   - `OrgId`, `CollectorName`: match the values used in Step 1.
+   - `OtlpIngressCidr`: narrow to the CIDR of the senders that will reach the
+     internal ALB on port 4318 (default `10.0.0.0/8`).
+1. This stack creates a **named** IAM role (`cardinal-remote-otel-<region>`, so
+   the main-account writer role's trust condition matches it). Acknowledge the
+   named-IAM capability (`CAPABILITY_NAMED_IAM`) when prompted.
+1. After it completes, point your OTLP senders at the `OtelExternalUrl` output
+   (`http://<alb-dns>:4318`).
+
+Only one remote collector per region per account is supported by the default
+role name. To run more, redeploy `cardinal-remote-ingest` with a different
+`BucketName` and adjust as needed.
+
+## Step 3: Register the storage profile and re-run the migrator
+
+Lakerunner attributes each ingested object to an org by looking up its bucket in
+the storage profiles. The new bucket needs a profile entry.
+
+1. Take the `StorageProfileSnippet` output from Step 1.
+1. Update the `cardinal-infrastructure` stack: append the snippet to the
+   `AdditionalStorageProfilesYaml` parameter (it accepts one or more YAML list
+   items) and apply the change. This updates the storage-profiles SSM parameter.
+1. Re-run the migrator so it re-imports the storage profiles into `configdb`.
+   Either bump `LakerunnerImage` on the `cardinal-lakerunner` stack, or cycle the
+   migrator service (`aws ecs update-service --desired-count 0` then `1`). The
+   migrator is idempotent.
+
+Until the migrator re-imports, objects from the new bucket land in SQS but
+lakerunner cannot attribute them to an org.
+
+## Notes and limits
+
+- **Region**: the bucket is pinned to the lakerunner region. If the second
+  account is in another region, the collector writes cross-region (data-transfer
+  cost). This is expected.
+- **Encryption**: the bucket uses SSE-S3. If you switch a bucket to SSE-KMS, the
+  writer role also needs `kms:GenerateDataKey` on the key.
+- **License**: the remote collector runs a receive-to-S3 pipeline only and needs
+  no license.
+- **Teardown**: the bucket has `DeletionPolicy: Retain`. Empty and delete it by
+  hand after deleting the stack if you want the data gone.

--- a/docs/superpowers/plans/2026-05-29-cross-account-remote-ingest.md
+++ b/docs/superpowers/plans/2026-05-29-cross-account-remote-ingest.md
@@ -1,0 +1,1190 @@
+# Cross-account remote ingest Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a second AWS account's otel collector feed telemetry into an existing lakerunner install by writing (via an assumed role) to an S3 bucket the main account owns, which notifies lakerunner's SQS queue.
+
+**Architecture:** A new standalone main-account template (`cardinal-remote-ingest.yaml`) creates the bucket, a cross-account writer IAM role, and the bucket->SQS notification. A new standalone remote-account template (`cardinal-remote-collector.yaml`) creates an ALB-fronted otel collector whose `awss3` exporter assumes the writer role. Small edits to `cardinal_infrastructure.py` broaden the SQS queue policy to accept `cardinal-remote-ingest-*` buckets and add an `AdditionalStorageProfilesYaml` parameter for registering the new org.
+
+**Tech Stack:** Python 3, troposphere, cloud-radar (template tests), pytest, cfn-lint.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md`
+
+---
+
+## File structure
+
+```
+cardinal-remote-otel-config.yaml             (new) otel config with role_arn per awss3 exporter
+src/cardinal_cfn/defaults.py                 (modify) add load_remote_otel_default_config()
+src/cardinal_cfn/cardinal_infrastructure.py  (modify) queue policy 2nd statement + AdditionalStorageProfilesYaml
+src/cardinal_cfn/remote_ingest.py            (new) cardinal-remote-ingest.yaml generator
+src/cardinal_cfn/remote_collector.py         (new) cardinal-remote-collector.yaml generator
+build.sh                                     (modify) generate + lint the two new templates
+Makefile                                     (modify) lint target
+tests/unit/test_remote_otel_config.py        (new)
+tests/templates/test_cardinal_infrastructure.py (modify) queue policy + new param
+tests/templates/test_remote_ingest.py        (new)
+tests/templates/test_remote_collector.py     (new)
+```
+
+---
+
+## Task 1: Remote otel config file + loader
+
+**Files:**
+- Create: `cardinal-remote-otel-config.yaml`
+- Modify: `src/cardinal_cfn/defaults.py`
+- Test: `tests/unit/test_remote_otel_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/unit/test_remote_otel_config.py
+"""The remote collector config must carry role_arn on every awss3 exporter."""
+
+import yaml
+
+from cardinal_cfn.defaults import load_remote_otel_default_config
+
+
+def test_loads_nonempty_string():
+    cfg = load_remote_otel_default_config()
+    assert isinstance(cfg, str) and cfg.strip()
+
+
+def test_every_awss3_exporter_has_role_arn():
+    cfg = yaml.safe_load(load_remote_otel_default_config())
+    exporters = cfg["exporters"]
+    awss3 = {k: v for k, v in exporters.items() if k.startswith("awss3")}
+    assert awss3, "expected at least one awss3 exporter"
+    for name, ex in awss3.items():
+        assert ex.get("role_arn") == "${env:LRDB_S3_ROLE_ARN}", (
+            f"{name} missing role_arn assume-role hook"
+        )
+
+
+def test_keeps_health_check_extension():
+    cfg = yaml.safe_load(load_remote_otel_default_config())
+    assert "health_check" in cfg["extensions"]
+    assert cfg["extensions"]["health_check"]["endpoint"] == "0.0.0.0:13133"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `.venv/bin/pytest tests/unit/test_remote_otel_config.py -v`
+Expected: FAIL — `ImportError: cannot import name 'load_remote_otel_default_config'`
+
+- [ ] **Step 3: Create the config file**
+
+Copy `cardinal-otel-config.yaml` to `cardinal-remote-otel-config.yaml`, change the header comment to describe the remote/assume-role variant, and add `role_arn: ${env:LRDB_S3_ROLE_ARN}` to each of the three `awss3/*` exporters (sibling of `s3uploader` and `marshaler`). Full file:
+
+```yaml
+# Remote-account cardinalhq-otel-collector config. Identical to
+# cardinal-otel-config.yaml except each awss3 exporter assumes the
+# cross-account writer role (LRDB_S3_ROLE_ARN) before writing to the
+# main-account ingest bucket. Used by cardinal-remote-collector.yaml.
+#
+# Env-var contract (set by the remote collector stack):
+#   LRDB_S3_BUCKET    - main-account remote-ingest bucket
+#   LRDB_S3_REGION    - bucket region (the main/lakerunner region, NOT the
+#                       remote account's region)
+#   LRDB_S3_ROLE_ARN  - writer role ARN to assume for the cross-account write
+#   ORG               - organization UUID for the s3_prefix path
+#   COLLECTOR         - collector name (defaults to "lakerunner")
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    limit_mib: 1024
+    check_interval: 1s
+  batch:
+    timeout: 10s
+    send_batch_max_size: 2000
+    send_batch_size: 1000
+
+exporters:
+  awss3/logs:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    role_arn: ${env:LRDB_S3_ROLE_ARN}
+    marshaler: otlp_proto
+
+  awss3/metrics:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    role_arn: ${env:LRDB_S3_ROLE_ARN}
+    marshaler: otlp_proto
+
+  awss3/traces:
+    s3uploader:
+      region: ${env:LRDB_S3_REGION}
+      s3_bucket: ${env:LRDB_S3_BUCKET}
+      s3_prefix: otel-raw/${env:ORG}/${env:COLLECTOR}
+      s3_force_path_style: true
+      s3_partition_format: 'year=%Y/month=%m/day=%d/hour=%H/minute=%M'
+      compression: gzip
+    role_arn: ${env:LRDB_S3_ROLE_ARN}
+    marshaler: otlp_proto
+
+extensions:
+  health_check:
+    endpoint: 0.0.0.0:13133
+
+service:
+  extensions:
+    - health_check
+  pipelines:
+    logs:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/logs]
+    metrics:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/metrics]
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [awss3/traces]
+```
+
+- [ ] **Step 4: Add the loader to `defaults.py`**
+
+Add the remote-config path constant next to `_OTEL_CONFIG_PATH`:
+
+```python
+_REMOTE_OTEL_CONFIG_PATH = os.path.join(_REPO_ROOT, "cardinal-remote-otel-config.yaml")
+```
+
+Add the function after `load_otel_default_config`:
+
+```python
+def load_remote_otel_default_config() -> str:
+    """Return cardinal-remote-otel-config.yaml as a string.
+
+    Same shape as load_otel_default_config but with role_arn on each awss3
+    exporter so the remote collector assumes the cross-account writer role.
+    """
+    with open(_REMOTE_OTEL_CONFIG_PATH, "r") as f:
+        return f.read()
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `.venv/bin/pytest tests/unit/test_remote_otel_config.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add cardinal-remote-otel-config.yaml src/cardinal_cfn/defaults.py tests/unit/test_remote_otel_config.py
+git commit -m "feat: remote otel config with cross-account assume-role"
+```
+
+---
+
+## Task 2: Infra queue policy + AdditionalStorageProfilesYaml
+
+**Files:**
+- Modify: `src/cardinal_cfn/cardinal_infrastructure.py` (queue policy ~360-388; storage profiles param ~209 and ~573-601; param-group metadata ~288/316)
+- Test: `tests/templates/test_cardinal_infrastructure.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/templates/test_cardinal_infrastructure.py` (it already has a `td` fixture loading `cardinal_infrastructure.build().to_json()`; if not, add one mirroring `test_otel.py`):
+
+```python
+def test_queue_policy_allows_remote_ingest_buckets(td):
+    """A second statement lets cardinal-remote-ingest-* buckets in this account
+    notify the queue, without naming each bucket."""
+    qp = next(
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::SQS::QueuePolicy"
+    )
+    stmts = qp["Properties"]["PolicyDocument"]["Statement"]
+    arnlikes = [
+        s["Condition"]["ArnLike"]["aws:SourceArn"]
+        for s in stmts
+        if "Condition" in s and "ArnLike" in s["Condition"]
+    ]
+    assert {"Fn::Sub": "arn:${AWS::Partition}:s3:::cardinal-remote-ingest-*"} in arnlikes
+    for s in stmts:
+        assert s["Condition"]["StringEquals"]["aws:SourceAccount"] == {"Ref": "AWS::AccountId"}
+
+
+def test_additional_storage_profiles_parameter(td):
+    assert "AdditionalStorageProfilesYaml" in td["Parameters"]
+    assert td["Parameters"]["AdditionalStorageProfilesYaml"]["Default"] == ""
+
+
+def test_storage_profiles_value_appends_additional(td):
+    ssm = next(
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::SSM::Parameter" and r["Properties"].get("Name", {})
+    )
+    # Find the storage-profiles SSM param specifically.
+    ssm_params = [
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::SSM::Parameter"
+    ]
+    sp = next(
+        r for r in ssm_params
+        if "storage_profiles" in json.dumps(r["Properties"]["Value"])
+        or "organization_id" in json.dumps(r["Properties"]["Value"])
+    )
+    assert "AdditionalStorageProfilesYaml" in json.dumps(sp["Properties"]["Value"])
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/templates/test_cardinal_infrastructure.py -k "remote_ingest or additional_storage or appends_additional" -v`
+Expected: FAIL — the assertions don't find the new statement/param.
+
+- [ ] **Step 3: Add the second queue-policy statement**
+
+In `cardinal_infrastructure.py`, the `IngestQueuePolicy` resource (~357-388) currently has one statement in `PolicyDocument["Statement"]`. Add a second statement to that list, after the existing one:
+
+```python
+                    {
+                        "Effect": "Allow",
+                        "Principal": {"Service": "s3.amazonaws.com"},
+                        "Action": [
+                            "sqs:SendMessage",
+                            "sqs:GetQueueAttributes",
+                            "sqs:GetQueueUrl",
+                        ],
+                        "Resource": GetAtt(ingest_queue, "Arn"),
+                        "Condition": {
+                            "StringEquals": {
+                                "aws:SourceAccount": Ref("AWS::AccountId")
+                            },
+                            "ArnLike": {
+                                "aws:SourceArn": Sub(
+                                    "arn:${AWS::Partition}:s3:::cardinal-remote-ingest-*"
+                                )
+                            },
+                        },
+                    },
+```
+
+- [ ] **Step 4: Add the `AdditionalStorageProfilesYaml` parameter**
+
+Near the other parameters (after `storage_profiles_param_name`, ~209-230), add:
+
+```python
+    additional_storage_profiles = t.add_parameter(
+        Parameter(
+            "AdditionalStorageProfilesYaml",
+            Type="String",
+            Default="",
+            Description=(
+                "Extra storage-profile YAML list items appended after the seeded "
+                "profile (e.g. cardinal-remote-ingest StorageProfileSnippet "
+                "outputs). Leave blank for none."
+            ),
+        )
+    )
+```
+
+- [ ] **Step 5: Append the parameter to the storage-profiles SSM value**
+
+In the `StorageProfilesParam` resource (~573-601), change the `Value=Sub(...)` so the additional YAML is appended after the seeded profile. The seeded template string ends with `"  use_path_style: true\n"`; append `"${Additional}"` and pass it:
+
+```python
+                Value=Sub(
+                    "- organization_id: ${OrgId}\n"
+                    "  instance_num: 1\n"
+                    "  collector_name: lakerunner\n"
+                    "  cloud_provider: aws\n"
+                    "  region: ${AWS::Region}\n"
+                    "  bucket: ${BucketName}\n"
+                    "  insecure_tls: false\n"
+                    "  use_path_style: true\n"
+                    "${Additional}",
+                    OrgId=Ref(organization_id),
+                    BucketName=bucket_name_value,
+                    Additional=Ref(additional_storage_profiles),
+                ),
+```
+
+- [ ] **Step 6: Add the parameter to the console parameter-group metadata**
+
+Find the parameter-group list (~288) that contains `"IngestBucketName"`, `"IngestBucketLifecycleDays"` and add `"AdditionalStorageProfilesYaml"` to that group's `parameters` list. Add a label in the labels dict (~316) if one exists for the group:
+
+```python
+        "AdditionalStorageProfilesYaml": "Additional storage-profile YAML (remote buckets)",
+```
+
+- [ ] **Step 7: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/templates/test_cardinal_infrastructure.py -v`
+Expected: PASS (all, including the three new tests)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/cardinal_cfn/cardinal_infrastructure.py tests/templates/test_cardinal_infrastructure.py
+git commit -m "feat: infra accepts remote-ingest bucket notifications + extra storage profiles"
+```
+
+---
+
+## Task 3: `cardinal-remote-ingest.yaml` generator
+
+**Files:**
+- Create: `src/cardinal_cfn/remote_ingest.py`
+- Test: `tests/templates/test_remote_ingest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/templates/test_remote_ingest.py
+"""Tests for the cardinal-remote-ingest standalone template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import remote_ingest
+
+
+@pytest.fixture
+def td():
+    return json.loads(remote_ingest.build().to_json())
+
+
+def test_parameters(td):
+    for n in ("RemoteAccountId", "OrgId", "QueueArn", "BucketName",
+              "CollectorName", "RemoteOtelRoleNamePattern",
+              "IngestBucketLifecycleDays"):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_remote_account_id_is_12_digits(td):
+    assert td["Parameters"]["RemoteAccountId"]["AllowedPattern"] == r"^[0-9]{12}$"
+
+
+def test_creates_one_bucket_retained_owner_enforced(td):
+    buckets = [r for r in td["Resources"].values() if r["Type"] == "AWS::S3::Bucket"]
+    assert len(buckets) == 1
+    b = buckets[0]
+    assert b["DeletionPolicy"] == "Retain"
+    assert b["UpdateReplacePolicy"] == "Retain"
+    rule = b["Properties"]["OwnershipControls"]["Rules"][0]
+    assert rule["ObjectOwnership"] == "BucketOwnerEnforced"
+    pab = b["Properties"]["PublicAccessBlockConfiguration"]
+    assert all(pab[k] is True for k in (
+        "BlockPublicAcls", "BlockPublicPolicy", "IgnorePublicAcls", "RestrictPublicBuckets"
+    ))
+
+
+def test_bucket_notifies_queue(td):
+    b = next(r for r in td["Resources"].values() if r["Type"] == "AWS::S3::Bucket")
+    qc = b["Properties"]["NotificationConfiguration"]["QueueConfigurations"][0]
+    assert qc["Event"] == "s3:ObjectCreated:*"
+    assert qc["Queue"] == {"Ref": "QueueArn"}
+
+
+def test_writer_role_trusts_remote_account_root_with_name_condition(td):
+    role = next(r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role")
+    stmt = role["Properties"]["AssumeRolePolicyDocument"]["Statement"][0]
+    assert stmt["Principal"]["AWS"] == {
+        "Fn::Sub": "arn:${AWS::Partition}:iam::${RemoteAccountId}:root"
+    }
+    assert stmt["Action"] == "sts:AssumeRole"
+    assert stmt["Condition"]["ArnLike"]["aws:PrincipalArn"] == {
+        "Fn::Sub": "arn:${AWS::Partition}:iam::${RemoteAccountId}:role/${RemoteOtelRoleNamePattern}"
+    }
+
+
+def test_writer_role_can_put_to_bucket(td):
+    role = next(r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role")
+    doc = role["Properties"]["Policies"][0]["PolicyDocument"]
+    actions = doc["Statement"][0]["Action"]
+    assert "s3:PutObject" in actions
+    assert "s3:AbortMultipartUpload" in actions
+
+
+def test_outputs(td):
+    for n in ("BucketName", "BucketArn", "BucketRegion", "WriterRoleArn",
+              "StorageProfileSnippet"):
+        assert n in td["Outputs"], f"missing output: {n}"
+
+
+def test_storage_profile_snippet_uses_region_and_bucket(td):
+    snippet = json.dumps(td["Outputs"]["StorageProfileSnippet"]["Value"])
+    assert "organization_id: ${OrgId}" in snippet
+    assert "use_path_style: true" in snippet
+
+
+def test_no_ecs_or_sqs_resources(td):
+    """This template only owns the bucket + writer role; the queue lives in infra."""
+    for r in td["Resources"].values():
+        assert r["Type"] not in ("AWS::SQS::Queue", "AWS::ECS::Service")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/templates/test_remote_ingest.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cardinal_cfn.remote_ingest'`
+
+- [ ] **Step 3: Write the generator**
+
+```python
+# src/cardinal_cfn/remote_ingest.py
+"""cardinal-remote-ingest.yaml: cross-account remote ingest bucket (main account).
+
+Standalone root template, one stack instance per remote bucket/account. Creates
+an S3 bucket in the main (lakerunner) account that a remote account's otel
+collector writes to (by assuming the WriterRole this stack creates), wires the
+bucket's s3:ObjectCreated notifications to the main SQS ingest queue, and emits
+a storage-profile snippet for the operator to register with lakerunner.
+
+Design: docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md
+"""
+
+from troposphere import (
+    Equals,
+    GetAtt,
+    If,
+    Output,
+    Parameter,
+    Ref,
+    Sub,
+    Tags,
+    Template,
+)
+from troposphere.iam import Policy, Role
+from troposphere.s3 import (
+    AbortIncompleteMultipartUpload,
+    Bucket,
+    LifecycleConfiguration,
+    LifecycleRule,
+    NotificationConfiguration,
+    OwnershipControls,
+    OwnershipControlsRule,
+    PublicAccessBlockConfiguration,
+    QueueConfigurations,
+)
+
+from cardinal_cfn.policies import apply_policy
+
+
+def _tags(*, component: str) -> Tags:
+    return Tags(
+        Name=Sub(f"cardinal-remote-ingest-{component}-${{RemoteAccountId}}"),
+        Project="cardinal",
+        Application="cardinal-lakerunner",
+        Component=component,
+        ManagedBy="cardinal-cfn",
+    )
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal remote ingest: an S3 bucket in the main account that a remote "
+        "account's otel collector writes to (via an assumed writer role), wired "
+        "to the main lakerunner SQS ingest queue. One stack per remote bucket."
+    )
+
+    remote_account_id = t.add_parameter(Parameter(
+        "RemoteAccountId",
+        Type="String",
+        AllowedPattern=r"^[0-9]{12}$",
+        Description="The second (remote) AWS account ID whose otel collector writes to this bucket.",
+    ))
+    org_id = t.add_parameter(Parameter(
+        "OrgId",
+        Type="String",
+        MinLength=1,
+        Description="Lakerunner organization_id this bucket's telemetry is attributed to.",
+    ))
+    queue_arn = t.add_parameter(Parameter(
+        "QueueArn",
+        Type="String",
+        MinLength=1,
+        Description="ARN of the main lakerunner SQS ingest queue (infra IngestQueueArn output).",
+    ))
+    bucket_name = t.add_parameter(Parameter(
+        "BucketName",
+        Type="String",
+        Default="",
+        AllowedPattern=r"^$|^cardinal-remote-ingest-[a-z0-9.-]{1,40}$",
+        Description=(
+            "Bucket name. Blank = cardinal-remote-ingest-<RemoteAccountId>. Any "
+            "override MUST keep the cardinal-remote-ingest- prefix so the infra "
+            "queue policy grants the notification."
+        ),
+    ))
+    collector_name = t.add_parameter(Parameter(
+        "CollectorName",
+        Type="String",
+        Default="lakerunner",
+        Description="Collector name for the storage profile and otel s3_prefix.",
+    ))
+    role_name_pattern = t.add_parameter(Parameter(
+        "RemoteOtelRoleNamePattern",
+        Type="String",
+        Default="cardinal-remote-otel-*",
+        Description="Remote task-role name pattern allowed to assume the writer role.",
+    ))
+    lifecycle_days = t.add_parameter(Parameter(
+        "IngestBucketLifecycleDays",
+        Type="Number",
+        Default=7,
+        MinValue=1,
+        Description="Days after which objects in the bucket expire (GC backstop).",
+    ))
+
+    t.add_condition("UseDefaultBucketName", Equals(Ref(bucket_name), ""))
+    bucket_name_value = If(
+        "UseDefaultBucketName",
+        Sub("cardinal-remote-ingest-${RemoteAccountId}"),
+        Ref(bucket_name),
+    )
+
+    writer_role = t.add_resource(Role(
+        "WriterRole",
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"AWS": Sub("arn:${AWS::Partition}:iam::${RemoteAccountId}:root")},
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                    "ArnLike": {
+                        "aws:PrincipalArn": Sub(
+                            "arn:${AWS::Partition}:iam::${RemoteAccountId}:role/${RemoteOtelRoleNamePattern}"
+                        )
+                    }
+                },
+            }],
+        },
+        Policies=[Policy(
+            PolicyName="cardinal-remote-writer",
+            PolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:PutObject",
+                        "s3:AbortMultipartUpload",
+                        "s3:ListMultipartUploadParts",
+                    ],
+                    "Resource": Sub(
+                        "arn:${AWS::Partition}:s3:::${BucketName}/*",
+                        BucketName=bucket_name_value,
+                    ),
+                }],
+            },
+        )],
+        Tags=_tags(component="writer-role"),
+    ))
+
+    bucket = t.add_resource(Bucket(
+        "RemoteIngestBucket",
+        BucketName=bucket_name_value,
+        OwnershipControls=OwnershipControls(
+            Rules=[OwnershipControlsRule(ObjectOwnership="BucketOwnerEnforced")]
+        ),
+        PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
+            BlockPublicAcls=True,
+            BlockPublicPolicy=True,
+            IgnorePublicAcls=True,
+            RestrictPublicBuckets=True,
+        ),
+        LifecycleConfiguration=LifecycleConfiguration(Rules=[
+            LifecycleRule(
+                Id="cardinal-remote-ingest-expire",
+                Status="Enabled",
+                Prefix="",
+                ExpirationInDays=Ref(lifecycle_days),
+                AbortIncompleteMultipartUpload=AbortIncompleteMultipartUpload(
+                    DaysAfterInitiation=1
+                ),
+            )
+        ]),
+        NotificationConfiguration=NotificationConfiguration(
+            QueueConfigurations=[
+                QueueConfigurations(Event="s3:ObjectCreated:*", Queue=Ref(queue_arn))
+            ]
+        ),
+        Tags=_tags(component="bucket"),
+    ))
+    apply_policy(bucket, "s3-ingest-bucket")
+
+    t.add_output(Output("BucketName", Description="Remote ingest bucket name.", Value=bucket_name_value))
+    t.add_output(Output("BucketArn", Description="Remote ingest bucket ARN.", Value=GetAtt(bucket, "Arn")))
+    t.add_output(Output(
+        "BucketRegion",
+        Description="Bucket region (the main/lakerunner region). Feed to the remote collector's BucketRegion.",
+        Value=Ref("AWS::Region"),
+    ))
+    t.add_output(Output(
+        "WriterRoleArn",
+        Description="Role ARN the remote collector assumes to write. Feed to the remote collector's WriterRoleArn.",
+        Value=GetAtt(writer_role, "Arn"),
+    ))
+    t.add_output(Output(
+        "StorageProfileSnippet",
+        Description="YAML list item to append to the infra stack's AdditionalStorageProfilesYaml, then re-run the migrator.",
+        Value=Sub(
+            "- organization_id: ${OrgId}\n"
+            "  instance_num: 1\n"
+            "  collector_name: ${CollectorName}\n"
+            "  cloud_provider: aws\n"
+            "  region: ${AWS::Region}\n"
+            "  bucket: ${BucketName}\n"
+            "  insecure_tls: false\n"
+            "  use_path_style: true\n",
+            BucketName=bucket_name_value,
+        ),
+    ))
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/templates/test_remote_ingest.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cardinal_cfn/remote_ingest.py tests/templates/test_remote_ingest.py
+git commit -m "feat: cardinal-remote-ingest template (bucket + cross-account writer role)"
+```
+
+---
+
+## Task 4: `cardinal-remote-collector.yaml` generator
+
+**Files:**
+- Create: `src/cardinal_cfn/remote_collector.py`
+- Test: `tests/templates/test_remote_collector.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/templates/test_remote_collector.py
+"""Tests for the cardinal-remote-collector standalone template (remote account)."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import remote_collector
+
+
+@pytest.fixture
+def td():
+    return json.loads(remote_collector.build().to_json())
+
+
+def test_customer_supplied_parameters(td):
+    for n in ("VpcId", "PrivateSubnetsCsv", "ClusterArn", "WriterRoleArn",
+              "BucketName", "BucketRegion", "OrgId", "CollectorName",
+              "OtlpIngressCidr"):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_no_license_secret_anywhere(td):
+    """The remote collector runs receive->S3 only; it needs no license."""
+    blob = json.dumps(td)
+    assert "LICENSE_DATA" not in blob
+    assert "LicenseSecretArn" not in td["Parameters"]
+    task_def = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    assert "Secrets" not in container or container["Secrets"] == []
+
+
+def test_creates_internal_alb_on_4318(td):
+    albs = [r for r in td["Resources"].values()
+            if r["Type"] == "AWS::ElasticLoadBalancingV2::LoadBalancer"]
+    assert len(albs) == 1
+    assert albs[0]["Properties"]["Scheme"] == "internal"
+    listeners = [r for r in td["Resources"].values()
+                 if r["Type"] == "AWS::ElasticLoadBalancingV2::Listener"]
+    assert len(listeners) == 1
+    assert listeners[0]["Properties"]["Port"] == 4318
+    assert listeners[0]["Properties"]["Protocol"] == "HTTP"
+
+
+def test_creates_two_security_groups(td):
+    sgs = [r for r in td["Resources"].values() if r["Type"] == "AWS::EC2::SecurityGroup"]
+    assert len(sgs) == 2
+
+
+def test_task_role_name_matches_writer_trust_pattern(td):
+    """Task role name must start with cardinal-remote-otel- so the main writer
+    role's trust condition matches it."""
+    roles = [r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role"]
+    task_roles = [
+        r for r in roles
+        if any(
+            "sts:AssumeRole" in json.dumps(p["PolicyDocument"])
+            and "WriterRoleArn" in json.dumps(p["PolicyDocument"])
+            for p in r["Properties"].get("Policies", [])
+        )
+    ]
+    assert len(task_roles) == 1
+    name = task_roles[0]["Properties"]["RoleName"]
+    assert name == {"Fn::Sub": "cardinal-remote-otel-${AWS::Region}"}
+
+
+def test_task_role_can_assume_writer_role(td):
+    roles = [r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role"]
+    found = False
+    for r in roles:
+        for p in r["Properties"].get("Policies", []):
+            doc = json.dumps(p["PolicyDocument"])
+            if "sts:AssumeRole" in doc and "WriterRoleArn" in doc:
+                found = True
+    assert found, "no role grants sts:AssumeRole on WriterRoleArn"
+
+
+def test_collector_env_uses_bucket_region_and_role(td):
+    task_def = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    env = {e["Name"]: e["Value"] for e in container["Environment"]}
+    assert env["LRDB_S3_BUCKET"] == {"Ref": "BucketName"}
+    assert env["LRDB_S3_REGION"] == {"Ref": "BucketRegion"}
+    assert env["LRDB_S3_ROLE_ARN"] == {"Ref": "WriterRoleArn"}
+    assert env["ORG"] == {"Ref": "OrgId"}
+    assert "CHQ_COLLECTOR_CONFIG_YAML" in env
+
+
+def test_service_disables_public_ip(td):
+    svc = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service")
+    awsvpc = svc["Properties"]["NetworkConfiguration"]["AwsvpcConfiguration"]
+    assert awsvpc["AssignPublicIp"] == "DISABLED"
+
+
+def test_no_cloud_map_registration(td):
+    """Self-telemetry discovery is a main-account concern; not here."""
+    assert not [r for r in td["Resources"].values()
+                if r["Type"] == "AWS::ServiceDiscovery::Service"]
+
+
+def test_outputs(td):
+    for n in ("OtelAlbDnsName", "OtelExternalUrl"):
+        assert n in td["Outputs"], f"missing output: {n}"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `.venv/bin/pytest tests/templates/test_remote_collector.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'cardinal_cfn.remote_collector'`
+
+- [ ] **Step 3: Write the generator**
+
+```python
+# src/cardinal_cfn/remote_collector.py
+"""cardinal-remote-collector.yaml: otel collector in a remote account.
+
+Standalone root template deployed via the AWS console in the second account.
+Receives OTLP, assumes the main-account writer role, and writes telemetry to the
+main-account remote-ingest bucket. The customer brings VpcId, PrivateSubnetsCsv,
+and ClusterArn; this stack creates the ALB, security groups, roles, log group,
+and the otel ECS service.
+
+Design: docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md
+"""
+
+from troposphere import (
+    GetAtt,
+    Output,
+    Parameter,
+    Ref,
+    Split,
+    Sub,
+    Tags,
+    Template,
+)
+from troposphere.ec2 import SecurityGroup, SecurityGroupRule
+from troposphere.ecs import (
+    AwsvpcConfiguration,
+    ContainerDefinition,
+    DeploymentCircuitBreaker,
+    DeploymentConfiguration,
+    Environment,
+    LoadBalancer as EcsLoadBalancer,
+    LogConfiguration,
+    NetworkConfiguration,
+    PortMapping,
+    Service,
+    TaskDefinition,
+)
+from troposphere.elasticloadbalancingv2 import (
+    Action,
+    Listener,
+    LoadBalancer,
+    Matcher,
+    TargetGroup,
+)
+from troposphere.iam import Policy, Role
+from troposphere.logs import LogGroup
+
+from cardinal_cfn.defaults import load_defaults, load_remote_otel_default_config
+from cardinal_cfn.images import add_image_override
+
+_SERVICE_KEY = "otel-grpc"
+_OTLP_HTTP_PORT = 4318
+_HEALTH_PORT = 13133
+
+
+def _tags(*, component: str) -> Tags:
+    return Tags(
+        Name=f"cardinal-remote-collector-{component}",
+        Project="cardinal",
+        Application="cardinal-lakerunner",
+        Component=component,
+        ManagedBy="cardinal-cfn",
+    )
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal remote collector: an ALB-fronted cardinalhq-otel-collector in a "
+        "remote account that assumes a main-account writer role to write telemetry "
+        "to the main-account remote-ingest bucket."
+    )
+
+    defaults = load_defaults()
+    otel_cfg = defaults["otel"]["otel-gateway"]
+
+    # Customer-supplied
+    t.add_parameter(Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="Customer VPC ID."))
+    t.add_parameter(Parameter(
+        "PrivateSubnetsCsv",
+        Type="String",
+        Description="Comma-separated private subnet IDs (>=2 AZs) for the internal ALB and the collector ENIs.",
+    ))
+    t.add_parameter(Parameter("ClusterArn", Type="String", Description="Customer ECS cluster ARN."))
+
+    # From the main-account cardinal-remote-ingest stack outputs
+    t.add_parameter(Parameter("WriterRoleArn", Type="String", Description="Writer role ARN to assume (remote-ingest WriterRoleArn output)."))
+    t.add_parameter(Parameter("BucketName", Type="String", Description="Main-account remote-ingest bucket name."))
+    t.add_parameter(Parameter(
+        "BucketRegion",
+        Type="String",
+        Description="Bucket region (the main/lakerunner region). NOT the remote account's region.",
+    ))
+    t.add_parameter(Parameter("OrgId", Type="String", Description="Lakerunner organization_id (match the remote-ingest OrgId)."))
+    t.add_parameter(Parameter("CollectorName", Type="String", Default="lakerunner", Description="Collector name (match the remote-ingest CollectorName)."))
+    t.add_parameter(Parameter(
+        "OtlpIngressCidr",
+        Type="String",
+        Default="10.0.0.0/8",
+        Description="Source CIDR allowed to reach the internal ALB on 4318. Narrow to your sender/VPC CIDR.",
+    ))
+
+    image_ref = add_image_override(
+        t,
+        name="OtelImage",
+        default=defaults["images"]["otel"],
+        description="Container image for the cardinalhq-otel-collector service.",
+    )
+    t.add_parameter(Parameter("OtelReplicas", Type="Number", Default=str(otel_cfg["replicas"]), Description="Desired replicas."))
+    t.add_parameter(Parameter("OtelCpu", Type="String", Default=str(otel_cfg["cpu"]), Description="Fargate CPU units."))
+    t.add_parameter(Parameter("OtelMemory", Type="String", Default=str(otel_cfg["memory_mib"]), Description="Fargate memory (MiB)."))
+
+    # ------------------------------------------------------------------ SGs
+    alb_sg = t.add_resource(SecurityGroup(
+        "AlbSecurityGroup",
+        GroupDescription="cardinal remote collector ALB; OTLP/HTTP 4318 ingress.",
+        VpcId=Ref("VpcId"),
+        SecurityGroupIngress=[SecurityGroupRule(
+            IpProtocol="tcp", FromPort=_OTLP_HTTP_PORT, ToPort=_OTLP_HTTP_PORT,
+            CidrIp=Ref("OtlpIngressCidr"),
+            Description="OTLP/HTTP from senders",
+        )],
+        SecurityGroupEgress=[SecurityGroupRule(
+            IpProtocol="-1", CidrIp="0.0.0.0/0", Description="All egress",
+        )],
+        Tags=_tags(component="alb-sg"),
+    ))
+    task_sg = t.add_resource(SecurityGroup(
+        "TaskSecurityGroup",
+        GroupDescription="cardinal remote collector tasks; 4318 from ALB only.",
+        VpcId=Ref("VpcId"),
+        SecurityGroupIngress=[SecurityGroupRule(
+            IpProtocol="tcp", FromPort=_OTLP_HTTP_PORT, ToPort=_OTLP_HTTP_PORT,
+            SourceSecurityGroupId=Ref(alb_sg),
+            Description="OTLP/HTTP from the ALB",
+        )],
+        SecurityGroupEgress=[SecurityGroupRule(
+            IpProtocol="-1", CidrIp="0.0.0.0/0", Description="All egress",
+        )],
+        Tags=_tags(component="task-sg"),
+    ))
+
+    # ------------------------------------------------------------------ ALB
+    alb = t.add_resource(LoadBalancer(
+        "Alb",
+        Scheme="internal",
+        Type="application",
+        Subnets=Split(",", Ref("PrivateSubnetsCsv")),
+        SecurityGroups=[Ref(alb_sg)],
+        Tags=_tags(component="alb"),
+    ))
+    target_group = t.add_resource(TargetGroup(
+        "OtelTargetGroup",
+        Port=_OTLP_HTTP_PORT,
+        Protocol="HTTP",
+        TargetType="ip",
+        VpcId=Ref("VpcId"),
+        HealthCheckPath="/",
+        HealthCheckPort=str(_HEALTH_PORT),
+        HealthCheckProtocol="HTTP",
+        Matcher=Matcher(HttpCode="200"),
+        Tags=_tags(component="otel-tg"),
+    ))
+    listener = t.add_resource(Listener(
+        "OtelHttpListener",
+        LoadBalancerArn=Ref(alb),
+        Port=_OTLP_HTTP_PORT,
+        Protocol="HTTP",
+        DefaultActions=[Action(Type="forward", TargetGroupArn=Ref(target_group))],
+    ))
+
+    # ------------------------------------------------------------------ Roles
+    exec_role = t.add_resource(Role(
+        "ExecutionRole",
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }],
+        },
+        ManagedPolicyArns=[
+            "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+        ],
+        Tags=_tags(component="exec-role"),
+    ))
+    task_role = t.add_resource(Role(
+        "TaskRole",
+        RoleName=Sub("cardinal-remote-otel-${AWS::Region}"),
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }],
+        },
+        Policies=[Policy(
+            PolicyName="cardinal-remote-otel-assume-writer",
+            PolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": Ref("WriterRoleArn"),
+                }],
+            },
+        )],
+        Tags=_tags(component="task-role"),
+    ))
+
+    log_group = t.add_resource(LogGroup(
+        "OtelLogGroup",
+        LogGroupName="/cardinal/otel-grpc",
+        RetentionInDays=14,
+        DeletionPolicy="Delete",
+        UpdateReplacePolicy="Delete",
+        Tags=_tags(component="otel-logs"),
+    ))
+
+    # ------------------------------------------------------------ Task def
+    env = [
+        Environment(Name="CHQ_COLLECTOR_CONFIG_YAML", Value=load_remote_otel_default_config()),
+        Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
+        Environment(Name="LRDB_S3_REGION", Value=Ref("BucketRegion")),
+        Environment(Name="LRDB_S3_ROLE_ARN", Value=Ref("WriterRoleArn")),
+        Environment(Name="ORG", Value=Ref("OrgId")),
+        Environment(Name="COLLECTOR", Value=Ref("CollectorName")),
+    ] + [Environment(Name=k, Value=str(v)) for k, v in (otel_cfg.get("environment") or {}).items()]
+
+    task_def = t.add_resource(TaskDefinition(
+        "OtelTaskDef",
+        RequiresCompatibilities=["FARGATE"],
+        NetworkMode="awsvpc",
+        Cpu=Ref("OtelCpu"),
+        Memory=Ref("OtelMemory"),
+        ExecutionRoleArn=GetAtt(exec_role, "Arn"),
+        TaskRoleArn=GetAtt(task_role, "Arn"),
+        ContainerDefinitions=[ContainerDefinition(
+            Name=_SERVICE_KEY,
+            Image=image_ref,
+            Essential=True,
+            Command=otel_cfg.get("command"),
+            Environment=env,
+            PortMappings=[PortMapping(ContainerPort=_OTLP_HTTP_PORT, Protocol="tcp")],
+            LogConfiguration=LogConfiguration(
+                LogDriver="awslogs",
+                Options={
+                    "awslogs-group": Ref(log_group),
+                    "awslogs-region": Ref("AWS::Region"),
+                    "awslogs-stream-prefix": _SERVICE_KEY,
+                },
+            ),
+        )],
+        Tags=_tags(component="otel-taskdef"),
+    ))
+
+    # ------------------------------------------------------------- Service
+    service = t.add_resource(Service(
+        "OtelService",
+        Cluster=Ref("ClusterArn"),
+        LaunchType="FARGATE",
+        DesiredCount=Ref("OtelReplicas"),
+        TaskDefinition=Ref(task_def),
+        DependsOn=[listener.title],
+        NetworkConfiguration=NetworkConfiguration(
+            AwsvpcConfiguration=AwsvpcConfiguration(
+                Subnets=Split(",", Ref("PrivateSubnetsCsv")),
+                SecurityGroups=[Ref(task_sg)],
+                AssignPublicIp="DISABLED",
+            )
+        ),
+        DeploymentConfiguration=DeploymentConfiguration(
+            MinimumHealthyPercent=50,
+            MaximumPercent=200,
+            DeploymentCircuitBreaker=DeploymentCircuitBreaker(Enable=True, Rollback=True),
+        ),
+        LoadBalancers=[EcsLoadBalancer(
+            ContainerName=_SERVICE_KEY,
+            ContainerPort=_OTLP_HTTP_PORT,
+            TargetGroupArn=Ref(target_group),
+        )],
+        Tags=_tags(component="otel-service"),
+    ))
+
+    t.add_output(Output("OtelAlbDnsName", Value=GetAtt(alb, "DNSName")))
+    t.add_output(Output("OtelExternalUrl", Value=Sub(f"http://${{Dns}}:{_OTLP_HTTP_PORT}", Dns=GetAtt(alb, "DNSName"))))
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `.venv/bin/pytest tests/templates/test_remote_collector.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cardinal_cfn/remote_collector.py tests/templates/test_remote_collector.py
+git commit -m "feat: cardinal-remote-collector template (ALB-fronted otel, assumes writer role)"
+```
+
+---
+
+## Task 5: Build + lint wiring
+
+**Files:**
+- Modify: `build.sh`
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add generation lines to `build.sh`**
+
+After the `cardinal-cleanup.yaml` generation block (~31), add:
+
+```sh
+echo "Generating cardinal-remote-ingest.yaml..."
+python3 -m cardinal_cfn.remote_ingest > generated-templates/cardinal-remote-ingest.yaml
+
+echo "Generating cardinal-remote-collector.yaml..."
+python3 -m cardinal_cfn.remote_collector > generated-templates/cardinal-remote-collector.yaml
+```
+
+Add both to the `cfn-lint` invocation (~50-55):
+
+```sh
+         generated-templates/cardinal-remote-ingest.yaml \
+         generated-templates/cardinal-remote-collector.yaml \
+```
+
+- [ ] **Step 2: Add both to the `Makefile` lint target**
+
+In the `lint:` target (~38-44), add the two lines before `generated-templates/cardinal-lakerunner.yaml`:
+
+```make
+	  generated-templates/cardinal-remote-ingest.yaml \
+	  generated-templates/cardinal-remote-collector.yaml \
+```
+
+- [ ] **Step 3: Build and lint everything**
+
+Run: `make build`
+Expected: generates all templates including the two new ones; cfn-lint passes (warnings tolerable, no errors). If cfn-lint flags an error on either new template, fix the template and re-run.
+
+- [ ] **Step 4: Run the full test suite**
+
+Run: `make test`
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add build.sh Makefile
+git commit -m "build: generate and lint the remote-ingest and remote-collector templates"
+```
+
+---
+
+## Task 6: Operator docs
+
+**Files:**
+- Modify or create: a short operator runbook section (e.g. `docs/operations/remote-ingest.md`)
+
+- [ ] **Step 1: Write the runbook**
+
+Document the operator workflow from the spec's "Operator workflow" section: deploy `cardinal-remote-ingest` in the main account, record outputs, deploy `cardinal-remote-collector` in the second account (CAPABILITY_NAMED_IAM), append the `StorageProfileSnippet` to the infra `AdditionalStorageProfilesYaml`, redeploy infra, re-run the migrator. Note the deploy-ordering prerequisite (infra must carry the broadened queue policy first) and the same-region bucket constraint.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/operations/remote-ingest.md
+git commit -m "docs: remote-ingest operator runbook"
+```
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** bucket+writer role (Task 3), remote collector ALB+otel+assume-role (Task 4), queue-policy widening + AdditionalStorageProfilesYaml (Task 2), remote otel config role_arn (Task 1), build/lint (Task 5), operator docs (Task 6). All spec sections mapped.
+- **Type/name consistency:** `WriterRoleArn`, `BucketName`, `BucketRegion`, `OrgId`, `CollectorName` parameter names are identical between the remote-ingest outputs and the remote-collector inputs. The task-role name `cardinal-remote-otel-${AWS::Region}` matches the writer-role trust default pattern `cardinal-remote-otel-*`. `_SERVICE_KEY="otel-grpc"` matches the log group `/cardinal/otel-grpc`.
+- **Verify-at-implementation:** the awss3 exporter `role_arn` field name and `${env:...}` expansion must be confirmed against the cardinalhq-otel-collector image (template tests do not run the collector). If the field differs, fix `cardinal-remote-otel-config.yaml` only.

--- a/docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md
+++ b/docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md
@@ -1,0 +1,293 @@
+# Cross-account remote ingest design
+
+Status: approved (brainstorming, 2026-05-29)
+
+## Problem
+
+A Cardinal lakerunner install lives in one AWS account (the "main" account).
+We need telemetry produced in a **second AWS account** to land in lakerunner's
+ingest pipeline. The pipeline is: an otel collector writes telemetry blobs to an
+S3 bucket; the bucket emits `s3:ObjectCreated` notifications to lakerunner's SQS
+queue; lakerunner's `pubsub-sqs` service fans those out to the process workers,
+which read each object back from S3 and ingest it.
+
+Getting a second account's telemetry into that pipeline requires crossing an
+account boundary somewhere. The question is *where*, and how to grant the
+minimum cross-account permission.
+
+## Decision: bucket in the main account, remote collector assumes a writer role
+
+The remote-ingest bucket lives in the **main account** (option 1). Consequence:
+
+- **Write** (remote collector -> bucket) crosses the account boundary.
+- **Notification** (bucket -> SQS) is same-account, same-region.
+- **Read** (lakerunner -> bucket) is same-account.
+
+Only the write crosses the boundary. The alternative (bucket in the remote
+account) would cross the boundary three times -- notification, read, and the
+read is the painful one (lakerunner reading objects owned by a foreign account).
+
+The write crosses via **STS assume-role**, not a direct bucket-policy grant:
+
+- The main account creates a **writer role**. Its trust policy allows the remote
+  account *root* to assume it, narrowed by a condition on the assuming
+  principal's name (`aws:PrincipalArn ArnLike .../role/cardinal-remote-otel-*`).
+  Trusting the account root (not a specific role ARN) is what removes the
+  circular dependency -- the writer role can be created before the remote role
+  exists, so the main stack is self-contained and just outputs the role ARN.
+- The remote collector's otel task role is granted `sts:AssumeRole` on that
+  writer-role ARN.
+- The collector's `awss3` exporter is configured with `role_arn` set to the
+  writer-role ARN. The collector assumes the role (using its task-role creds as
+  the STS source) before each S3 write.
+- Because the collector writes *as the assumed main-account role*, the objects
+  are natively owned by the main account, so lakerunner reads them with no ACL
+  or ownership fuss. The bucket is also set to `BucketOwnerEnforced` (ACLs off)
+  for hygiene.
+
+Why assume-role over a direct cross-account bucket-policy grant:
+
+1. Clean ordering / no circularity (trust the account root + name condition).
+2. Native main-account object ownership (lakerunner reads with zero ACL work).
+3. Tight scope: only the named role pattern can write, gated by the trust policy.
+
+The `awss3` exporter's `role_arn` field is confirmed against the
+opentelemetry-collector-contrib README (top-level field, sibling of
+`s3uploader`). The `cardinalhq-otel-collector` image is a custom build; the
+exact field name and env-expansion behaviour must be re-confirmed against that
+image during implementation (template tests do not run the collector).
+
+## Data flow
+
+```
+remote app --OTLP--> remote ALB :4318 --> remote otel collector
+   --(assume main writer role via STS)--> PutObject  main-account bucket
+       (bucket is in the main account, in lakerunner's region)
+   --> S3 ObjectCreated --> main SQS (same-account, same-region)
+   --> lakerunner pubsub-sqs --> process-{logs,metrics,traces}
+   --> read object from bucket (same-account) --> ingest under the bucket's org
+```
+
+## Components
+
+### 1. New main-account template: `cardinal-remote-ingest.yaml`
+
+Generator: `src/cardinal_cfn/remote_ingest.py` (standalone root template, in the
+style of `lrdev_baseinfra.py`). One **stack instance per remote bucket/account**.
+Published to S3 alongside the other `cardinal-*` templates.
+
+Parameters:
+
+- `RemoteAccountId` (String, 12 digits, `AllowedPattern ^[0-9]{12}$`) -- the
+  second account, used in the writer role's trust policy.
+- `OrgId` (String, required) -- the lakerunner organization this bucket's
+  telemetry is attributed to. One org per remote bucket.
+- `QueueArn` (String) -- the main SQS ingest queue ARN (from the infra stack's
+  `IngestQueueArn` output). Target of the bucket notification.
+- `BucketName` (String, default `cardinal-remote-ingest-${RemoteAccountId}` via
+  a rendered default; `AllowedPattern` enforces the `cardinal-remote-ingest-`
+  prefix). The prefix is mandatory because the infra queue policy grants the
+  notification by prefix match (see component 3).
+- `CollectorName` (String, default `lakerunner`) -- collector name for the
+  storage-profile and the otel `s3_prefix`.
+- `RemoteOtelRoleNamePattern` (String, default `cardinal-remote-otel-*`) -- the
+  remote task-role name pattern allowed to assume the writer role. Default
+  matches the name the remote collector template assigns its task role.
+- `IngestBucketLifecycleDays` (Number, default 7) -- mirrors the primary ingest
+  bucket's GC backstop.
+
+Resources:
+
+- **S3 bucket** (`Retain`): explicit `BucketName`; `BucketOwnerEnforced`
+  ownership; `PublicAccessBlockConfiguration` all-true; lifecycle expiration
+  (`IngestBucketLifecycleDays`) + abort-incomplete-multipart; and a
+  `NotificationConfiguration` -> `QueueConfigurations` with `Event
+  s3:ObjectCreated:*`, `Queue=Ref(QueueArn)`. No cross-stack `DependsOn` is
+  possible; the infra queue policy must already permit this bucket's prefix
+  (see component 3) -- documented as a deploy-ordering prerequisite.
+- **Writer IAM role** (`cardinal-remote-writer-...`, CFN-generated name fine):
+  - Trust: `Principal AWS: arn:${AWS::Partition}:iam::${RemoteAccountId}:root`,
+    `Action sts:AssumeRole`, `Condition ArnLike aws:PrincipalArn
+    arn:${AWS::Partition}:iam::${RemoteAccountId}:role/${RemoteOtelRoleNamePattern}`.
+  - Permissions: `s3:PutObject`, `s3:AbortMultipartUpload`,
+    `s3:ListMultipartUploadParts` on `${BucketArn}/*`. (The s3manager uploader
+    used by the exporter may multipart large blobs.)
+
+Outputs:
+
+- `BucketName`, `BucketArn`
+- `BucketRegion` (`Ref AWS::Region` -- this stack runs in the main/lakerunner
+  region, which is the bucket's region).
+- `WriterRoleArn`
+- `StorageProfileSnippet` -- a ready-to-paste YAML list item for the operator to
+  append to the infra stack's `AdditionalStorageProfilesYaml` (see component 3),
+  in the same shape the infra stack seeds:
+
+  ```yaml
+  - organization_id: <OrgId>
+    instance_num: 1
+    collector_name: <CollectorName>
+    cloud_provider: aws
+    region: <BucketRegion>
+    bucket: <BucketName>
+    insecure_tls: false
+    use_path_style: true
+  ```
+
+### 2. New remote-account template: `cardinal-remote-collector.yaml`
+
+Generator: `src/cardinal_cfn/remote_collector.py` (standalone root template).
+Deployed by the operator via the AWS console in the **second account**. Customer
+brings VPC, subnets, and an ECS cluster; this stack creates everything else
+(ALB, SGs, roles, log group, otel service) -- mirroring how the main product
+creates its own ALB while consuming a customer SG.
+
+Parameters:
+
+- `VpcId` (`AWS::EC2::VPC::Id`) -- customer-supplied.
+- `PrivateSubnetsCsv` (String) -- customer-supplied; used for the internal ALB
+  and the ECS service ENIs.
+- `ClusterArn` (String) -- customer-supplied ECS cluster.
+- `WriterRoleArn` (String) -- from the main stack's `WriterRoleArn` output.
+- `BucketName` (String) -- from the main stack's `BucketName` output.
+- `BucketRegion` (String) -- from the main stack's `BucketRegion` output. NOTE:
+  this is the *bucket's* region (lakerunner's), which may differ from the remote
+  account's region. The otel `LRDB_S3_REGION` env var is set from this, **not**
+  from `AWS::Region`.
+- `OrgId`, `CollectorName` -- match the main stack's values (drive the
+  `s3_prefix`).
+- `OtlpIngressCidr` (String, default `10.0.0.0/8`) -- source CIDR allowed to
+  reach the internal ALB on 4318. Operator narrows to the VPC/sender CIDR.
+- `OtelImage` -- image override (default from `cardinal-defaults.yaml`).
+- `OtelReplicas` / `OtelCpu` / `OtelMemory` -- tunables (defaults from
+  `cardinal-defaults.yaml` `otel.otel-gateway`).
+
+Resources:
+
+- **ALB security group**: ingress tcp/4318 from `OtlpIngressCidr`; egress all.
+- **Task security group**: ingress tcp/4318 from the ALB SG; egress all.
+- **Internal ALB** + HTTP listener on 4318 whose default action forwards to the
+  collector target group (no path-pattern rules needed -- single backend).
+- **Target group** (HTTP, ip target, port 4318, health check on 13133 `/`),
+  reusing `services_common.build_target_group`.
+- **Log group** `/cardinal/otel-grpc` via `services_common.build_log_group`.
+- **Execution role**: ECR pull + CloudWatch Logs. No secrets (no license).
+- **Task role** named with the `cardinal-remote-otel-` prefix (so it matches the
+  writer role's trust condition): granted `sts:AssumeRole` on `WriterRoleArn`
+  plus CloudWatch Logs. No SQS, no DB, no SSM. The explicit role name is a
+  sanctioned exception to the CFN-generated-name rule (it is externally
+  referenced by the main account's writer-role trust condition, like SSM param
+  names and the ingest bucket name are externally-referenced exceptions). It
+  forces `CAPABILITY_NAMED_IAM` at deploy time -- the console handles this.
+  Cross-account assume-role requires both sides to allow: the writer role's
+  trust policy (resource side, account-root + name condition) and this role's
+  `sts:AssumeRole` identity policy (principal side). The name condition is
+  therefore defense-in-depth on top of the principal-side scoping.
+- **Task definition** via `services_common.build_task_definition`, with env:
+  - `CHQ_COLLECTOR_CONFIG_YAML` = the remote otel config (see below).
+  - `LRDB_S3_BUCKET` = `Ref(BucketName)`.
+  - `LRDB_S3_REGION` = `Ref(BucketRegion)`  (not `AWS::Region`).
+  - `LRDB_S3_ROLE_ARN` = `Ref(WriterRoleArn)`.
+  - `ORG` = `Ref(OrgId)`, `COLLECTOR` = `Ref(CollectorName)`.
+  - No `LICENSE_DATA` secret.
+- **ECS service** attached to the target group (inline, like `otel.py`, so the
+  `LoadBalancers` block references the always-present target group). No Cloud Map
+  registration (self-telemetry discovery is a main-account concern).
+
+Outputs: `OtelAlbDnsName`, `OtelExternalUrl` (`http://<alb>:4318`).
+
+New config file: `cardinal-remote-otel-config.yaml` -- a copy of
+`cardinal-otel-config.yaml` with `role_arn: ${env:LRDB_S3_ROLE_ARN}` added to
+each `awss3/*` exporter (top-level, sibling of `s3uploader` and `marshaler`).
+A separate file (not a shared one) because an empty `role_arn` is not safely
+ignored by the exporter, so the main collector cannot share it.
+
+`defaults.py` gains `load_remote_otel_default_config()` (or
+`load_otel_default_config` is generalized to take a filename) to read it.
+
+### 3. Edits to `cardinal_infrastructure.py`
+
+- **Queue policy**: keep the existing statement scoped to the primary ingest
+  bucket ARN exactly as-is. **Add a second statement** allowing
+  `s3.amazonaws.com` `sqs:SendMessage` with `Condition StringEquals
+  aws:SourceAccount = ${AWS::AccountId}` and `ArnLike aws:SourceArn =
+  arn:${AWS::Partition}:s3:::cardinal-remote-ingest-*`. This lets each new
+  remote-ingest bucket notify the queue without per-bucket edits to the
+  infra-owned policy. The distinct `cardinal-remote-ingest-` prefix does not
+  overlap the primary `cardinal-ingest-` prefix.
+- **Storage profiles**: add an `AdditionalStorageProfilesYaml` parameter
+  (String, default `""`) and append it to the `StorageProfilesParam` value after
+  the seeded primary profile. Empty default is harmless (appends nothing). The
+  operator pastes one or more `cardinal-remote-ingest.yaml` `StorageProfileSnippet`
+  outputs here.
+
+## Operator workflow (manual, AWS console)
+
+No cross-account automation (no StackSets, no spanning script).
+
+1. `cardinal-infrastructure` + `cardinal-lakerunner` already deployed. Infra
+   must be on a template version that includes the broadened queue policy
+   (component 3) before any remote-ingest stack is deployed.
+2. **Main account**: deploy `cardinal-remote-ingest.yaml` with `RemoteAccountId`,
+   `OrgId`, and `QueueArn` (the infra `IngestQueueArn` output). Record its
+   outputs.
+3. **Second account**: deploy `cardinal-remote-collector.yaml` via the console,
+   pasting `WriterRoleArn`, `BucketName`, `BucketRegion`, `OrgId`,
+   `CollectorName`, plus the customer's `VpcId`, `PrivateSubnetsCsv`,
+   `ClusterArn`, and an `OtlpIngressCidr`.
+4. **Register the storage profile**: append the remote-ingest stack's
+   `StorageProfileSnippet` to the infra stack's `AdditionalStorageProfilesYaml`
+   parameter and redeploy infra (updates the SSM param).
+5. **Re-run the migrator** so it re-imports the storage profiles into `configdb`
+   (bump `LakerunnerImage`, or cycle the migrator service desired-count). The
+   migrator is idempotent. This re-import is the main ergonomic cost; automatic
+   registration is an explicit non-goal for v1.
+
+## File layout
+
+```
+src/cardinal_cfn/remote_ingest.py        -> generated-templates/cardinal-remote-ingest.yaml
+src/cardinal_cfn/remote_collector.py     -> generated-templates/cardinal-remote-collector.yaml
+cardinal-remote-otel-config.yaml         (new; remote collector config with role_arn)
+src/cardinal_cfn/cardinal_infrastructure.py  (edits: queue policy + AdditionalStorageProfilesYaml)
+src/cardinal_cfn/defaults.py             (edit: load remote otel config)
+build.sh                                 (edit: generate the two new templates)
+Makefile lint target                     (edit: lint the two new templates)
+tests/templates/test_remote_ingest.py    (new)
+tests/templates/test_remote_collector.py (new)
+tests/templates/...                      (edit existing infra test for queue policy + new param)
+```
+
+These are `cardinal-*` product templates (customer/operator-facing, published to
+S3), not `lrdev-*` scaffolding.
+
+## Testing
+
+- `cloud-radar` per-template assertions for both new templates: writer-role
+  trust + permissions shape, bucket ownership/notification, the assume-role
+  env wiring, `LRDB_S3_REGION` sourced from `BucketRegion` (not `AWS::Region`),
+  no `LICENSE_DATA` secret on the remote collector, and the storage-profile
+  snippet shape.
+- An assertion on the infra queue policy's second statement
+  (`cardinal-remote-ingest-*` ArnLike) and the `AdditionalStorageProfilesYaml`
+  append.
+- `cfn-lint` clean on both new templates (via `build.sh` / `make lint`).
+- End-to-end cross-account verification needs a second AWS account and is a
+  documented manual procedure; it cannot run in the single test account
+  (493746473138). Not automated.
+
+## Flags / non-goals
+
+- **Cross-region write cost**: the bucket is pinned to lakerunner's region
+  (S3 -> SQS must be same-region). If the remote account is in another region,
+  the collector writes cross-region (egress cost). Accepted.
+- **KMS**: buckets are SSE-S3 today; if a bucket is later switched to SSE-KMS,
+  the writer role needs `kms:GenerateDataKey` on the key. Out of scope now.
+- **License**: the remote collector runs a pure OTLP-receive -> S3-write
+  pipeline and needs no `LICENSE_DATA`. If the image refuses to boot without a
+  license, that surfaces in testing and the design is revisited.
+- **Automatic storage-profile registration / migrator re-run**: explicit
+  non-goal for v1; documented manual step instead.
+- **Multiple buckets per remote account**: supported by overriding `BucketName`
+  (keeping the required prefix) and deploying additional stack instances; the
+  default name encodes one bucket per remote account.

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -230,6 +230,19 @@ def build() -> Template:
             AllowedPattern=r"^/[A-Za-z0-9._/-]{1,1011}$",
         )
     )
+    additional_storage_profiles = t.add_parameter(
+        Parameter(
+            "AdditionalStorageProfilesYaml",
+            Type="String",
+            Default="",
+            Description=(
+                "Extra storage-profile YAML list items appended after the seeded "
+                "profile (e.g. cardinal-remote-ingest StorageProfileSnippet "
+                "outputs). Leave blank for none. Re-run the migrator after "
+                "changing this so it re-imports into configdb."
+            ),
+        )
+    )
     organization_id = t.add_parameter(
         Parameter(
             "OrganizationId",
@@ -287,6 +300,7 @@ def build() -> Template:
                 "parameters": [
                     "IngestBucketName",
                     "IngestBucketLifecycleDays",
+                    "AdditionalStorageProfilesYaml",
                 ],
             },
             {
@@ -315,6 +329,7 @@ def build() -> Template:
             "DBAllocatedStorage": "Storage (GiB)",
             "IngestBucketName": "Ingest bucket name (blank = default)",
             "IngestBucketLifecycleDays": "Ingest object retention (days)",
+            "AdditionalStorageProfilesYaml": "Additional storage-profile YAML (remote buckets)",
             "LicenseData": "License token (z64:...)",
             "OrganizationId": "Organization UUID",
             "InitialIngestApiKey": "Initial ingest API key (blank = none)",
@@ -381,7 +396,32 @@ def build() -> Template:
                                 )
                             },
                         },
-                    }
+                    },
+                    {
+                        # Cross-account remote ingest: cardinal-remote-ingest
+                        # stacks create same-account buckets (named
+                        # cardinal-remote-ingest-*) that notify this queue. Grant
+                        # by prefix so each new bucket works without editing this
+                        # infra-owned policy. Still gated to this account.
+                        "Effect": "Allow",
+                        "Principal": {"Service": "s3.amazonaws.com"},
+                        "Action": [
+                            "sqs:SendMessage",
+                            "sqs:GetQueueAttributes",
+                            "sqs:GetQueueUrl",
+                        ],
+                        "Resource": GetAtt(ingest_queue, "Arn"),
+                        "Condition": {
+                            "StringEquals": {
+                                "aws:SourceAccount": Ref("AWS::AccountId")
+                            },
+                            "ArnLike": {
+                                "aws:SourceArn": Sub(
+                                    "arn:${AWS::Partition}:s3:::cardinal-remote-ingest-*"
+                                )
+                            },
+                        },
+                    },
                 ],
             },
         )
@@ -584,9 +624,11 @@ def build() -> Template:
                     "  region: ${AWS::Region}\n"
                     "  bucket: ${BucketName}\n"
                     "  insecure_tls: false\n"
-                    "  use_path_style: true\n",
+                    "  use_path_style: true\n"
+                    "${Additional}",
                     OrgId=Ref(organization_id),
                     BucketName=bucket_name_value,
+                    Additional=Ref(additional_storage_profiles),
                 ),
                 Description="Cardinal storage profiles (YAML; operator-managed).",
                 Tags={

--- a/src/cardinal_cfn/defaults.py
+++ b/src/cardinal_cfn/defaults.py
@@ -8,6 +8,7 @@ import yaml
 _REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
 _DEFAULTS_PATH = os.path.join(_REPO_ROOT, "cardinal-defaults.yaml")
 _OTEL_CONFIG_PATH = os.path.join(_REPO_ROOT, "cardinal-otel-config.yaml")
+_REMOTE_OTEL_CONFIG_PATH = os.path.join(_REPO_ROOT, "cardinal-remote-otel-config.yaml")
 
 
 def load_defaults() -> dict:
@@ -35,4 +36,14 @@ def load_otel_default_config() -> str:
     override it via the OtelConfigYaml root parameter.
     """
     with open(_OTEL_CONFIG_PATH, "r") as f:
+        return f.read()
+
+
+def load_remote_otel_default_config() -> str:
+    """Return cardinal-remote-otel-config.yaml as a string.
+
+    Same shape as load_otel_default_config but with role_arn on each awss3
+    exporter so the remote collector assumes the cross-account writer role.
+    """
+    with open(_REMOTE_OTEL_CONFIG_PATH, "r") as f:
         return f.read()

--- a/src/cardinal_cfn/remote_collector.py
+++ b/src/cardinal_cfn/remote_collector.py
@@ -1,0 +1,295 @@
+"""cardinal-remote-collector.yaml: otel collector in a remote account.
+
+Standalone root template deployed via the AWS console in the second account.
+Receives OTLP, assumes the main-account writer role, and writes telemetry to the
+main-account remote-ingest bucket. The customer brings VpcId, PrivateSubnetsCsv,
+and ClusterArn; this stack creates the ALB, security groups, roles, log group,
+and the otel ECS service.
+
+Design: docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md
+"""
+
+from troposphere import (
+    GetAtt,
+    Output,
+    Parameter,
+    Ref,
+    Split,
+    Sub,
+    Tags,
+    Template,
+)
+from troposphere.ec2 import SecurityGroup, SecurityGroupRule
+from troposphere.ecs import (
+    AwsvpcConfiguration,
+    ContainerDefinition,
+    DeploymentCircuitBreaker,
+    DeploymentConfiguration,
+    Environment,
+    LoadBalancer as EcsLoadBalancer,
+    LogConfiguration,
+    NetworkConfiguration,
+    PortMapping,
+    Service,
+    TaskDefinition,
+)
+from troposphere.elasticloadbalancingv2 import (
+    Action,
+    Listener,
+    LoadBalancer,
+    Matcher,
+    TargetGroup,
+)
+from troposphere.iam import Policy, Role
+from troposphere.logs import LogGroup
+
+from cardinal_cfn.defaults import load_defaults, load_remote_otel_default_config
+from cardinal_cfn.images import add_image_override
+
+_SERVICE_KEY = "otel-grpc"
+_OTLP_HTTP_PORT = 4318
+_HEALTH_PORT = 13133
+
+
+def _tags(*, component: str) -> Tags:
+    return Tags(
+        Name=f"cardinal-remote-collector-{component}",
+        Project="cardinal",
+        Application="cardinal-lakerunner",
+        Component=component,
+        ManagedBy="cardinal-cfn",
+    )
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal remote collector: an ALB-fronted cardinalhq-otel-collector in a "
+        "remote account that assumes a main-account writer role to write telemetry "
+        "to the main-account remote-ingest bucket."
+    )
+
+    defaults = load_defaults()
+    otel_cfg = defaults["otel"]["otel-gateway"]
+
+    # Customer-supplied
+    t.add_parameter(Parameter("VpcId", Type="AWS::EC2::VPC::Id", Description="Customer VPC ID."))
+    t.add_parameter(Parameter(
+        "PrivateSubnetsCsv",
+        Type="String",
+        Description="Comma-separated private subnet IDs (>=2 AZs) for the internal ALB and the collector ENIs.",
+    ))
+    t.add_parameter(Parameter("ClusterArn", Type="String", Description="Customer ECS cluster ARN."))
+
+    # From the main-account cardinal-remote-ingest stack outputs
+    t.add_parameter(Parameter("WriterRoleArn", Type="String", Description="Writer role ARN to assume (remote-ingest WriterRoleArn output)."))
+    t.add_parameter(Parameter("BucketName", Type="String", Description="Main-account remote-ingest bucket name."))
+    t.add_parameter(Parameter(
+        "BucketRegion",
+        Type="String",
+        Description="Bucket region (the main/lakerunner region). NOT the remote account's region.",
+    ))
+    t.add_parameter(Parameter("OrgId", Type="String", Description="Lakerunner organization_id (match the remote-ingest OrgId)."))
+    t.add_parameter(Parameter("CollectorName", Type="String", Default="lakerunner", Description="Collector name (match the remote-ingest CollectorName)."))
+    t.add_parameter(Parameter(
+        "OtlpIngressCidr",
+        Type="String",
+        Default="10.0.0.0/8",
+        Description="Source CIDR allowed to reach the internal ALB on 4318. Narrow to your sender/VPC CIDR.",
+    ))
+
+    image_ref = add_image_override(
+        t,
+        name="OtelImage",
+        default=defaults["images"]["otel"],
+        description="Container image for the cardinalhq-otel-collector service.",
+    )
+    t.add_parameter(Parameter("OtelReplicas", Type="Number", Default=str(otel_cfg["replicas"]), Description="Desired replicas."))
+    t.add_parameter(Parameter("OtelCpu", Type="String", Default=str(otel_cfg["cpu"]), Description="Fargate CPU units."))
+    t.add_parameter(Parameter("OtelMemory", Type="String", Default=str(otel_cfg["memory_mib"]), Description="Fargate memory (MiB)."))
+
+    # ------------------------------------------------------------------ SGs
+    alb_sg = t.add_resource(SecurityGroup(
+        "AlbSecurityGroup",
+        GroupDescription="cardinal remote collector ALB; OTLP/HTTP 4318 ingress.",
+        VpcId=Ref("VpcId"),
+        SecurityGroupIngress=[SecurityGroupRule(
+            IpProtocol="tcp", FromPort=_OTLP_HTTP_PORT, ToPort=_OTLP_HTTP_PORT,
+            CidrIp=Ref("OtlpIngressCidr"),
+            Description="OTLP/HTTP from senders",
+        )],
+        SecurityGroupEgress=[SecurityGroupRule(
+            IpProtocol="-1", CidrIp="0.0.0.0/0", Description="All egress",
+        )],
+        Tags=_tags(component="alb-sg"),
+    ))
+    task_sg = t.add_resource(SecurityGroup(
+        "TaskSecurityGroup",
+        GroupDescription="cardinal remote collector tasks; 4318 from ALB only.",
+        VpcId=Ref("VpcId"),
+        SecurityGroupIngress=[SecurityGroupRule(
+            IpProtocol="tcp", FromPort=_OTLP_HTTP_PORT, ToPort=_OTLP_HTTP_PORT,
+            SourceSecurityGroupId=Ref(alb_sg),
+            Description="OTLP/HTTP from the ALB",
+        )],
+        SecurityGroupEgress=[SecurityGroupRule(
+            IpProtocol="-1", CidrIp="0.0.0.0/0", Description="All egress",
+        )],
+        Tags=_tags(component="task-sg"),
+    ))
+
+    # ------------------------------------------------------------------ ALB
+    alb = t.add_resource(LoadBalancer(
+        "Alb",
+        Scheme="internal",
+        Type="application",
+        Subnets=Split(",", Ref("PrivateSubnetsCsv")),
+        SecurityGroups=[Ref(alb_sg)],
+        Tags=_tags(component="alb"),
+    ))
+    target_group = t.add_resource(TargetGroup(
+        "OtelTargetGroup",
+        Port=_OTLP_HTTP_PORT,
+        Protocol="HTTP",
+        TargetType="ip",
+        VpcId=Ref("VpcId"),
+        HealthCheckPath="/",
+        HealthCheckPort=str(_HEALTH_PORT),
+        HealthCheckProtocol="HTTP",
+        Matcher=Matcher(HttpCode="200"),
+        Tags=_tags(component="otel-tg"),
+    ))
+    listener = t.add_resource(Listener(
+        "OtelHttpListener",
+        LoadBalancerArn=Ref(alb),
+        Port=_OTLP_HTTP_PORT,
+        Protocol="HTTP",
+        DefaultActions=[Action(Type="forward", TargetGroupArn=Ref(target_group))],
+    ))
+
+    # ------------------------------------------------------------------ Roles
+    exec_role = t.add_resource(Role(
+        "ExecutionRole",
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }],
+        },
+        ManagedPolicyArns=[
+            "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
+        ],
+        Tags=_tags(component="exec-role"),
+    ))
+    task_role = t.add_resource(Role(
+        "TaskRole",
+        RoleName=Sub("cardinal-remote-otel-${AWS::Region}"),
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "ecs-tasks.amazonaws.com"},
+                "Action": "sts:AssumeRole",
+            }],
+        },
+        Policies=[Policy(
+            PolicyName="cardinal-remote-otel-assume-writer",
+            PolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": "sts:AssumeRole",
+                    "Resource": Ref("WriterRoleArn"),
+                }],
+            },
+        )],
+        Tags=_tags(component="task-role"),
+    ))
+
+    log_group = t.add_resource(LogGroup(
+        "OtelLogGroup",
+        LogGroupName="/cardinal/otel-grpc",
+        RetentionInDays=14,
+        DeletionPolicy="Delete",
+        UpdateReplacePolicy="Delete",
+        Tags=_tags(component="otel-logs"),
+    ))
+
+    # ------------------------------------------------------------ Task def
+    env = [
+        Environment(Name="CHQ_COLLECTOR_CONFIG_YAML", Value=load_remote_otel_default_config()),
+        Environment(Name="LRDB_S3_BUCKET", Value=Ref("BucketName")),
+        Environment(Name="LRDB_S3_REGION", Value=Ref("BucketRegion")),
+        Environment(Name="LRDB_S3_ROLE_ARN", Value=Ref("WriterRoleArn")),
+        Environment(Name="ORG", Value=Ref("OrgId")),
+        Environment(Name="COLLECTOR", Value=Ref("CollectorName")),
+    ] + [Environment(Name=k, Value=str(v)) for k, v in (otel_cfg.get("environment") or {}).items()]
+
+    task_def = t.add_resource(TaskDefinition(
+        "OtelTaskDef",
+        RequiresCompatibilities=["FARGATE"],
+        NetworkMode="awsvpc",
+        Cpu=Ref("OtelCpu"),
+        Memory=Ref("OtelMemory"),
+        ExecutionRoleArn=GetAtt(exec_role, "Arn"),
+        TaskRoleArn=GetAtt(task_role, "Arn"),
+        ContainerDefinitions=[ContainerDefinition(
+            Name=_SERVICE_KEY,
+            Image=image_ref,
+            Essential=True,
+            Command=otel_cfg.get("command"),
+            Environment=env,
+            PortMappings=[PortMapping(ContainerPort=_OTLP_HTTP_PORT, Protocol="tcp")],
+            LogConfiguration=LogConfiguration(
+                LogDriver="awslogs",
+                Options={
+                    "awslogs-group": Ref(log_group),
+                    "awslogs-region": Ref("AWS::Region"),
+                    "awslogs-stream-prefix": _SERVICE_KEY,
+                },
+            ),
+        )],
+        Tags=_tags(component="otel-taskdef"),
+    ))
+
+    # ------------------------------------------------------------- Service
+    t.add_resource(Service(
+        "OtelService",
+        Cluster=Ref("ClusterArn"),
+        LaunchType="FARGATE",
+        DesiredCount=Ref("OtelReplicas"),
+        TaskDefinition=Ref(task_def),
+        DependsOn=[listener.title],
+        NetworkConfiguration=NetworkConfiguration(
+            AwsvpcConfiguration=AwsvpcConfiguration(
+                Subnets=Split(",", Ref("PrivateSubnetsCsv")),
+                SecurityGroups=[Ref(task_sg)],
+                AssignPublicIp="DISABLED",
+            )
+        ),
+        DeploymentConfiguration=DeploymentConfiguration(
+            MinimumHealthyPercent=50,
+            MaximumPercent=200,
+            DeploymentCircuitBreaker=DeploymentCircuitBreaker(Enable=True, Rollback=True),
+        ),
+        LoadBalancers=[EcsLoadBalancer(
+            ContainerName=_SERVICE_KEY,
+            ContainerPort=_OTLP_HTTP_PORT,
+            TargetGroupArn=Ref(target_group),
+        )],
+        Tags=_tags(component="otel-service"),
+    ))
+
+    t.add_output(Output("OtelAlbDnsName", Value=GetAtt(alb, "DNSName")))
+    t.add_output(Output(
+        "OtelExternalUrl",
+        Value=Sub(f"http://${{Dns}}:{_OTLP_HTTP_PORT}", Dns=GetAtt(alb, "DNSName")),
+    ))
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")

--- a/src/cardinal_cfn/remote_ingest.py
+++ b/src/cardinal_cfn/remote_ingest.py
@@ -1,0 +1,218 @@
+"""cardinal-remote-ingest.yaml: cross-account remote ingest bucket (main account).
+
+Standalone root template, one stack instance per remote bucket/account. Creates
+an S3 bucket in the main (lakerunner) account that a remote account's otel
+collector writes to (by assuming the WriterRole this stack creates), wires the
+bucket's s3:ObjectCreated notifications to the main SQS ingest queue, and emits
+a storage-profile snippet for the operator to register with lakerunner.
+
+Design: docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md
+"""
+
+from troposphere import (
+    Equals,
+    GetAtt,
+    If,
+    Output,
+    Parameter,
+    Ref,
+    Sub,
+    Tags,
+    Template,
+)
+from troposphere.iam import Policy, Role
+from troposphere.s3 import (
+    AbortIncompleteMultipartUpload,
+    Bucket,
+    LifecycleConfiguration,
+    LifecycleRule,
+    NotificationConfiguration,
+    OwnershipControls,
+    OwnershipControlsRule,
+    PublicAccessBlockConfiguration,
+    QueueConfigurations,
+)
+
+from cardinal_cfn.policies import apply_policy
+
+
+def _tags(*, component: str) -> Tags:
+    return Tags(
+        Name=Sub(f"cardinal-remote-ingest-{component}-${{RemoteAccountId}}"),
+        Project="cardinal",
+        Application="cardinal-lakerunner",
+        Component=component,
+        ManagedBy="cardinal-cfn",
+    )
+
+
+def build() -> Template:
+    t = Template()
+    t.set_description(
+        "Cardinal remote ingest: an S3 bucket in the main account that a remote "
+        "account's otel collector writes to (via an assumed writer role), wired "
+        "to the main lakerunner SQS ingest queue. One stack per remote bucket."
+    )
+
+    # RemoteAccountId, OrgId, CollectorName, and RemoteOtelRoleNamePattern are
+    # referenced by name inside Sub templates below (e.g. "${OrgId}"), so they
+    # are declared without binding a local.
+    t.add_parameter(Parameter(
+        "RemoteAccountId",
+        Type="String",
+        AllowedPattern=r"^[0-9]{12}$",
+        Description="The second (remote) AWS account ID whose otel collector writes to this bucket.",
+    ))
+    t.add_parameter(Parameter(
+        "OrgId",
+        Type="String",
+        MinLength=1,
+        Description="Lakerunner organization_id this bucket's telemetry is attributed to.",
+    ))
+    queue_arn = t.add_parameter(Parameter(
+        "QueueArn",
+        Type="String",
+        MinLength=1,
+        Description="ARN of the main lakerunner SQS ingest queue (infra IngestQueueArn output).",
+    ))
+    bucket_name = t.add_parameter(Parameter(
+        "BucketName",
+        Type="String",
+        Default="",
+        AllowedPattern=r"^$|^cardinal-remote-ingest-[a-z0-9.-]{1,40}$",
+        Description=(
+            "Bucket name. Blank = cardinal-remote-ingest-<RemoteAccountId>. Any "
+            "override MUST keep the cardinal-remote-ingest- prefix so the infra "
+            "queue policy grants the notification."
+        ),
+    ))
+    t.add_parameter(Parameter(
+        "CollectorName",
+        Type="String",
+        Default="lakerunner",
+        Description="Collector name for the storage profile and otel s3_prefix.",
+    ))
+    t.add_parameter(Parameter(
+        "RemoteOtelRoleNamePattern",
+        Type="String",
+        Default="cardinal-remote-otel-*",
+        Description="Remote task-role name pattern allowed to assume the writer role.",
+    ))
+    lifecycle_days = t.add_parameter(Parameter(
+        "IngestBucketLifecycleDays",
+        Type="Number",
+        Default=7,
+        MinValue=1,
+        Description="Days after which objects in the bucket expire (GC backstop).",
+    ))
+
+    t.add_condition("UseDefaultBucketName", Equals(Ref(bucket_name), ""))
+    bucket_name_value = If(
+        "UseDefaultBucketName",
+        Sub("cardinal-remote-ingest-${RemoteAccountId}"),
+        Ref(bucket_name),
+    )
+
+    writer_role = t.add_resource(Role(
+        "WriterRole",
+        AssumeRolePolicyDocument={
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"AWS": Sub("arn:${AWS::Partition}:iam::${RemoteAccountId}:root")},
+                "Action": "sts:AssumeRole",
+                "Condition": {
+                    "ArnLike": {
+                        "aws:PrincipalArn": Sub(
+                            "arn:${AWS::Partition}:iam::${RemoteAccountId}:role/${RemoteOtelRoleNamePattern}"
+                        )
+                    }
+                },
+            }],
+        },
+        Policies=[Policy(
+            PolicyName="cardinal-remote-writer",
+            PolicyDocument={
+                "Version": "2012-10-17",
+                "Statement": [{
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:PutObject",
+                        "s3:AbortMultipartUpload",
+                        "s3:ListMultipartUploadParts",
+                    ],
+                    "Resource": Sub(
+                        "arn:${AWS::Partition}:s3:::${BucketName}/*",
+                        BucketName=bucket_name_value,
+                    ),
+                }],
+            },
+        )],
+        Tags=_tags(component="writer-role"),
+    ))
+
+    bucket = t.add_resource(Bucket(
+        "RemoteIngestBucket",
+        BucketName=bucket_name_value,
+        OwnershipControls=OwnershipControls(
+            Rules=[OwnershipControlsRule(ObjectOwnership="BucketOwnerEnforced")]
+        ),
+        PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
+            BlockPublicAcls=True,
+            BlockPublicPolicy=True,
+            IgnorePublicAcls=True,
+            RestrictPublicBuckets=True,
+        ),
+        LifecycleConfiguration=LifecycleConfiguration(Rules=[
+            LifecycleRule(
+                Id="cardinal-remote-ingest-expire",
+                Status="Enabled",
+                Prefix="",
+                ExpirationInDays=Ref(lifecycle_days),
+                AbortIncompleteMultipartUpload=AbortIncompleteMultipartUpload(
+                    DaysAfterInitiation=1
+                ),
+            )
+        ]),
+        NotificationConfiguration=NotificationConfiguration(
+            QueueConfigurations=[
+                QueueConfigurations(Event="s3:ObjectCreated:*", Queue=Ref(queue_arn))
+            ]
+        ),
+        Tags=_tags(component="bucket"),
+    ))
+    apply_policy(bucket, "s3-ingest-bucket")
+
+    t.add_output(Output("BucketName", Description="Remote ingest bucket name.", Value=bucket_name_value))
+    t.add_output(Output("BucketArn", Description="Remote ingest bucket ARN.", Value=GetAtt(bucket, "Arn")))
+    t.add_output(Output(
+        "BucketRegion",
+        Description="Bucket region (the main/lakerunner region). Feed to the remote collector's BucketRegion.",
+        Value=Ref("AWS::Region"),
+    ))
+    t.add_output(Output(
+        "WriterRoleArn",
+        Description="Role ARN the remote collector assumes to write. Feed to the remote collector's WriterRoleArn.",
+        Value=GetAtt(writer_role, "Arn"),
+    ))
+    t.add_output(Output(
+        "StorageProfileSnippet",
+        Description="YAML list item to append to the infra stack's AdditionalStorageProfilesYaml, then re-run the migrator.",
+        Value=Sub(
+            "- organization_id: ${OrgId}\n"
+            "  instance_num: 1\n"
+            "  collector_name: ${CollectorName}\n"
+            "  cloud_provider: aws\n"
+            "  region: ${AWS::Region}\n"
+            "  bucket: ${BucketName}\n"
+            "  insecure_tls: false\n"
+            "  use_path_style: true\n",
+            BucketName=bucket_name_value,
+        ),
+    ))
+
+    return t
+
+
+if __name__ == "__main__":
+    print(build().to_yaml(), end="")

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -459,3 +459,43 @@ def test_no_resource_is_conditional(td):
     """Import mode was the only source of resource-level conditions."""
     for lid, res in td["Resources"].items():
         assert "Condition" not in res, f"{lid} should not be conditional"
+
+
+# ---------------------------------------------------------------------------
+# Cross-account remote ingest support
+# ---------------------------------------------------------------------------
+
+
+def test_queue_policy_allows_remote_ingest_buckets(td):
+    """A second statement lets cardinal-remote-ingest-* buckets in this account
+    notify the queue, without naming each bucket."""
+    qp = next(
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::SQS::QueuePolicy"
+    )
+    stmts = qp["Properties"]["PolicyDocument"]["Statement"]
+    arnlikes = [
+        s["Condition"]["ArnLike"]["aws:SourceArn"]
+        for s in stmts
+        if "Condition" in s and "ArnLike" in s["Condition"]
+    ]
+    assert {"Fn::Sub": "arn:${AWS::Partition}:s3:::cardinal-remote-ingest-*"} in arnlikes
+    for s in stmts:
+        assert s["Condition"]["StringEquals"]["aws:SourceAccount"] == {"Ref": "AWS::AccountId"}
+
+
+def test_additional_storage_profiles_parameter(td):
+    assert "AdditionalStorageProfilesYaml" in td["Parameters"]
+    assert td["Parameters"]["AdditionalStorageProfilesYaml"]["Default"] == ""
+
+
+def test_storage_profiles_value_appends_additional(td):
+    ssm_params = [
+        r for r in td["Resources"].values()
+        if r["Type"] == "AWS::SSM::Parameter"
+    ]
+    sp = next(
+        r for r in ssm_params
+        if "use_path_style" in json.dumps(r["Properties"]["Value"])
+    )
+    assert "AdditionalStorageProfilesYaml" in json.dumps(sp["Properties"]["Value"])

--- a/tests/templates/test_remote_collector.py
+++ b/tests/templates/test_remote_collector.py
@@ -1,0 +1,102 @@
+"""Tests for the cardinal-remote-collector standalone template (remote account)."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import remote_collector
+
+
+@pytest.fixture
+def td():
+    return json.loads(remote_collector.build().to_json())
+
+
+def test_customer_supplied_parameters(td):
+    for n in ("VpcId", "PrivateSubnetsCsv", "ClusterArn", "WriterRoleArn",
+              "BucketName", "BucketRegion", "OrgId", "CollectorName",
+              "OtlpIngressCidr"):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_no_license_secret_anywhere(td):
+    """The remote collector runs receive->S3 only; it needs no license."""
+    blob = json.dumps(td)
+    assert "LICENSE_DATA" not in blob
+    assert "LicenseSecretArn" not in td["Parameters"]
+    task_def = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    assert "Secrets" not in container or container["Secrets"] == []
+
+
+def test_creates_internal_alb_on_4318(td):
+    albs = [r for r in td["Resources"].values()
+            if r["Type"] == "AWS::ElasticLoadBalancingV2::LoadBalancer"]
+    assert len(albs) == 1
+    assert albs[0]["Properties"]["Scheme"] == "internal"
+    listeners = [r for r in td["Resources"].values()
+                 if r["Type"] == "AWS::ElasticLoadBalancingV2::Listener"]
+    assert len(listeners) == 1
+    assert listeners[0]["Properties"]["Port"] == 4318
+    assert listeners[0]["Properties"]["Protocol"] == "HTTP"
+
+
+def test_creates_two_security_groups(td):
+    sgs = [r for r in td["Resources"].values() if r["Type"] == "AWS::EC2::SecurityGroup"]
+    assert len(sgs) == 2
+
+
+def test_task_role_name_matches_writer_trust_pattern(td):
+    """Task role name must start with cardinal-remote-otel- so the main writer
+    role's trust condition matches it."""
+    roles = [r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role"]
+    task_roles = [
+        r for r in roles
+        if any(
+            "sts:AssumeRole" in json.dumps(p["PolicyDocument"])
+            and "WriterRoleArn" in json.dumps(p["PolicyDocument"])
+            for p in r["Properties"].get("Policies", [])
+        )
+    ]
+    assert len(task_roles) == 1
+    name = task_roles[0]["Properties"]["RoleName"]
+    assert name == {"Fn::Sub": "cardinal-remote-otel-${AWS::Region}"}
+
+
+def test_task_role_can_assume_writer_role(td):
+    roles = [r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role"]
+    found = False
+    for r in roles:
+        for p in r["Properties"].get("Policies", []):
+            doc = json.dumps(p["PolicyDocument"])
+            if "sts:AssumeRole" in doc and "WriterRoleArn" in doc:
+                found = True
+    assert found, "no role grants sts:AssumeRole on WriterRoleArn"
+
+
+def test_collector_env_uses_bucket_region_and_role(td):
+    task_def = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    env = {e["Name"]: e["Value"] for e in container["Environment"]}
+    assert env["LRDB_S3_BUCKET"] == {"Ref": "BucketName"}
+    assert env["LRDB_S3_REGION"] == {"Ref": "BucketRegion"}
+    assert env["LRDB_S3_ROLE_ARN"] == {"Ref": "WriterRoleArn"}
+    assert env["ORG"] == {"Ref": "OrgId"}
+    assert "CHQ_COLLECTOR_CONFIG_YAML" in env
+
+
+def test_service_disables_public_ip(td):
+    svc = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service")
+    awsvpc = svc["Properties"]["NetworkConfiguration"]["AwsvpcConfiguration"]
+    assert awsvpc["AssignPublicIp"] == "DISABLED"
+
+
+def test_no_cloud_map_registration(td):
+    """Self-telemetry discovery is a main-account concern; not here."""
+    assert not [r for r in td["Resources"].values()
+                if r["Type"] == "AWS::ServiceDiscovery::Service"]
+
+
+def test_outputs(td):
+    for n in ("OtelAlbDnsName", "OtelExternalUrl"):
+        assert n in td["Outputs"], f"missing output: {n}"

--- a/tests/templates/test_remote_ingest.py
+++ b/tests/templates/test_remote_ingest.py
@@ -1,0 +1,82 @@
+"""Tests for the cardinal-remote-ingest standalone template."""
+
+import json
+
+import pytest
+
+from cardinal_cfn import remote_ingest
+
+
+@pytest.fixture
+def td():
+    return json.loads(remote_ingest.build().to_json())
+
+
+def test_parameters(td):
+    for n in ("RemoteAccountId", "OrgId", "QueueArn", "BucketName",
+              "CollectorName", "RemoteOtelRoleNamePattern",
+              "IngestBucketLifecycleDays"):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+
+
+def test_remote_account_id_is_12_digits(td):
+    assert td["Parameters"]["RemoteAccountId"]["AllowedPattern"] == r"^[0-9]{12}$"
+
+
+def test_creates_one_bucket_retained_owner_enforced(td):
+    buckets = [r for r in td["Resources"].values() if r["Type"] == "AWS::S3::Bucket"]
+    assert len(buckets) == 1
+    b = buckets[0]
+    assert b["DeletionPolicy"] == "Retain"
+    assert b["UpdateReplacePolicy"] == "Retain"
+    rule = b["Properties"]["OwnershipControls"]["Rules"][0]
+    assert rule["ObjectOwnership"] == "BucketOwnerEnforced"
+    pab = b["Properties"]["PublicAccessBlockConfiguration"]
+    assert all(pab[k] is True for k in (
+        "BlockPublicAcls", "BlockPublicPolicy", "IgnorePublicAcls", "RestrictPublicBuckets"
+    ))
+
+
+def test_bucket_notifies_queue(td):
+    b = next(r for r in td["Resources"].values() if r["Type"] == "AWS::S3::Bucket")
+    qc = b["Properties"]["NotificationConfiguration"]["QueueConfigurations"][0]
+    assert qc["Event"] == "s3:ObjectCreated:*"
+    assert qc["Queue"] == {"Ref": "QueueArn"}
+
+
+def test_writer_role_trusts_remote_account_root_with_name_condition(td):
+    role = next(r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role")
+    stmt = role["Properties"]["AssumeRolePolicyDocument"]["Statement"][0]
+    assert stmt["Principal"]["AWS"] == {
+        "Fn::Sub": "arn:${AWS::Partition}:iam::${RemoteAccountId}:root"
+    }
+    assert stmt["Action"] == "sts:AssumeRole"
+    assert stmt["Condition"]["ArnLike"]["aws:PrincipalArn"] == {
+        "Fn::Sub": "arn:${AWS::Partition}:iam::${RemoteAccountId}:role/${RemoteOtelRoleNamePattern}"
+    }
+
+
+def test_writer_role_can_put_to_bucket(td):
+    role = next(r for r in td["Resources"].values() if r["Type"] == "AWS::IAM::Role")
+    doc = role["Properties"]["Policies"][0]["PolicyDocument"]
+    actions = doc["Statement"][0]["Action"]
+    assert "s3:PutObject" in actions
+    assert "s3:AbortMultipartUpload" in actions
+
+
+def test_outputs(td):
+    for n in ("BucketName", "BucketArn", "BucketRegion", "WriterRoleArn",
+              "StorageProfileSnippet"):
+        assert n in td["Outputs"], f"missing output: {n}"
+
+
+def test_storage_profile_snippet_uses_region_and_bucket(td):
+    snippet = json.dumps(td["Outputs"]["StorageProfileSnippet"]["Value"])
+    assert "organization_id: ${OrgId}" in snippet
+    assert "use_path_style: true" in snippet
+
+
+def test_no_ecs_or_sqs_resources(td):
+    """This template only owns the bucket + writer role; the queue lives in infra."""
+    for r in td["Resources"].values():
+        assert r["Type"] not in ("AWS::SQS::Queue", "AWS::ECS::Service")

--- a/tests/unit/test_remote_otel_config.py
+++ b/tests/unit/test_remote_otel_config.py
@@ -1,0 +1,27 @@
+"""The remote collector config must carry role_arn on every awss3 exporter."""
+
+import yaml
+
+from cardinal_cfn.defaults import load_remote_otel_default_config
+
+
+def test_loads_nonempty_string():
+    cfg = load_remote_otel_default_config()
+    assert isinstance(cfg, str) and cfg.strip()
+
+
+def test_every_awss3_exporter_has_role_arn():
+    cfg = yaml.safe_load(load_remote_otel_default_config())
+    exporters = cfg["exporters"]
+    awss3 = {k: v for k, v in exporters.items() if k.startswith("awss3")}
+    assert awss3, "expected at least one awss3 exporter"
+    for name, ex in awss3.items():
+        assert ex.get("role_arn") == "${env:LRDB_S3_ROLE_ARN}", (
+            f"{name} missing role_arn assume-role hook"
+        )
+
+
+def test_keeps_health_check_extension():
+    cfg = yaml.safe_load(load_remote_otel_default_config())
+    assert "health_check" in cfg["extensions"]
+    assert cfg["extensions"]["health_check"]["endpoint"] == "0.0.0.0:13133"


### PR DESCRIPTION
## What

Adds cross-account remote ingest: a second AWS account's otel collector can feed telemetry into an existing lakerunner install.

Approved design (brainstormed in-session): the ingest bucket lives in the **main** account so only the **write** crosses the account boundary, via STS assume-role. The notification (bucket -> SQS) and lakerunner's read are both same-account.

```
remote app --OTLP--> remote ALB :4318 --> remote otel collector
   --(assume main writer role)--> PutObject  main-account bucket
   --> S3 ObjectCreated --> main SQS --> lakerunner ingest (under the bucket's org)
```

## Changes

- **`cardinal-remote-ingest.yaml`** (new, main account, one per remote bucket): S3 bucket (`BucketOwnerEnforced`, `Retain`), cross-account writer IAM role (trusts the remote account root, narrowed by an `aws:PrincipalArn` name condition), bucket -> SQS notification, and a `StorageProfileSnippet` output.
- **`cardinal-remote-collector.yaml`** (new, second account, console-deployed): internal ALB on 4318, SGs, exec/task roles, log group, and the otel ECS service. Task role assumes the writer role; the `awss3` exporter config carries `role_arn: ${env:LRDB_S3_ROLE_ARN}`. Customer brings VPC, subnets, ECS cluster. No license needed.
- **`cardinal-infrastructure.py`**: second SQS queue-policy statement allowing same-account `cardinal-remote-ingest-*` buckets to notify; new `AdditionalStorageProfilesYaml` parameter appended to the storage-profiles SSM seed.
- **`cardinal-remote-otel-config.yaml`** (new) + `defaults.load_remote_otel_default_config()`.
- Build/lint wiring (`build.sh`, `Makefile`) and operator runbook (`docs/operations/remote-ingest.md`).

## Operator flow

Deploy `cardinal-remote-ingest` (main) -> deploy `cardinal-remote-collector` (second account, `CAPABILITY_NAMED_IAM`) -> append the `StorageProfileSnippet` to infra's `AdditionalStorageProfilesYaml` and re-run the migrator. Full runbook in `docs/operations/remote-ingest.md`.

## Testing

- `make test`: 478 passed, 5 skipped (pre-existing). New: `test_remote_ingest.py`, `test_remote_collector.py`, `test_remote_otel_config.py`, plus 3 infra assertions.
- `make build` / `cfn-lint`: clean (exit 0, no warnings) on both new templates.
- End-to-end cross-account verification needs a second AWS account; it is a documented manual procedure, not automated.

## Needs a human eye

- The `awss3` exporter `role_arn` field + `${env:...}` expansion are confirmed against the upstream README but the `cardinalhq-otel-collector` image is a custom build — worth confirming the field name against that image (template tests don't run the collector). If it differs, only `cardinal-remote-otel-config.yaml` changes.
- Remote collector task-role name is `cardinal-remote-otel-<region>` (one collector per region per account by default).

Design spec: `docs/superpowers/specs/2026-05-29-cross-account-remote-ingest-design.md`
Plan: `docs/superpowers/plans/2026-05-29-cross-account-remote-ingest.md`

Do not merge without review.
