### PR TITLE
Default RDS Postgres to 18.4

### DIFF
--- a/docs/operations/infrastructure-stack-parameters.md
+++ b/docs/operations/infrastructure-stack-parameters.md
@@ -75,7 +75,7 @@ other than the defaults:
 
 | Parameter | Default |
 |---|---|
-| `DBEngineVersion` | `18.3` |
+| `DBEngineVersion` | `18.4` |
 | `DBInstanceClass` | `db.r7g.large` |
 | `DBAllocatedStorage` | `100` |
 | `IngestBucketLifecycleDays` | `7` |

--- a/docs/operations/install-infrastructure.md
+++ b/docs/operations/install-infrastructure.md
@@ -56,7 +56,7 @@ Optional sizing knobs:
 
 | Parameter | Default | Notes |
 |---|---|---|
-| `DBEngineVersion` | `18.3` | PostgreSQL engine version. |
+| `DBEngineVersion` | `18.4` | PostgreSQL engine version. |
 | `DBInstanceClass` | `db.r7g.large` | RDS instance class. |
 | `DBAllocatedStorage` | `100` | RDS GiB. |
 | `IngestBucketLifecycleDays` | `7` | Ingest object expiry. |

--- a/src/cardinal_cfn/cardinal_infrastructure.py
+++ b/src/cardinal_cfn/cardinal_infrastructure.py
@@ -135,7 +135,7 @@ def build() -> Template:
         Parameter(
             "DBEngineVersion",
             Type="String",
-            Default="18.3",
+            Default="18.4",
             Description="PostgreSQL engine version for the RDS instance.",
         )
     )

--- a/tests/templates/test_cardinal_infrastructure.py
+++ b/tests/templates/test_cardinal_infrastructure.py
@@ -45,8 +45,8 @@ def test_license_data_is_no_echo(td):
 
 
 def test_db_engine_version_default_matches_test_account(td):
-    """The script's test deploys land on Postgres 18.3 -- pin same default."""
-    assert td["Parameters"]["DBEngineVersion"]["Default"] == "18.3"
+    """The script's test deploys land on Postgres 18.4 -- pin same default."""
+    assert td["Parameters"]["DBEngineVersion"]["Default"] == "18.4"
 
 
 def test_db_instance_class_default(td):


### PR DESCRIPTION
Bump `DBEngineVersion` default 18.3 -> 18.4 (latest available on RDS in us-east-2; supports db.r7g.large). Minor version bump. Updated generator default + test + docs. make test: 459 passed.