### PR TITLE
chore: bump lakerunner v1.33.0 and maestro v1.46.4

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.32.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.46.1"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.33.0"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.46.4"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
## What

Bumps the two image pins in `cardinal-defaults.yaml` to the latest published `public.ecr.aws/cardinalhq.io` releases:

| Image | Old | New |
|---|---|---|
| lakerunner | v1.32.0 | **v1.33.0** |
| maestro | v1.46.1 | **v1.46.4** |

(The otel collector is already at the latest, v1.8.0, so it's unchanged.) Latest tags were determined by listing the public ECR registry via the Docker Registry v2 API.

The migrator runs from the same `LakerunnerImage`, so this also reruns DB migrations on deploy.

## Compatibility check

- **lakerunner v1.33.0** (released 2026-05-29): changes are `feat(worklane): split WORKLANE_MAX_AGE into per-action knobs` and an internal perf refactor (shared cluster catalog). Our templates reference neither `WORKLANE` nor `MAX_AGE`, and there are no port/SG/env-contract changes that the templates encode. No template changes needed.
- **maestro v1.46.4**: patch-level bump from v1.46.1 (same minor). I could not pull its release notes — `cardinalhq/maestro` did not resolve via `gh` (private or differently named) — but a patch bump should not change the config shape our `maestro.py` encodes.

## Verification

- `make build` (cfn-lint): clean.
- `make test`: 453 passed, 5 skipped (pre-existing).
- Generated templates embed `lakerunner:v1.33.0` and `maestro:v1.46.4`.

Do not merge without review.
