### PR TITLE
Run all ECS tasks on FARGATE_SPOT + arm64

### DIFF
--- a/src/cardinal_cfn/cardinal_cleanup.py
+++ b/src/cardinal_cfn/cardinal_cleanup.py
@@ -22,6 +22,7 @@ from troposphere.ecs import (
     ContainerDefinition,
     Environment,
     LogConfiguration,
+    RuntimePlatform,
     TaskDefinition,
 )
 from troposphere.logs import LogGroup
@@ -99,6 +100,10 @@ def build() -> Template:
         Family="cardinal-cleanup",
         RequiresCompatibilities=["FARGATE"],
         NetworkMode="awsvpc",
+        RuntimePlatform=RuntimePlatform(
+            CpuArchitecture="ARM64",
+            OperatingSystemFamily="LINUX",
+        ),
         Cpu="512",
         Memory="1024",
         TaskRoleArn=Ref(p_task_role),

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -35,6 +35,7 @@ from troposphere import (
 )
 from troposphere.ecs import (
     AwsvpcConfiguration,
+    CapacityProviderStrategyItem,
     ContainerDefinition,
     DeploymentCircuitBreaker,
     DeploymentConfiguration,
@@ -44,6 +45,7 @@ from troposphere.ecs import (
     MountPoint,
     NetworkConfiguration,
     PortMapping,
+    RuntimePlatform,
     Secret,
     Service,
     TaskDefinition,
@@ -672,6 +674,10 @@ def build() -> Template:
             "MaestroTaskDef",
             RequiresCompatibilities=["FARGATE"],
             NetworkMode="awsvpc",
+            RuntimePlatform=RuntimePlatform(
+                CpuArchitecture="ARM64",
+                OperatingSystemFamily="LINUX",
+            ),
             Cpu=Ref("MaestroTaskCpu"),
             Memory=Ref("MaestroTaskMemory"),
             ExecutionRoleArn=Ref("ExecutionRoleArn"),
@@ -741,7 +747,9 @@ def build() -> Template:
         Service(
             "MaestroService",
             Cluster=Ref("ClusterArn"),
-            LaunchType="FARGATE",
+            CapacityProviderStrategy=[
+                CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
+            ],
             DesiredCount=1,
             TaskDefinition=Ref(task_def),
             NetworkConfiguration=NetworkConfiguration(

--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -42,6 +42,7 @@ from troposphere.ecs import (
     ContainerDependency,
     Environment,
     LogConfiguration,
+    RuntimePlatform,
     Secret,
     TaskDefinition,
 )
@@ -337,6 +338,10 @@ def build() -> Template:
             Family="cardinal-migrator",
             NetworkMode="awsvpc",
             RequiresCompatibilities=["FARGATE"],
+            RuntimePlatform=RuntimePlatform(
+                CpuArchitecture="ARM64",
+                OperatingSystemFamily="LINUX",
+            ),
             Cpu="256",
             Memory="512",
             ExecutionRoleArn=Ref("ExecutionRoleArn"),

--- a/src/cardinal_cfn/children/otel.py
+++ b/src/cardinal_cfn/children/otel.py
@@ -40,6 +40,7 @@ from troposphere import (
 )
 from troposphere.ecs import (
     AwsvpcConfiguration,
+    CapacityProviderStrategyItem,
     DeploymentCircuitBreaker,
     DeploymentConfiguration,
     Environment,
@@ -375,7 +376,9 @@ def build() -> Template:
         Service(
             "OtelGrpcService",
             Cluster=Ref("ClusterArn"),
-            LaunchType="FARGATE",
+            CapacityProviderStrategy=[
+                CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
+            ],
             DesiredCount=Ref("OtelReplicas"),
             TaskDefinition=Ref(task_def),
             NetworkConfiguration=NetworkConfiguration(

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -7,6 +7,7 @@ The caller is responsible for adding it to a template.
 from troposphere import GetAtt, Ref, Split, Sub
 from troposphere.ecs import (
     AwsvpcConfiguration,
+    CapacityProviderStrategyItem,
     ContainerDefinition,
     DeploymentCircuitBreaker,
     DeploymentConfiguration,
@@ -15,6 +16,7 @@ from troposphere.ecs import (
     LogConfiguration,
     NetworkConfiguration,
     PortMapping,
+    RuntimePlatform,
     Service,
     ServiceRegistry,
     TaskDefinition,
@@ -191,6 +193,10 @@ def build_task_definition(
         _resource_title(service_key, "TaskDef"),
         RequiresCompatibilities=["FARGATE"],
         NetworkMode="awsvpc",
+        RuntimePlatform=RuntimePlatform(
+            CpuArchitecture="ARM64",
+            OperatingSystemFamily="LINUX",
+        ),
         Cpu=_coerce_size(cpu),
         Memory=_coerce_size(memory_mib),
         ExecutionRoleArn=Ref(execution_role_arn_param),
@@ -235,7 +241,9 @@ def build_ecs_service(
     """
     kwargs: dict = dict(
         Cluster=Ref(cluster_arn_param),
-        LaunchType="FARGATE",
+        CapacityProviderStrategy=[
+            CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
+        ],
         DesiredCount=desired_count,
         TaskDefinition=Ref(task_definition_ref),
         NetworkConfiguration=NetworkConfiguration(

--- a/src/cardinal_cfn/lrdev_baseinfra.py
+++ b/src/cardinal_cfn/lrdev_baseinfra.py
@@ -57,6 +57,10 @@ def build() -> Template:
     cluster = t.add_resource(
         Cluster(
             "EcsCluster",
+            # Associate both Fargate capacity providers so services can run on
+            # FARGATE_SPOT. A customer-supplied cluster must do the same for the
+            # lakerunner services (which request FARGATE_SPOT) to schedule.
+            CapacityProviders=["FARGATE", "FARGATE_SPOT"],
             ClusterSettings=[
                 ClusterSetting(Name="containerInsights", Value="enabled"),
             ],

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -195,7 +195,10 @@ def test_creates_ecs_service(template_dict):
 
 def test_service_runs_one_fargate_task_no_lb(template_dict):
     svc = _service(template_dict)["Properties"]
-    assert svc["LaunchType"] == "FARGATE"
+    assert "LaunchType" not in svc
+    assert svc["CapacityProviderStrategy"] == [
+        {"CapacityProvider": "FARGATE_SPOT", "Weight": 1}
+    ]
     assert svc["DesiredCount"] == 1
     assert svc["TaskDefinition"] == {"Ref": "MigratorTaskDef"}
     assert "LoadBalancers" not in svc

--- a/tests/unit/test_services_common.py
+++ b/tests/unit/test_services_common.py
@@ -83,6 +83,28 @@ def test_build_task_definition_accepts_ref_cpu_memory():
     assert rendered["Properties"]["Memory"] == {"Ref": "QueryApiMemory"}
 
 
+def test_build_task_definition_runs_on_arm64():
+    from troposphere import Ref
+    from troposphere.logs import LogGroup
+
+    lg = LogGroup("L", LogGroupName="x")
+    td = services_common.build_task_definition(
+        service_key="query-api",
+        image_ref="image",
+        cpu=1024,
+        memory_mib=2048,
+        execution_role_arn_param="ExecutionRoleArn",
+        task_role_arn=Ref("TaskRoleArn"),
+        environment=[],
+        log_group_ref=lg,
+    )
+    rendered = json.loads(json.dumps(td, default=lambda o: o.to_dict()))
+    assert rendered["Properties"]["RuntimePlatform"] == {
+        "CpuArchitecture": "ARM64",
+        "OperatingSystemFamily": "LINUX",
+    }
+
+
 def test_build_ecs_service_has_circuit_breaker_and_rolling_deploy():
     svc = services_common.build_ecs_service(
         service_key="query-api",
@@ -99,3 +121,21 @@ def test_build_ecs_service_has_circuit_breaker_and_rolling_deploy():
     assert dc.get("MaximumPercent") == 200
     assert dc.get("DeploymentCircuitBreaker", {}).get("Enable") is True
     assert dc.get("DeploymentCircuitBreaker", {}).get("Rollback") is True
+
+
+def test_build_ecs_service_uses_fargate_spot():
+    svc = services_common.build_ecs_service(
+        service_key="query-api",
+        cluster_arn_param="ClusterArn",
+        task_definition_ref="MyTaskDef",
+        desired_count=2,
+        subnets_csv_param="PrivateSubnetsCsv",
+        security_group_id_param="TaskSecurityGroupId",
+        container_name="query-api",
+    )
+    rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
+    props = rendered["Properties"]
+    assert "LaunchType" not in props
+    assert props["CapacityProviderStrategy"] == [
+        {"CapacityProvider": "FARGATE_SPOT", "Weight": 1}
+    ]


### PR DESCRIPTION
Switch every ECS task in the product (and the lrdev test cluster) from on-demand amd64 to FARGATE_SPOT on arm64.

## Changes
- All task definitions declare `RuntimePlatform: ARM64 / LINUX` (central `services_common.build_task_definition` + inline `migration`, `maestro`, `cardinal-cleanup`).
- All ECS services use `CapacityProviderStrategy: [FARGATE_SPOT weight 1]` instead of `LaunchType: FARGATE` (central `services_common.build_ecs_service` + inline `maestro`, `otel`).
- `lrdev-baseinfra` cluster associates both `FARGATE` and `FARGATE_SPOT` capacity providers (a customer-supplied cluster must do the same for the spot strategy to schedule).

## Notes
- Verified all six product images plus the cleanup `aws-cli` image are multi-arch with `linux/arm64`.
- The migrator/cleanup tasks remain idempotent, so a spot reclamation that recycles a task is a no-op (consistent with the existing migration design).

## Tests
- Added unit coverage asserting `RuntimePlatform=ARM64` and the `FARGATE_SPOT` strategy; updated the migration test that asserted `LaunchType`.
- `make test`: 459 passed, 1 skipped. `make build` cfn-lint clean.