### PR TITLE
Default RDS to db.r7g.large

### DIFF
--- a/docs/operations/infrastructure-stack-parameters.md
+++ b/docs/operations/infrastructure-stack-parameters.md
@@ -76,7 +76,7 @@ other than the defaults:
 | Parameter | Default |
 |---|---|
 | `DBEngineVersion` | `18.3` |
-| `DBInstanceClass` | `db.t3.medium` |
+| `DBInstanceClass` | `db.r7g.large` |
 | `DBAllocatedStorage` | `100` |
 | `IngestBucketLifecycleDays` | `7` |
 

--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -57,7 +57,7 @@ Optional sizing knobs:
 | Parameter | Default | Notes |
 |---|---|---|
 | `DBEngineVersion` | `18.3` | PostgreSQL engine version. |
-| `DBInstanceClass` | `db.t3.medium` | RDS instance class. |
+| `DBInstanceClass` | `db.r7g.large` | RDS instance class. |
 | `DBAllocatedStorage` | `100` | RDS GiB. |
 | `IngestBucketLifecycleDays` | `7` | Ingest object expiry. |
 

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -143,7 +143,7 @@ def build() -> Template:
         Parameter(
             "DBInstanceClass",
             Type="String",
-            Default="db.t3.medium",
+            Default="db.r7g.large",
             Description="RDS instance class.",
         )
     )

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -50,7 +50,7 @@ def test_db_engine_version_default_matches_test_account(td):
 
 
 def test_db_instance_class_default(td):
-    assert td["Parameters"]["DBInstanceClass"]["Default"] == "db.t3.medium"
+    assert td["Parameters"]["DBInstanceClass"]["Default"] == "db.r7g.large"
 
 
 def test_db_allocated_storage_default(td):


### PR DESCRIPTION
Bump the `cardinal-infrastructure` `DBInstanceClass` default from `db.t3.medium` to `db.r7g.large`: db.t3.medium (2 vCPU / 4 GiB, burstable) is too small for a prod-like cluster. db.r7g.large is Graviton (2 vCPU / 16 GiB), no burst-credit cliff, still plain RDS PostgreSQL (not Aurora).

- Updated generator default + template test + the two operations docs.
- `make test`: 459 passed. cfn-lint clean.