### PR TITLE
Deploy scripts: env-var driven (required-first, REGION required)

### DIFF
--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -30,9 +30,10 @@ Each script collects all missing required variables up front, prints its usage
 Each Jenkins job runs one thin wrapper. The wrapper reads its friendly env vars,
 composes the published template URL from `TEMPLATE_BASE_URL` (default
 `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner`) and `VERSION`
-(e.g. `v0.0.70`), sets `TEMPLATE_URL`, `FROM_STACKS`, `PARAMS`, and `MAPS`, then
-`exec`s the generic driver `scripts/deploy-stack.sh` with the environment
-inherited.
+(e.g. `v0.0.70`), sets `TEMPLATE_URL`, `FROM_STACKS`, `PARAMS`, `FILE_PARAMS`,
+and `MAPS`, then invokes the generic driver `scripts/deploy-stack.sh` with the
+environment inherited. Most wrappers `exec` the driver; `lakerunner-services`
+runs it as a child so it can clean up an auto-generated cert temp dir on exit.
 
 ### deploy-stack.sh environment
 
@@ -43,6 +44,7 @@ inherited.
 | `REGION` | required | AWS region (never defaulted). |
 | `FROM_STACKS` | optional | Space-separated upstream stack names; an Output whose key equals a target parameter name supplies that parameter. |
 | `PARAMS` | optional | Newline-separated `Key=Value` overrides (highest precedence). Newline- (not semicolon-) separated so values like `PubsubSqsEnv` that contain semicolons are safe. |
+| `FILE_PARAMS` | optional | Newline-separated `ParamName=/path/to/file` entries. Each file's full content becomes that parameter's value, read via `jq --rawfile` so multi-line / PEM material is JSON-escaped correctly. Same explicit-override tier as `PARAMS`; if both set the same parameter, `PARAMS` wins. |
 | `MAPS` | optional | Newline-separated `TargetParam=SourceOutputKey` entries. |
 | `DEPLOYER_ROLE_ARN` | optional | Forwarded via `--role-arn` to `create-change-set`. |
 | `NO_EXECUTE` | optional | Non-empty: create and describe the change set, then stop. |
@@ -52,6 +54,7 @@ inherited.
 For each parameter in the target template (from `get-template-summary`):
 
 1. `PARAMS Key=Value` explicit override (highest precedence)
+1. `FILE_PARAMS ParamName=/path` file content (same tier as `PARAMS`; `PARAMS` wins on a clash)
 1. `MAPS TargetParam=SourceOutputKey` value of the named upstream Output
 1. matching `FROM_STACKS` Output (Output key == parameter name)
 1. on UPDATE only: `UsePreviousValue: true` (carry the current stack value)
@@ -226,6 +229,18 @@ so nested children load from the matching version prefix. `OTEL_REPLICAS`
 defaults to `0` here: the same-account satellite collector does ingest, so the
 lakerunner-tier collector is off by default.
 
+Certificate: if `CERTIFICATE_ARN` is set, it is passed through unchanged (a
+stable ARN, no churn). If it is empty and no PEM files are supplied, the wrapper
+auto-generates a self-signed internal cert **only on first create** and passes
+it via `FILE_PARAMS` (the `cert.yaml` child builds an `AWS::IAM::ServerCertificate`
+from it). Browsers will warn on a self-signed cert — fine for internal/test. On
+a re-run (the stack already exists, an UPDATE), the wrapper generates nothing and
+passes no cert params, so `deploy-stack.sh` resolves `CertificateBody`/
+`CertificatePrivateKey` to `UsePreviousValue` and the existing IAM
+ServerCertificate (and the ALB listener) is left untouched. Nothing is committed
+to the repo; the PEMs are generated per run into a temp dir that is removed on
+exit. Set `CERTIFICATE_ARN` to use a real cert.
+
 | Variable | Req/Opt | Default |
 |---|---|---|
 | `STACK_NAME` | required | — |
@@ -238,10 +253,10 @@ lakerunner-tier collector is off by default.
 | `CLUSTER_NAME` | required | ECS cluster name (no upstream output for it) |
 | `VPC_ID` | required | — |
 | `PRIVATE_SUBNETS` | required | comma-separated private subnet ids |
-| `CERTIFICATE_ARN` | optional | ACM/IAM cert ARN; Maestro HTTPS needs this **or** the three PEM files |
-| `CERTIFICATE_BODY_FILE` | optional | PEM cert body path |
-| `CERTIFICATE_PRIVATE_KEY_FILE` | optional | PEM private key path |
-| `CERTIFICATE_CHAIN_FILE` | optional | PEM chain path |
+| `CERTIFICATE_ARN` | optional | ACM/IAM cert ARN for the Maestro HTTPS listener. If unset, the wrapper auto-generates a self-signed internal cert **only on first create** (re-runs keep the existing cert — no churn). Set it to use a real cert. |
+| `CERTIFICATE_BODY_FILE` | optional | PEM cert body path (overrides auto-generation; passed via `FILE_PARAMS`) |
+| `CERTIFICATE_PRIVATE_KEY_FILE` | optional | PEM private key path (overrides auto-generation; passed via `FILE_PARAMS`) |
+| `CERTIFICATE_CHAIN_FILE` | optional | PEM chain path (passed via `FILE_PARAMS`) |
 | `DEX_ADMIN_EMAIL` | optional | template: `admin@cardinal.local` |
 | `DEX_ADMIN_PASSWORD_HASH` | optional | template: empty — **needed for Maestro UI login** |
 | `DEX_CLIENT_ID` | optional | template: `maestro-ui` |

--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -10,22 +10,50 @@ All six scripts are self-contained POSIX sh + AWS CLI v2 + jq (no Python at
 runtime). They create the stack if missing, otherwise update it in place, via a
 change set.
 
+## Pure environment-variable interface (no flags)
+
+Every script is driven entirely by environment variables in
+`SCREAMING_SNAKE_CASE`; none of them take command-line flags. AWS credentials
+are the only implicit input (from the usual AWS CLI sources); everything else is
+explicit.
+
+`REGION` is **required in every script** and is never defaulted — it does not
+fall back to `AWS_DEFAULT_REGION` or the profile region. A wrong region is hard
+for customers to undo, so it must be set explicitly or the script fails.
+
+Each script collects all missing required variables up front, prints its usage
+(with a `Required:` section above an `Optional:` section) to stderr, prints a
+`missing required: VAR1, VAR2` line, and exits `2` before deploying anything.
+
 ## Per-job model
 
-Each Jenkins job runs one thin wrapper. The wrapper composes the published
-template URL from `--template-base-url` (default
-`https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner`) and `--version`
-(e.g. `v0.0.70`), declares its upstream stack(s), and exposes only the add-in
-parameters relevant to that stack. Everything else is forwarded to the generic
-driver `scripts/deploy-stack.sh`.
+Each Jenkins job runs one thin wrapper. The wrapper reads its friendly env vars,
+composes the published template URL from `TEMPLATE_BASE_URL` (default
+`https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner`) and `VERSION`
+(e.g. `v0.0.70`), sets `TEMPLATE_URL`, `FROM_STACKS`, `PARAMS`, and `MAPS`, then
+`exec`s the generic driver `scripts/deploy-stack.sh` with the environment
+inherited.
+
+### deploy-stack.sh environment
+
+| Variable | Req/Opt | Meaning |
+|---|---|---|
+| `STACK_NAME` | required | Stack to create or upgrade. |
+| `TEMPLATE_URL` | required | S3 URL of the generated template. |
+| `REGION` | required | AWS region (never defaulted). |
+| `FROM_STACKS` | optional | Space-separated upstream stack names; an Output whose key equals a target parameter name supplies that parameter. |
+| `PARAMS` | optional | Newline-separated `Key=Value` overrides (highest precedence). Newline- (not semicolon-) separated so values like `PubsubSqsEnv` that contain semicolons are safe. |
+| `MAPS` | optional | Newline-separated `TargetParam=SourceOutputKey` entries. |
+| `DEPLOYER_ROLE_ARN` | optional | Forwarded via `--role-arn` to `create-change-set`. |
+| `NO_EXECUTE` | optional | Non-empty: create and describe the change set, then stop. |
 
 ### deploy-stack.sh resolution precedence
 
 For each parameter in the target template (from `get-template-summary`):
 
-1. `--param Key=Value` explicit override (highest precedence)
-1. `--map TargetParam=SourceOutputKey` value of the named upstream Output
-1. matching `--from-stack` Output (Output key == parameter name)
+1. `PARAMS Key=Value` explicit override (highest precedence)
+1. `MAPS TargetParam=SourceOutputKey` value of the named upstream Output
+1. matching `FROM_STACKS` Output (Output key == parameter name)
 1. on UPDATE only: `UsePreviousValue: true` (carry the current stack value)
 1. the template's `Default`
 1. otherwise FAIL, listing the unresolved required parameters
@@ -47,7 +75,7 @@ lakerunner-infra-base
 - `satellite-infra-base` parameter `LakerunnerPrincipal` is mapped from the
   `lakerunner-infra-base` Output `ProcessRoleArn` (the satellite trusts the
   lakerunner process role to assume into the satellite access role). The
-  wrapper adds `--map LakerunnerPrincipal=ProcessRoleArn`.
+  wrapper sets `MAPS="LakerunnerPrincipal=ProcessRoleArn"`.
 - `lakerunner-services` parameter `PubsubSqsEnv` is **computed**, not a single
   Output. The wrapper reads three Outputs from the `satellite-infra-base` stack
   and assembles:
@@ -56,85 +84,198 @@ lakerunner-infra-base
   SQS_QUEUE_URL=<RawQueueUrl>;SQS_REGION=<Region>;SQS_ROLE_ARN=<LakerunnerAccessRoleArn>
   ```
 
-  then passes it via `--param PubsubSqsEnv=...`.
+  then passes it as a `PARAMS` line.
 
-## Example invocations
+## Job 1: lakerunner-infra-base
 
-### Job 1: lakerunner-infra-base
+`scripts/deploy-lakerunner-infra-base.sh` — head of the chain, no upstream.
+
+| Variable | Req/Opt | Default |
+|---|---|---|
+| `STACK_NAME` | required | — |
+| `REGION` | required | — |
+| `VERSION` | required | — |
+| `VPC_ID` | required | — |
+| `CLUSTER_ARN` | required | — |
+| `LICENSE_DATA_FILE` | required | path to license JSON, read into the license secret |
+| `ALB_SCHEME` | optional | template: `internal` |
+| `ALB_ALLOWED_CIDR1` | optional | template: `10.0.0.0/8` |
+| `ALB_ALLOWED_CIDR2` | optional | template: `172.16.0.0/12` |
+| `ALB_ALLOWED_CIDR3` | optional | template: `192.168.0.0/16` |
+| `ORGANIZATION_ID` | optional | template default |
+| `INITIAL_INGEST_API_KEY` | optional | template: empty |
+| `COOKED_BUCKET_NAME` | optional | template: generated |
+| `LICENSE_SECRET_NAME` | optional | template: `cardinal-license` |
+| `ADMIN_KEY_SECRET_NAME` | optional | template: `cardinal-admin-key` |
+| `API_KEYS_PARAM_NAME` | optional | template: `/cardinal/api-keys` |
+| `STORAGE_PROFILES_PARAM_NAME` | optional | template: `/cardinal/storage-profiles` |
+| `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` |
+| `DEPLOYER_ROLE_ARN` | optional | unset |
+| `NO_EXECUTE` | optional | unset |
 
 ```sh
-scripts/deploy-lakerunner-infra-base.sh \
-    --stack-name cardinal-lakerunner-infra-base \
-    --region us-east-1 --version v0.0.70 \
-    --vpc-id vpc-0abc \
-    --cluster-arn arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
-    --license-data-file ./license.json \
-    --alb-allowed-cidr1 10.0.0.0/8
+STACK_NAME=cardinal-lakerunner-infra-base \
+REGION=us-east-1 \
+VERSION=v0.0.70 \
+VPC_ID=vpc-0abc \
+CLUSTER_ARN=arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
+LICENSE_DATA_FILE=./license.json \
+ALB_ALLOWED_CIDR1=10.0.0.0/8 \
+./scripts/deploy-lakerunner-infra-base.sh
 ```
 
-### Job 2: lakerunner-infra-rds
+## Job 2: lakerunner-infra-rds
+
+`scripts/deploy-lakerunner-infra-rds.sh` — pulls the five tier security-group
+ids from the infra-base stack via `FROM_STACKS`.
+
+| Variable | Req/Opt | Default |
+|---|---|---|
+| `STACK_NAME` | required | — |
+| `REGION` | required | — |
+| `VERSION` | required | — |
+| `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base stack name |
+| `VPC_ID` | required | — |
+| `PRIVATE_SUBNETS` | required | comma-separated private subnet ids |
+| `DB_ENGINE_VERSION` | optional | template: `18.4` |
+| `DB_INSTANCE_CLASS` | optional | template: `db.r7g.large` |
+| `DB_ALLOCATED_STORAGE` | optional | template: `100` |
+| `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` |
+| `DEPLOYER_ROLE_ARN` | optional | unset |
+| `NO_EXECUTE` | optional | unset |
 
 ```sh
-scripts/deploy-lakerunner-infra-rds.sh \
-    --stack-name cardinal-lakerunner-infra-rds \
-    --region us-east-1 --version v0.0.70 \
-    --infra-base-stack cardinal-lakerunner-infra-base \
-    --vpc-id vpc-0abc \
-    --private-subnets-csv subnet-1,subnet-2
+STACK_NAME=cardinal-lakerunner-infra-rds \
+REGION=us-east-1 \
+VERSION=v0.0.70 \
+INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
+VPC_ID=vpc-0abc \
+PRIVATE_SUBNETS=subnet-1,subnet-2 \
+./scripts/deploy-lakerunner-infra-rds.sh
 ```
 
-### Job 3: satellite-infra-base (per ingest account/region)
+## Job 3: satellite-infra-base (per ingest account/region)
+
+`scripts/deploy-satellite-infra-base.sh` — pulls infra-base Outputs and maps
+`LakerunnerPrincipal=ProcessRoleArn`.
+
+| Variable | Req/Opt | Default |
+|---|---|---|
+| `STACK_NAME` | required | — |
+| `REGION` | required | — |
+| `VERSION` | required | — |
+| `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base stack name |
+| `EXTERNAL_ID` | optional | template: empty |
+| `RAW_BUCKET_NAME` | optional | template: generated |
+| `RAW_BUCKET_LIFECYCLE_DAYS` | optional | template: `7` |
+| `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` |
+| `DEPLOYER_ROLE_ARN` | optional | unset |
+| `NO_EXECUTE` | optional | unset |
 
 ```sh
-scripts/deploy-satellite-infra-base.sh \
-    --stack-name cardinal-satellite-infra-base \
-    --region us-east-1 --version v0.0.70 \
-    --infra-base-stack cardinal-lakerunner-infra-base \
-    --external-id myExternalId
+STACK_NAME=cardinal-satellite-infra-base \
+REGION=us-east-1 \
+VERSION=v0.0.70 \
+INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
+EXTERNAL_ID=myExternalId \
+./scripts/deploy-satellite-infra-base.sh
 ```
 
-### Job 4: satellite-services
+## Job 4: satellite-services
 
-`OtelReplicas` defaults to `1`; the collector config must change before scaling
-past one replica.
+`scripts/deploy-satellite-services.sh` — `OTEL_REPLICAS` defaults to `1`; the
+collector config must change before scaling past one replica.
+
+| Variable | Req/Opt | Default |
+|---|---|---|
+| `STACK_NAME` | required | — |
+| `REGION` | required | — |
+| `VERSION` | required | — |
+| `SATELLITE_INFRA_BASE_STACK` | required | upstream satellite-infra-base (`RawBucketName`) |
+| `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base (`LicenseSecretArn`) |
+| `VPC_ID` | required | — |
+| `ALB_SUBNETS` | required | comma-separated subnets for the collector ALB |
+| `TASK_SUBNETS` | required | comma-separated subnets for the collector tasks |
+| `ECS_CLUSTER_ARN` | required | ECS cluster for the collector |
+| `ALB_SCHEME` | optional | `internal` |
+| `INGEST_SOURCE_CIDR` | optional | template: `10.0.0.0/8` |
+| `OTEL_REPLICAS` | optional | `1` (>1 needs a collector config change first) |
+| `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` |
+| `DEPLOYER_ROLE_ARN` | optional | unset |
+| `NO_EXECUTE` | optional | unset |
 
 ```sh
-scripts/deploy-satellite-services.sh \
-    --stack-name cardinal-satellite-services \
-    --region us-east-1 --version v0.0.70 \
-    --satellite-infra-base-stack cardinal-satellite-infra-base \
-    --infra-base-stack cardinal-lakerunner-infra-base \
-    --vpc-id vpc-0abc \
-    --alb-subnets-csv subnet-a,subnet-b \
-    --task-subnets-csv subnet-1,subnet-2 \
-    --ecs-cluster-arn arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
-    --ingest-source-cidr 10.0.0.0/8
+STACK_NAME=cardinal-satellite-services \
+REGION=us-east-1 \
+VERSION=v0.0.70 \
+SATELLITE_INFRA_BASE_STACK=cardinal-satellite-infra-base \
+INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
+VPC_ID=vpc-0abc \
+ALB_SUBNETS=subnet-a,subnet-b \
+TASK_SUBNETS=subnet-1,subnet-2 \
+ECS_CLUSTER_ARN=arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
+INGEST_SOURCE_CIDR=10.0.0.0/8 \
+./scripts/deploy-satellite-services.sh
 ```
 
-### Job 5: lakerunner-services
+## Job 5: lakerunner-services
 
-`OtelReplicas` defaults to `0` here: the same-account satellite collector does
-ingest, so the lakerunner-tier collector is off by default.
+`scripts/deploy-lakerunner-services.sh` — pulls infra-base + infra-rds Outputs,
+computes `PubsubSqsEnv` from the satellite stack, and forwards `TemplateBaseUrl`
+so nested children load from the matching version prefix. `OTEL_REPLICAS`
+defaults to `0` here: the same-account satellite collector does ingest, so the
+lakerunner-tier collector is off by default.
+
+| Variable | Req/Opt | Default |
+|---|---|---|
+| `STACK_NAME` | required | — |
+| `REGION` | required | — |
+| `VERSION` | required | — |
+| `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base |
+| `INFRA_RDS_STACK` | required | upstream lakerunner-infra-rds |
+| `SATELLITE_INFRA_BASE_STACK` | required | source of `RawQueueUrl`/`Region`/`LakerunnerAccessRoleArn` |
+| `CLUSTER_ARN` | required | ECS cluster ARN |
+| `CLUSTER_NAME` | required | ECS cluster name (no upstream output for it) |
+| `VPC_ID` | required | — |
+| `PRIVATE_SUBNETS` | required | comma-separated private subnet ids |
+| `CERTIFICATE_ARN` | optional | ACM/IAM cert ARN; Maestro HTTPS needs this **or** the three PEM files |
+| `CERTIFICATE_BODY_FILE` | optional | PEM cert body path |
+| `CERTIFICATE_PRIVATE_KEY_FILE` | optional | PEM private key path |
+| `CERTIFICATE_CHAIN_FILE` | optional | PEM chain path |
+| `DEX_ADMIN_EMAIL` | optional | template: `admin@cardinal.local` |
+| `DEX_ADMIN_PASSWORD_HASH` | optional | template: empty — **needed for Maestro UI login** |
+| `DEX_CLIENT_ID` | optional | template: `maestro-ui` |
+| `OIDC_SUPERADMIN_EMAILS` | optional | template: `admin@cardinal.local` |
+| `SERVICE_NAMESPACE_NAME` | optional | template: `cardinal.local` |
+| `PUBLIC_SUBNETS` | optional | template: empty |
+| `OTEL_REPLICAS` | optional | `0` |
+| `LAKERUNNER_IMAGE` `MAESTRO_IMAGE` `OTEL_IMAGE` `DEX_IMAGE` `DEX_INIT_IMAGE` `DB_INIT_IMAGE` | optional | template defaults |
+| `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` (also forwarded as `TemplateBaseUrl`) |
+| `DEPLOYER_ROLE_ARN` | optional | unset |
+| `NO_EXECUTE` | optional | unset |
 
 ```sh
-scripts/deploy-lakerunner-services.sh \
-    --stack-name cardinal-lakerunner-services \
-    --region us-east-1 --version v0.0.70 \
-    --infra-base-stack cardinal-lakerunner-infra-base \
-    --infra-rds-stack cardinal-lakerunner-infra-rds \
-    --satellite-infra-base-stack cardinal-satellite-infra-base \
-    --vpc-id vpc-0abc \
-    --cluster-arn arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
-    --cluster-name cardinal \
-    --private-subnets subnet-1,subnet-2 \
-    --dex-admin-password-hash '$2y$10$...'
+STACK_NAME=cardinal-lakerunner-services \
+REGION=us-east-1 \
+VERSION=v0.0.70 \
+INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
+INFRA_RDS_STACK=cardinal-lakerunner-infra-rds \
+SATELLITE_INFRA_BASE_STACK=cardinal-satellite-infra-base \
+CLUSTER_ARN=arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
+CLUSTER_NAME=cardinal \
+VPC_ID=vpc-0abc \
+PRIVATE_SUBNETS=subnet-1,subnet-2 \
+DEX_ADMIN_PASSWORD_HASH='$2y$10$...' \
+./scripts/deploy-lakerunner-services.sh
 ```
 
 ## Notes
 
-- `--no-execute` (any wrapper) creates and describes the change set, then
-  stops, leaving it in place for manual review.
-- `--deployer-role-arn ARN` is forwarded to `create-change-set`; CloudFormation
-  reuses that role during execution.
+- `NO_EXECUTE` (any wrapper, set to any non-empty value) creates and describes
+  the change set, then stops, leaving it in place for manual review.
+- `DEPLOYER_ROLE_ARN` is forwarded to `create-change-set`; CloudFormation reuses
+  that role during execution.
 - Re-running a wrapper is idempotent: an existing stack is updated, a no-op
   change set is detected and discarded.
+- A missing required variable fails fast: the script prints its usage and a
+  `missing required: ...` line to stderr and exits `2` before any AWS call.

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -6,7 +6,8 @@
 # that every downstream stack consumes.
 #
 # Thin wrapper over deploy-stack.sh: composes the published template URL from
-# --template-base-url + --version and forwards this stack's add-in parameters.
+# TEMPLATE_BASE_URL + VERSION, builds the PARAMS block, and execs deploy-stack.sh
+# with the environment inherited.  Pure environment-variable interface (no flags).
 
 set -eu
 
@@ -14,119 +15,101 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-base.yaml"
 
-stack_name=""
-region=""
-version=""
-template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
-deployer_role_arn=""
-no_execute=""
-
-vpc_id=""
-cluster_arn=""
-alb_scheme=""
-alb_cidr1=""
-alb_cidr2=""
-alb_cidr3=""
-organization_id=""
-initial_ingest_api_key=""
-license_data_file=""
-cooked_bucket_name=""
-license_secret_name=""
-admin_key_secret_name=""
-api_keys_param_name=""
-storage_profiles_param_name=""
-
 usage() {
-    cat <<'EOF'
-Usage: deploy-lakerunner-infra-base.sh --stack-name NAME --region REGION --version VER [options]
+    cat <<EOF
+deploy-lakerunner-infra-base.sh -- deploy the cardinal-lakerunner-infra-base stack.
+
+All inputs come from environment variables (no flags).
 
 Required:
-  --stack-name NAME           Stack to create/update.
-  --region REGION             AWS region.
-  --version VERSION           Published template tag, e.g. v0.0.70.
-  --vpc-id VPC                VPC for the security groups.
-  --cluster-arn ARN           Customer-supplied ECS cluster ARN.
-  --license-data-file PATH    Path to license JSON (seeds the license secret).
+  STACK_NAME           Stack to create/update.
+  REGION               AWS region (never defaulted; must be set explicitly).
+  VERSION              Published template tag, e.g. v0.0.70.
+  VPC_ID               VPC for the security groups.
+  CLUSTER_ARN          Customer-supplied ECS cluster ARN.
+  LICENSE_DATA_FILE    Path to license JSON (seeds the license secret).
 
-Add-ins (defaults in the template are fine if omitted):
-  --alb-scheme SCHEME         internet-facing | internal.
-  --alb-allowed-cidr1 CIDR    ALB ingress CIDR allowlist (up to three).
-  --alb-allowed-cidr2 CIDR
-  --alb-allowed-cidr3 CIDR
-  --organization-id UUID      Canonical org id seeded into config.
-  --initial-ingest-api-key K  Bootstrap ingest API key.
-  --cooked-bucket-name NAME
-  --license-secret-name NAME
-  --admin-key-secret-name NAME
-  --api-keys-param-name NAME
-  --storage-profiles-param-name NAME
-
-Common:
-  --template-base-url URL     Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
-  --deployer-role-arn ARN
-  --no-execute
+Optional (template defaults preserved when unset):
+  ALB_SCHEME                   internet-facing | internal (template default: internal).
+  ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
+  ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
+  ALB_ALLOWED_CIDR3            (template default 192.168.0.0/16).
+  ORGANIZATION_ID              Canonical org id seeded into config.
+  INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
+  COOKED_BUCKET_NAME           Explicit cooked bucket name.
+  LICENSE_SECRET_NAME          (template default cardinal-license).
+  ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
+  API_KEYS_PARAM_NAME          (template default /cardinal/api-keys).
+  STORAGE_PROFILES_PARAM_NAME  (template default /cardinal/storage-profiles).
+  TEMPLATE_BASE_URL            Default: $DEFAULT_TEMPLATE_BASE_URL
+  DEPLOYER_ROLE_ARN            Passed to create-change-set.
+  NO_EXECUTE                   Non-empty: change-set only, do not execute.
 EOF
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --stack-name) stack_name="$2"; shift 2 ;;
-        --region) region="$2"; shift 2 ;;
-        --version) version="$2"; shift 2 ;;
-        --template-base-url) template_base_url="$2"; shift 2 ;;
-        --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
-        --no-execute) no_execute="--no-execute"; shift ;;
-        --vpc-id) vpc_id="$2"; shift 2 ;;
-        --cluster-arn) cluster_arn="$2"; shift 2 ;;
-        --alb-scheme) alb_scheme="$2"; shift 2 ;;
-        --alb-allowed-cidr1) alb_cidr1="$2"; shift 2 ;;
-        --alb-allowed-cidr2) alb_cidr2="$2"; shift 2 ;;
-        --alb-allowed-cidr3) alb_cidr3="$2"; shift 2 ;;
-        --organization-id) organization_id="$2"; shift 2 ;;
-        --initial-ingest-api-key) initial_ingest_api_key="$2"; shift 2 ;;
-        --license-data-file) license_data_file="$2"; shift 2 ;;
-        --cooked-bucket-name) cooked_bucket_name="$2"; shift 2 ;;
-        --license-secret-name) license_secret_name="$2"; shift 2 ;;
-        --admin-key-secret-name) admin_key_secret_name="$2"; shift 2 ;;
-        --api-keys-param-name) api_keys_param_name="$2"; shift 2 ;;
-        --storage-profiles-param-name) storage_profiles_param_name="$2"; shift 2 ;;
-        -h|--help) usage; exit 0 ;;
-        *) echo "[deploy-lakerunner-infra-base] ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
-    esac
-done
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    "") : ;;
+    *) echo "[deploy-lakerunner-infra-base] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
+esac
 
-if [ -z "$stack_name" ] || [ -z "$region" ] || [ -z "$version" ]; then
+# --- Required-input check (collect all missing, fail once). -------------------
+missing=""
+[ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
+[ -z "${REGION:-}" ] && missing="$missing REGION"
+[ -z "${VERSION:-}" ] && missing="$missing VERSION"
+[ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
+[ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
+[ -z "${LICENSE_DATA_FILE:-}" ] && missing="$missing LICENSE_DATA_FILE"
+if [ -n "$missing" ]; then
     usage >&2
-    echo "[deploy-lakerunner-infra-base] ERROR: --stack-name, --region, and --version are required" >&2
+    echo "[deploy-lakerunner-infra-base] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
-template_url="$template_base_url/$version/$TEMPLATE_KEY"
-
-set -- --stack-name "$stack_name" --template-url "$template_url" --region "$region"
-[ -n "$deployer_role_arn" ] && set -- "$@" --deployer-role-arn "$deployer_role_arn"
-[ -n "$no_execute" ] && set -- "$@" "$no_execute"
-
-[ -n "$vpc_id" ] && set -- "$@" --param "VpcId=$vpc_id"
-[ -n "$cluster_arn" ] && set -- "$@" --param "ClusterArn=$cluster_arn"
-[ -n "$alb_scheme" ] && set -- "$@" --param "AlbScheme=$alb_scheme"
-[ -n "$alb_cidr1" ] && set -- "$@" --param "AlbAllowedCidr1=$alb_cidr1"
-[ -n "$alb_cidr2" ] && set -- "$@" --param "AlbAllowedCidr2=$alb_cidr2"
-[ -n "$alb_cidr3" ] && set -- "$@" --param "AlbAllowedCidr3=$alb_cidr3"
-[ -n "$organization_id" ] && set -- "$@" --param "OrganizationId=$organization_id"
-[ -n "$initial_ingest_api_key" ] && set -- "$@" --param "InitialIngestApiKey=$initial_ingest_api_key"
-[ -n "$cooked_bucket_name" ] && set -- "$@" --param "CookedBucketName=$cooked_bucket_name"
-[ -n "$license_secret_name" ] && set -- "$@" --param "LicenseSecretName=$license_secret_name"
-[ -n "$admin_key_secret_name" ] && set -- "$@" --param "AdminKeySecretName=$admin_key_secret_name"
-[ -n "$api_keys_param_name" ] && set -- "$@" --param "ApiKeysParamName=$api_keys_param_name"
-[ -n "$storage_profiles_param_name" ] && set -- "$@" --param "StorageProfilesParamName=$storage_profiles_param_name"
-
-if [ -n "$license_data_file" ]; then
-    if [ ! -r "$license_data_file" ]; then
-        echo "[deploy-lakerunner-infra-base] ERROR: cannot read --license-data-file: $license_data_file" >&2
-        exit 2
-    fi
-    set -- "$@" --param "LicenseData=$(cat "$license_data_file")"
+if [ ! -r "$LICENSE_DATA_FILE" ]; then
+    echo "[deploy-lakerunner-infra-base] ERROR: cannot read LICENSE_DATA_FILE: $LICENSE_DATA_FILE" >&2
+    exit 2
 fi
+license_data=$(cat "$LICENSE_DATA_FILE")
 
-exec "$SCRIPT_DIR/deploy-stack.sh" "$@"
+template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+
+# --- Compose the deploy-stack.sh environment. --------------------------------
+TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+
+# Build PARAMS (newline-separated Key=Value).  Required values always present;
+# optional ones added only when set so the template default applies otherwise.
+params="VpcId=$VPC_ID
+ClusterArn=$CLUSTER_ARN
+LicenseData=$license_data"
+[ -n "${ALB_SCHEME:-}" ] && params="$params
+AlbScheme=$ALB_SCHEME"
+[ -n "${ALB_ALLOWED_CIDR1:-}" ] && params="$params
+AlbAllowedCidr1=$ALB_ALLOWED_CIDR1"
+[ -n "${ALB_ALLOWED_CIDR2:-}" ] && params="$params
+AlbAllowedCidr2=$ALB_ALLOWED_CIDR2"
+[ -n "${ALB_ALLOWED_CIDR3:-}" ] && params="$params
+AlbAllowedCidr3=$ALB_ALLOWED_CIDR3"
+[ -n "${ORGANIZATION_ID:-}" ] && params="$params
+OrganizationId=$ORGANIZATION_ID"
+[ -n "${INITIAL_INGEST_API_KEY:-}" ] && params="$params
+InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
+[ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params
+CookedBucketName=$COOKED_BUCKET_NAME"
+[ -n "${LICENSE_SECRET_NAME:-}" ] && params="$params
+LicenseSecretName=$LICENSE_SECRET_NAME"
+[ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params
+AdminKeySecretName=$ADMIN_KEY_SECRET_NAME"
+[ -n "${API_KEYS_PARAM_NAME:-}" ] && params="$params
+ApiKeysParamName=$API_KEYS_PARAM_NAME"
+[ -n "${STORAGE_PROFILES_PARAM_NAME:-}" ] && params="$params
+StorageProfilesParamName=$STORAGE_PROFILES_PARAM_NAME"
+
+PARAMS="$params"
+FROM_STACKS=""
+MAPS=""
+
+export TEMPLATE_URL PARAMS FROM_STACKS MAPS
+
+exec "$SCRIPT_DIR/deploy-stack.sh"

--- a/scripts/deploy-lakerunner-infra-rds.sh
+++ b/scripts/deploy-lakerunner-infra-rds.sh
@@ -4,9 +4,9 @@
 # Upstream: the lakerunner-infra-base stack supplies the per-service security
 # group ids (Control/Maestro/Migration/Process/Query SecurityGroupId outputs),
 # which this stack uses to authorize DB ingress.  Those output names match this
-# template's parameter names, so a plain --from-stack pull wires them up.
+# template's parameter names, so a plain FROM_STACKS pull wires them up.
 #
-# Thin wrapper over deploy-stack.sh.
+# Thin wrapper over deploy-stack.sh.  Pure environment-variable interface.
 
 set -eu
 
@@ -14,82 +14,67 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-rds.yaml"
 
-stack_name=""
-region=""
-version=""
-template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
-deployer_role_arn=""
-no_execute=""
-
-infra_base_stack=""
-vpc_id=""
-private_subnets_csv=""
-db_engine_version=""
-db_instance_class=""
-db_allocated_storage=""
-
 usage() {
-    cat <<'EOF'
-Usage: deploy-lakerunner-infra-rds.sh --stack-name NAME --region REGION --version VER \
-           --infra-base-stack NAME [options]
+    cat <<EOF
+deploy-lakerunner-infra-rds.sh -- deploy the cardinal-lakerunner-infra-rds stack.
+
+All inputs come from environment variables (no flags).
 
 Required:
-  --stack-name NAME           Stack to create/update.
-  --region REGION             AWS region.
-  --version VERSION           Published template tag.
-  --infra-base-stack NAME     Upstream lakerunner-infra-base stack (supplies the
-                              service security-group ids).
-  --vpc-id VPC
-  --private-subnets-csv CSV   Comma-separated private subnet ids for the DB.
+  STACK_NAME         Stack to create/update.
+  REGION             AWS region (never defaulted; must be set explicitly).
+  VERSION            Published template tag.
+  INFRA_BASE_STACK   Upstream lakerunner-infra-base stack (supplies the service
+                     security-group ids via FROM_STACKS).
+  VPC_ID             VPC for the DB.
+  PRIVATE_SUBNETS    Comma-separated private subnet ids for the DB.
 
-Add-ins (template defaults are fine if omitted):
-  --db-engine-version VER
-  --db-instance-class CLASS
-  --db-allocated-storage GB
-
-Common:
-  --template-base-url URL     Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
-  --deployer-role-arn ARN
-  --no-execute
+Optional (template defaults preserved when unset):
+  DB_ENGINE_VERSION     (template default 18.4).
+  DB_INSTANCE_CLASS     (template default db.r7g.large).
+  DB_ALLOCATED_STORAGE  (template default 100).
+  TEMPLATE_BASE_URL     Default: $DEFAULT_TEMPLATE_BASE_URL
+  DEPLOYER_ROLE_ARN     Passed to create-change-set.
+  NO_EXECUTE            Non-empty: change-set only, do not execute.
 EOF
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --stack-name) stack_name="$2"; shift 2 ;;
-        --region) region="$2"; shift 2 ;;
-        --version) version="$2"; shift 2 ;;
-        --template-base-url) template_base_url="$2"; shift 2 ;;
-        --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
-        --no-execute) no_execute="--no-execute"; shift ;;
-        --infra-base-stack) infra_base_stack="$2"; shift 2 ;;
-        --vpc-id) vpc_id="$2"; shift 2 ;;
-        --private-subnets-csv) private_subnets_csv="$2"; shift 2 ;;
-        --db-engine-version) db_engine_version="$2"; shift 2 ;;
-        --db-instance-class) db_instance_class="$2"; shift 2 ;;
-        --db-allocated-storage) db_allocated_storage="$2"; shift 2 ;;
-        -h|--help) usage; exit 0 ;;
-        *) echo "[deploy-lakerunner-infra-rds] ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
-    esac
-done
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    "") : ;;
+    *) echo "[deploy-lakerunner-infra-rds] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
+esac
 
-if [ -z "$stack_name" ] || [ -z "$region" ] || [ -z "$version" ] || [ -z "$infra_base_stack" ]; then
+missing=""
+[ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
+[ -z "${REGION:-}" ] && missing="$missing REGION"
+[ -z "${VERSION:-}" ] && missing="$missing VERSION"
+[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+[ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
+[ -z "${PRIVATE_SUBNETS:-}" ] && missing="$missing PRIVATE_SUBNETS"
+if [ -n "$missing" ]; then
     usage >&2
-    echo "[deploy-lakerunner-infra-rds] ERROR: --stack-name, --region, --version, and --infra-base-stack are required" >&2
+    echo "[deploy-lakerunner-infra-rds] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
-template_url="$template_base_url/$version/$TEMPLATE_KEY"
+template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
-set -- --stack-name "$stack_name" --template-url "$template_url" --region "$region"
-set -- "$@" --from-stack "$infra_base_stack"
-[ -n "$deployer_role_arn" ] && set -- "$@" --deployer-role-arn "$deployer_role_arn"
-[ -n "$no_execute" ] && set -- "$@" "$no_execute"
+TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+FROM_STACKS="$INFRA_BASE_STACK"
+MAPS=""
 
-[ -n "$vpc_id" ] && set -- "$@" --param "VpcId=$vpc_id"
-[ -n "$private_subnets_csv" ] && set -- "$@" --param "PrivateSubnetsCsv=$private_subnets_csv"
-[ -n "$db_engine_version" ] && set -- "$@" --param "DBEngineVersion=$db_engine_version"
-[ -n "$db_instance_class" ] && set -- "$@" --param "DBInstanceClass=$db_instance_class"
-[ -n "$db_allocated_storage" ] && set -- "$@" --param "DBAllocatedStorage=$db_allocated_storage"
+params="VpcId=$VPC_ID
+PrivateSubnetsCsv=$PRIVATE_SUBNETS"
+[ -n "${DB_ENGINE_VERSION:-}" ] && params="$params
+DBEngineVersion=$DB_ENGINE_VERSION"
+[ -n "${DB_INSTANCE_CLASS:-}" ] && params="$params
+DBInstanceClass=$DB_INSTANCE_CLASS"
+[ -n "${DB_ALLOCATED_STORAGE:-}" ] && params="$params
+DBAllocatedStorage=$DB_ALLOCATED_STORAGE"
 
-exec "$SCRIPT_DIR/deploy-stack.sh" "$@"
+PARAMS="$params"
+
+export TEMPLATE_URL PARAMS FROM_STACKS MAPS
+
+exec "$SCRIPT_DIR/deploy-stack.sh"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -46,10 +46,14 @@ Required:
   PRIVATE_SUBNETS             Comma-separated private subnet ids.
 
 Optional (template defaults preserved when unset):
-  CERTIFICATE_ARN             ACM/IAM cert ARN.  Maestro HTTPS needs either this
-                              or the three PEM files below.
-  CERTIFICATE_BODY_FILE       PEM cert body (path).
-  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path).
+  CERTIFICATE_ARN             ACM/IAM cert ARN for the Maestro HTTPS listener.
+                              If unset, the script auto-generates a self-signed
+                              internal cert ON FIRST CREATE only (browsers will
+                              warn; fine for internal/test).  Re-runs (UPDATE)
+                              keep the existing cert untouched -- no churn.  Set
+                              CERTIFICATE_ARN to use a real cert.
+  CERTIFICATE_BODY_FILE       PEM cert body (path).  Overrides auto-generation.
+  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path).  Overrides auto-generation.
   CERTIFICATE_CHAIN_FILE      PEM chain (path).
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
   DEX_ADMIN_PASSWORD_HASH     bcrypt hash; REQUIRED for Maestro UI login even
@@ -74,15 +78,6 @@ case "${1:-}" in
     "") : ;;
     *) echo "[deploy-lakerunner-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
 esac
-
-read_file_or_die() {
-    p="$1"
-    if [ ! -r "$p" ]; then
-        echo "[deploy-lakerunner-services] ERROR: cannot read file: $p" >&2
-        exit 2
-    fi
-    cat "$p"
-}
 
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
@@ -161,14 +156,63 @@ DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params
 DbInitImage=$DB_INIT_IMAGE"
 
-[ -n "${CERTIFICATE_ARN:-}" ] && params="$params
+# --- Certificate handling. ---------------------------------------------------
+# Cert PEM material is passed via FILE_PARAMS (multi-line safe), never inlined
+# into the newline-delimited PARAMS string.
+#
+# Create-only auto-generation: the cert.yaml child builds an AWS::IAM::Server-
+# Certificate from CertificateBody/CertificatePrivateKey when CertificateArn is
+# empty.  A fresh self-signed PEM on every re-run would replace that cert and
+# churn the ALB listener, so we generate it ONLY on first create:
+#   - CERTIFICATE_ARN set            -> pass it (stable ARN, no churn).
+#   - empty + PEM files supplied     -> pass the supplied PEMs.
+#   - empty + stack absent (CREATE)  -> generate a self-signed cert, pass it.
+#   - empty + stack present (UPDATE) -> pass nothing; deploy-stack.sh resolves
+#     CertificateBody/CertificatePrivateKey to UsePreviousValue, keeping the
+#     existing IAM ServerCertificate untouched.
+file_params=""
+cert_dir=""
+
+cleanup_cert() {
+    [ -n "$cert_dir" ] && [ -d "$cert_dir" ] && rm -rf "$cert_dir"
+}
+trap cleanup_cert EXIT INT TERM HUP
+
+if [ -n "${CERTIFICATE_ARN:-}" ]; then
+    params="$params
 CertificateArn=$CERTIFICATE_ARN"
-[ -n "${CERTIFICATE_BODY_FILE:-}" ] && params="$params
-CertificateBody=$(read_file_or_die "$CERTIFICATE_BODY_FILE")"
-[ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ] && params="$params
-CertificatePrivateKey=$(read_file_or_die "$CERTIFICATE_PRIVATE_KEY_FILE")"
-[ -n "${CERTIFICATE_CHAIN_FILE:-}" ] && params="$params
-CertificateChain=$(read_file_or_die "$CERTIFICATE_CHAIN_FILE")"
+elif [ -n "${CERTIFICATE_BODY_FILE:-}" ] || [ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ]; then
+    [ -r "${CERTIFICATE_BODY_FILE:-}" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_BODY_FILE: ${CERTIFICATE_BODY_FILE:-}" >&2; exit 2; }
+    [ -r "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_PRIVATE_KEY_FILE: ${CERTIFICATE_PRIVATE_KEY_FILE:-}" >&2; exit 2; }
+    file_params="CertificateBody=$CERTIFICATE_BODY_FILE
+CertificatePrivateKey=$CERTIFICATE_PRIVATE_KEY_FILE"
+    if [ -n "${CERTIFICATE_CHAIN_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_CHAIN_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_CHAIN_FILE: $CERTIFICATE_CHAIN_FILE" >&2; exit 2; }
+        file_params="$file_params
+CertificateChain=$CERTIFICATE_CHAIN_FILE"
+    fi
+else
+    # No ARN, no PEM files.  Generate only on first create (stack absent).
+    if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
+        echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
+    else
+        if ! command -v openssl >/dev/null 2>&1; then
+            echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_*_FILE" >&2
+            exit 2
+        fi
+        echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
+        cert_dir=$(mktemp -d)
+        if ! openssl req -x509 -newkey rsa:2048 -nodes \
+                -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
+                -days 825 -subj "/CN=cardinal.test" \
+                -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
+            echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
+            exit 1
+        fi
+        file_params="CertificateBody=$cert_dir/cert.pem
+CertificatePrivateKey=$cert_dir/key.pem"
+    fi
+fi
 
 [ -n "${DEX_ADMIN_EMAIL:-}" ] && params="$params
 DexAdminEmail=$DEX_ADMIN_EMAIL"
@@ -180,7 +224,12 @@ DexClientId=$DEX_CLIENT_ID"
 OidcSuperadminEmails=$OIDC_SUPERADMIN_EMAILS"
 
 PARAMS="$params"
+FILE_PARAMS="$file_params"
 
-export TEMPLATE_URL PARAMS FROM_STACKS MAPS
+export TEMPLATE_URL PARAMS FILE_PARAMS FROM_STACKS MAPS
 
-exec "$SCRIPT_DIR/deploy-stack.sh"
+# Not exec: deploy-stack.sh must read the generated cert PEMs before the
+# cleanup_cert EXIT trap removes the temp dir, so run it as a child and forward
+# its exit code.  (When no cert was generated, cert_dir is empty and the trap
+# is a no-op.)
+"$SCRIPT_DIR/deploy-stack.sh"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -6,19 +6,19 @@
 #   - lakerunner-infra-base : roles, security groups, secrets, SSM param names.
 #   - lakerunner-infra-rds  : Db{Endpoint,MasterSecretArn,Name,Port}.
 # All of those output names match the template's parameter names, so plain
-# --from-stack pulls wire them up.
+# FROM_STACKS pulls wire them up.
 #
 # Special case: PubsubSqsEnv is COMPUTED here.  It is not a single upstream
 # output -- we read three outputs from the satellite-infra-base stack and
 # assemble the env string the pubsub-sqs container expects:
 #   SQS_QUEUE_URL=<RawQueueUrl>;SQS_REGION=<Region>;SQS_ROLE_ARN=<LakerunnerAccessRoleArn>
-# then pass it via --param PubsubSqsEnv=... (highest precedence).
+# then pass it via a PARAMS line (highest precedence).
 #
-# OtelReplicas defaults to 0 here: in the satellite topology the same-account
+# OTEL_REPLICAS defaults to 0 here: in the satellite topology the same-account
 # satellite collector performs ingest, so the lakerunner-tier otel collector is
 # off by default.
 #
-# Thin wrapper over deploy-stack.sh.
+# Thin wrapper over deploy-stack.sh.  Pure environment-variable interface.
 
 set -eu
 
@@ -26,90 +26,54 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-services.yaml"
 
-stack_name=""
-region=""
-version=""
-template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
-deployer_role_arn=""
-no_execute=""
-
-infra_base_stack=""
-infra_rds_stack=""
-satellite_infra_base_stack=""
-
-vpc_id=""
-cluster_arn=""
-cluster_name=""
-private_subnets=""
-public_subnets=""
-service_namespace_name=""
-otel_replicas="0"   # default: lakerunner-tier collector off; satellite ingests
-
-# Images.
-lakerunner_image=""
-maestro_image=""
-otel_image=""
-dex_image=""
-dex_init_image=""
-db_init_image=""
-
-# Cert (ACM ARN, or PEM material).
-certificate_arn=""
-certificate_body_file=""
-certificate_private_key_file=""
-certificate_chain_file=""
-
-# Dex / OIDC.
-dex_admin_email=""
-dex_admin_password_hash=""
-dex_client_id=""
-oidc_superadmin_emails=""
-
 usage() {
-    cat <<'EOF'
-Usage: deploy-lakerunner-services.sh --stack-name NAME --region REGION --version VER \
-           --infra-base-stack NAME --infra-rds-stack NAME \
-           --satellite-infra-base-stack NAME [options]
+    cat <<EOF
+deploy-lakerunner-services.sh -- deploy the cardinal-lakerunner-services stack.
+
+All inputs come from environment variables (no flags).
 
 Required:
-  --stack-name NAME                  Stack to create/update.
-  --region REGION                    AWS region.
-  --version VERSION                  Published template tag.
-  --infra-base-stack NAME            Upstream lakerunner-infra-base.
-  --infra-rds-stack NAME             Upstream lakerunner-infra-rds.
-  --satellite-infra-base-stack NAME  Source of RawQueueUrl/Region/
-                                     LakerunnerAccessRoleArn for the computed
-                                     PubsubSqsEnv.
+  STACK_NAME                  Stack to create/update.
+  REGION                      AWS region (never defaulted; must be set explicitly).
+  VERSION                     Published template tag.
+  INFRA_BASE_STACK            Upstream lakerunner-infra-base.
+  INFRA_RDS_STACK             Upstream lakerunner-infra-rds.
+  SATELLITE_INFRA_BASE_STACK  Source of RawQueueUrl/Region/LakerunnerAccessRoleArn
+                              for the computed PubsubSqsEnv.
+  CLUSTER_ARN                 ECS cluster ARN.
+  CLUSTER_NAME                ECS cluster name (no upstream output for it).
+  VPC_ID                      VPC for the services.
+  PRIVATE_SUBNETS             Comma-separated private subnet ids.
 
-Networking / cluster add-ins:
-  --vpc-id VPC
-  --cluster-arn ARN
-  --cluster-name NAME
-  --private-subnets CSV
-  --public-subnets CSV
-  --service-namespace-name NAME
-  --otel-replicas N                  Default 0 (satellite collector ingests).
-
-Images:
-  --lakerunner-image REF             --maestro-image REF    --otel-image REF
-  --dex-image REF                    --dex-init-image REF   --db-init-image REF
-
-Cert (ACM ARN or PEM material):
-  --certificate-arn ARN
-  --certificate-body-file PATH       --certificate-private-key-file PATH
-  --certificate-chain-file PATH
-
-Dex / OIDC:
-  --dex-admin-email EMAIL            --dex-admin-password-hash HASH
-  --dex-client-id ID                 --oidc-superadmin-emails CSV
-
-Common:
-  --template-base-url URL            Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
-                                     Also forwarded as the TemplateBaseUrl param.
-  --deployer-role-arn ARN
-  --no-execute
+Optional (template defaults preserved when unset):
+  CERTIFICATE_ARN             ACM/IAM cert ARN.  Maestro HTTPS needs either this
+                              or the three PEM files below.
+  CERTIFICATE_BODY_FILE       PEM cert body (path).
+  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path).
+  CERTIFICATE_CHAIN_FILE      PEM chain (path).
+  DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
+  DEX_ADMIN_PASSWORD_HASH     bcrypt hash; REQUIRED for Maestro UI login even
+                              though the template defaults it to ''.
+  DEX_CLIENT_ID               (template default maestro-ui).
+  OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
+  SERVICE_NAMESPACE_NAME      Cloud Map namespace (template default cardinal.local).
+  PUBLIC_SUBNETS              Comma-separated public subnet ids (template default '').
+  OTEL_REPLICAS               lakerunner-tier collector replicas (default 0).
+  LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
+  DB_INIT_IMAGE               Image overrides (template defaults otherwise).
+  TEMPLATE_BASE_URL           Default: $DEFAULT_TEMPLATE_BASE_URL.  Also
+                              forwarded as the TemplateBaseUrl param (nested
+                              children load from the matching prefix).
+  DEPLOYER_ROLE_ARN           Passed to create-change-set.
+  NO_EXECUTE                  Non-empty: change-set only, do not execute.
 EOF
 }
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    "") : ;;
+    *) echo "[deploy-lakerunner-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
+esac
 
 read_file_or_die() {
     p="$1"
@@ -120,48 +84,20 @@ read_file_or_die() {
     cat "$p"
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --stack-name) stack_name="$2"; shift 2 ;;
-        --region) region="$2"; shift 2 ;;
-        --version) version="$2"; shift 2 ;;
-        --template-base-url) template_base_url="$2"; shift 2 ;;
-        --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
-        --no-execute) no_execute="--no-execute"; shift ;;
-        --infra-base-stack) infra_base_stack="$2"; shift 2 ;;
-        --infra-rds-stack) infra_rds_stack="$2"; shift 2 ;;
-        --satellite-infra-base-stack) satellite_infra_base_stack="$2"; shift 2 ;;
-        --vpc-id) vpc_id="$2"; shift 2 ;;
-        --cluster-arn) cluster_arn="$2"; shift 2 ;;
-        --cluster-name) cluster_name="$2"; shift 2 ;;
-        --private-subnets) private_subnets="$2"; shift 2 ;;
-        --public-subnets) public_subnets="$2"; shift 2 ;;
-        --service-namespace-name) service_namespace_name="$2"; shift 2 ;;
-        --otel-replicas) otel_replicas="$2"; shift 2 ;;
-        --lakerunner-image) lakerunner_image="$2"; shift 2 ;;
-        --maestro-image) maestro_image="$2"; shift 2 ;;
-        --otel-image) otel_image="$2"; shift 2 ;;
-        --dex-image) dex_image="$2"; shift 2 ;;
-        --dex-init-image) dex_init_image="$2"; shift 2 ;;
-        --db-init-image) db_init_image="$2"; shift 2 ;;
-        --certificate-arn) certificate_arn="$2"; shift 2 ;;
-        --certificate-body-file) certificate_body_file="$2"; shift 2 ;;
-        --certificate-private-key-file) certificate_private_key_file="$2"; shift 2 ;;
-        --certificate-chain-file) certificate_chain_file="$2"; shift 2 ;;
-        --dex-admin-email) dex_admin_email="$2"; shift 2 ;;
-        --dex-admin-password-hash) dex_admin_password_hash="$2"; shift 2 ;;
-        --dex-client-id) dex_client_id="$2"; shift 2 ;;
-        --oidc-superadmin-emails) oidc_superadmin_emails="$2"; shift 2 ;;
-        -h|--help) usage; exit 0 ;;
-        *) echo "[deploy-lakerunner-services] ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
-    esac
-done
-
-if [ -z "$stack_name" ] || [ -z "$region" ] || [ -z "$version" ] \
-    || [ -z "$infra_base_stack" ] || [ -z "$infra_rds_stack" ] \
-    || [ -z "$satellite_infra_base_stack" ]; then
+missing=""
+[ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
+[ -z "${REGION:-}" ] && missing="$missing REGION"
+[ -z "${VERSION:-}" ] && missing="$missing VERSION"
+[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+[ -z "${INFRA_RDS_STACK:-}" ] && missing="$missing INFRA_RDS_STACK"
+[ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
+[ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
+[ -z "${CLUSTER_NAME:-}" ] && missing="$missing CLUSTER_NAME"
+[ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
+[ -z "${PRIVATE_SUBNETS:-}" ] && missing="$missing PRIVATE_SUBNETS"
+if [ -n "$missing" ]; then
     usage >&2
-    echo "[deploy-lakerunner-services] ERROR: --stack-name, --region, --version, --infra-base-stack, --infra-rds-stack, and --satellite-infra-base-stack are required" >&2
+    echo "[deploy-lakerunner-services] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
@@ -170,12 +106,15 @@ if ! command -v aws >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
     exit 2
 fi
 
-template_url="$template_base_url/$version/$TEMPLATE_KEY"
+template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+otel_replicas="${OTEL_REPLICAS:-0}"
+
+TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 
 # --- Compute PubsubSqsEnv from the satellite-infra-base stack outputs. -------
 sat_outputs=$(aws cloudformation describe-stacks \
-    --stack-name "$satellite_infra_base_stack" \
-    --region "$region" \
+    --stack-name "$SATELLITE_INFRA_BASE_STACK" \
+    --region "$REGION" \
     --query 'Stacks[0].Outputs' \
     --output json)
 
@@ -184,47 +123,64 @@ sqs_region=$(printf '%s' "$sat_outputs" | jq -r '(.[] | select(.OutputKey == "Re
 role_arn=$(printf '%s' "$sat_outputs" | jq -r '(.[] | select(.OutputKey == "LakerunnerAccessRoleArn") | .OutputValue) // ""')
 
 if [ -z "$queue_url" ] || [ -z "$sqs_region" ] || [ -z "$role_arn" ]; then
-    echo "[deploy-lakerunner-services] ERROR: satellite-infra-base stack '$satellite_infra_base_stack' is missing one of RawQueueUrl/Region/LakerunnerAccessRoleArn outputs" >&2
+    echo "[deploy-lakerunner-services] ERROR: satellite-infra-base stack '$SATELLITE_INFRA_BASE_STACK' is missing one of RawQueueUrl/Region/LakerunnerAccessRoleArn outputs" >&2
     exit 2
 fi
 
 pubsub_sqs_env="SQS_QUEUE_URL=$queue_url;SQS_REGION=$sqs_region;SQS_ROLE_ARN=$role_arn"
 
-# --- Assemble deploy-stack.sh invocation. ------------------------------------
-set -- --stack-name "$stack_name" --template-url "$template_url" --region "$region"
-set -- "$@" --from-stack "$infra_base_stack"
-set -- "$@" --from-stack "$infra_rds_stack"
-[ -n "$deployer_role_arn" ] && set -- "$@" --deployer-role-arn "$deployer_role_arn"
-[ -n "$no_execute" ] && set -- "$@" "$no_execute"
+# --- Compose the deploy-stack.sh environment. --------------------------------
+FROM_STACKS="$INFRA_BASE_STACK $INFRA_RDS_STACK"
+MAPS=""
 
-set -- "$@" --param "PubsubSqsEnv=$pubsub_sqs_env"
-# TemplateBaseUrl must track the version we deploy so nested children load from
-# the matching prefix.
-set -- "$@" --param "TemplateBaseUrl=$template_base_url/$version/cardinal-lakerunner/"
+# PubsubSqsEnv and TemplateBaseUrl are always set.  TemplateBaseUrl must track
+# the version we deploy so nested children load from the matching prefix.
+params="PubsubSqsEnv=$pubsub_sqs_env
+TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
+ClusterArn=$CLUSTER_ARN
+ClusterName=$CLUSTER_NAME
+VpcId=$VPC_ID
+PrivateSubnets=$PRIVATE_SUBNETS
+OtelReplicas=$otel_replicas"
 
-[ -n "$vpc_id" ] && set -- "$@" --param "VpcId=$vpc_id"
-[ -n "$cluster_arn" ] && set -- "$@" --param "ClusterArn=$cluster_arn"
-[ -n "$cluster_name" ] && set -- "$@" --param "ClusterName=$cluster_name"
-[ -n "$private_subnets" ] && set -- "$@" --param "PrivateSubnets=$private_subnets"
-[ -n "$public_subnets" ] && set -- "$@" --param "PublicSubnets=$public_subnets"
-[ -n "$service_namespace_name" ] && set -- "$@" --param "ServiceNamespaceName=$service_namespace_name"
-[ -n "$otel_replicas" ] && set -- "$@" --param "OtelReplicas=$otel_replicas"
+[ -n "${PUBLIC_SUBNETS:-}" ] && params="$params
+PublicSubnets=$PUBLIC_SUBNETS"
+[ -n "${SERVICE_NAMESPACE_NAME:-}" ] && params="$params
+ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 
-[ -n "$lakerunner_image" ] && set -- "$@" --param "LakerunnerImage=$lakerunner_image"
-[ -n "$maestro_image" ] && set -- "$@" --param "MaestroImage=$maestro_image"
-[ -n "$otel_image" ] && set -- "$@" --param "OtelImage=$otel_image"
-[ -n "$dex_image" ] && set -- "$@" --param "DexImage=$dex_image"
-[ -n "$dex_init_image" ] && set -- "$@" --param "DexInitImage=$dex_init_image"
-[ -n "$db_init_image" ] && set -- "$@" --param "DbInitImage=$db_init_image"
+[ -n "${LAKERUNNER_IMAGE:-}" ] && params="$params
+LakerunnerImage=$LAKERUNNER_IMAGE"
+[ -n "${MAESTRO_IMAGE:-}" ] && params="$params
+MaestroImage=$MAESTRO_IMAGE"
+[ -n "${OTEL_IMAGE:-}" ] && params="$params
+OtelImage=$OTEL_IMAGE"
+[ -n "${DEX_IMAGE:-}" ] && params="$params
+DexImage=$DEX_IMAGE"
+[ -n "${DEX_INIT_IMAGE:-}" ] && params="$params
+DexInitImage=$DEX_INIT_IMAGE"
+[ -n "${DB_INIT_IMAGE:-}" ] && params="$params
+DbInitImage=$DB_INIT_IMAGE"
 
-[ -n "$certificate_arn" ] && set -- "$@" --param "CertificateArn=$certificate_arn"
-[ -n "$certificate_body_file" ] && set -- "$@" --param "CertificateBody=$(read_file_or_die "$certificate_body_file")"
-[ -n "$certificate_private_key_file" ] && set -- "$@" --param "CertificatePrivateKey=$(read_file_or_die "$certificate_private_key_file")"
-[ -n "$certificate_chain_file" ] && set -- "$@" --param "CertificateChain=$(read_file_or_die "$certificate_chain_file")"
+[ -n "${CERTIFICATE_ARN:-}" ] && params="$params
+CertificateArn=$CERTIFICATE_ARN"
+[ -n "${CERTIFICATE_BODY_FILE:-}" ] && params="$params
+CertificateBody=$(read_file_or_die "$CERTIFICATE_BODY_FILE")"
+[ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ] && params="$params
+CertificatePrivateKey=$(read_file_or_die "$CERTIFICATE_PRIVATE_KEY_FILE")"
+[ -n "${CERTIFICATE_CHAIN_FILE:-}" ] && params="$params
+CertificateChain=$(read_file_or_die "$CERTIFICATE_CHAIN_FILE")"
 
-[ -n "$dex_admin_email" ] && set -- "$@" --param "DexAdminEmail=$dex_admin_email"
-[ -n "$dex_admin_password_hash" ] && set -- "$@" --param "DexAdminPasswordHash=$dex_admin_password_hash"
-[ -n "$dex_client_id" ] && set -- "$@" --param "DexClientId=$dex_client_id"
-[ -n "$oidc_superadmin_emails" ] && set -- "$@" --param "OidcSuperadminEmails=$oidc_superadmin_emails"
+[ -n "${DEX_ADMIN_EMAIL:-}" ] && params="$params
+DexAdminEmail=$DEX_ADMIN_EMAIL"
+[ -n "${DEX_ADMIN_PASSWORD_HASH:-}" ] && params="$params
+DexAdminPasswordHash=$DEX_ADMIN_PASSWORD_HASH"
+[ -n "${DEX_CLIENT_ID:-}" ] && params="$params
+DexClientId=$DEX_CLIENT_ID"
+[ -n "${OIDC_SUPERADMIN_EMAILS:-}" ] && params="$params
+OidcSuperadminEmails=$OIDC_SUPERADMIN_EMAILS"
 
-exec "$SCRIPT_DIR/deploy-stack.sh" "$@"
+PARAMS="$params"
+
+export TEMPLATE_URL PARAMS FROM_STACKS MAPS
+
+exec "$SCRIPT_DIR/deploy-stack.sh"

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -4,10 +4,10 @@
 #
 # Upstream: the lakerunner-infra-base stack.  This stack's LakerunnerPrincipal
 # parameter does NOT match any infra-base output name, so it is wired via an
-# explicit --map LakerunnerPrincipal=ProcessRoleArn: the satellite trusts the
+# explicit MAPS LakerunnerPrincipal=ProcessRoleArn: the satellite trusts the
 # lakerunner process role to assume into the satellite ingest access role.
 #
-# Thin wrapper over deploy-stack.sh.
+# Thin wrapper over deploy-stack.sh.  Pure environment-variable interface.
 
 set -eu
 
@@ -15,76 +15,62 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-infra-base.yaml"
 
-stack_name=""
-region=""
-version=""
-template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
-deployer_role_arn=""
-no_execute=""
-
-infra_base_stack=""
-external_id=""
-raw_bucket_name=""
-raw_bucket_lifecycle_days=""
-
 usage() {
-    cat <<'EOF'
-Usage: deploy-satellite-infra-base.sh --stack-name NAME --region REGION --version VER \
-           --infra-base-stack NAME [options]
+    cat <<EOF
+deploy-satellite-infra-base.sh -- deploy the cardinal-satellite-infra-base stack.
+
+All inputs come from environment variables (no flags).
 
 Required:
-  --stack-name NAME           Stack to create/update.
-  --region REGION             AWS region.
-  --version VERSION           Published template tag.
-  --infra-base-stack NAME     Upstream lakerunner-infra-base stack.  Its
-                              ProcessRoleArn output is mapped to this stack's
-                              LakerunnerPrincipal parameter.
+  STACK_NAME         Stack to create/update.
+  REGION             AWS region (never defaulted; must be set explicitly).
+  VERSION            Published template tag.
+  INFRA_BASE_STACK   Upstream lakerunner-infra-base stack.  Its ProcessRoleArn
+                     output is mapped to this stack's LakerunnerPrincipal param.
 
-Add-ins (template defaults are fine if omitted):
-  --external-id ID            Optional STS ExternalId for the assume-role trust.
-  --raw-bucket-name NAME      Optional explicit raw ingest bucket name.
-  --raw-bucket-lifecycle-days N
-
-Common:
-  --template-base-url URL     Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
-  --deployer-role-arn ARN
-  --no-execute
+Optional (template defaults preserved when unset):
+  EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
+  RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
+  RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
+  TEMPLATE_BASE_URL          Default: $DEFAULT_TEMPLATE_BASE_URL
+  DEPLOYER_ROLE_ARN          Passed to create-change-set.
+  NO_EXECUTE                 Non-empty: change-set only, do not execute.
 EOF
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --stack-name) stack_name="$2"; shift 2 ;;
-        --region) region="$2"; shift 2 ;;
-        --version) version="$2"; shift 2 ;;
-        --template-base-url) template_base_url="$2"; shift 2 ;;
-        --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
-        --no-execute) no_execute="--no-execute"; shift ;;
-        --infra-base-stack) infra_base_stack="$2"; shift 2 ;;
-        --external-id) external_id="$2"; shift 2 ;;
-        --raw-bucket-name) raw_bucket_name="$2"; shift 2 ;;
-        --raw-bucket-lifecycle-days) raw_bucket_lifecycle_days="$2"; shift 2 ;;
-        -h|--help) usage; exit 0 ;;
-        *) echo "[deploy-satellite-infra-base] ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
-    esac
-done
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    "") : ;;
+    *) echo "[deploy-satellite-infra-base] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
+esac
 
-if [ -z "$stack_name" ] || [ -z "$region" ] || [ -z "$version" ] || [ -z "$infra_base_stack" ]; then
+missing=""
+[ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
+[ -z "${REGION:-}" ] && missing="$missing REGION"
+[ -z "${VERSION:-}" ] && missing="$missing VERSION"
+[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+if [ -n "$missing" ]; then
     usage >&2
-    echo "[deploy-satellite-infra-base] ERROR: --stack-name, --region, --version, and --infra-base-stack are required" >&2
+    echo "[deploy-satellite-infra-base] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
-template_url="$template_base_url/$version/$TEMPLATE_KEY"
+template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
-set -- --stack-name "$stack_name" --template-url "$template_url" --region "$region"
-set -- "$@" --from-stack "$infra_base_stack"
-set -- "$@" --map "LakerunnerPrincipal=ProcessRoleArn"
-[ -n "$deployer_role_arn" ] && set -- "$@" --deployer-role-arn "$deployer_role_arn"
-[ -n "$no_execute" ] && set -- "$@" "$no_execute"
+TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+FROM_STACKS="$INFRA_BASE_STACK"
+MAPS="LakerunnerPrincipal=ProcessRoleArn"
 
-[ -n "$external_id" ] && set -- "$@" --param "ExternalId=$external_id"
-[ -n "$raw_bucket_name" ] && set -- "$@" --param "RawBucketName=$raw_bucket_name"
-[ -n "$raw_bucket_lifecycle_days" ] && set -- "$@" --param "RawBucketLifecycleDays=$raw_bucket_lifecycle_days"
+params=""
+[ -n "${EXTERNAL_ID:-}" ] && params="${params}ExternalId=$EXTERNAL_ID
+"
+[ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME
+"
+[ -n "${RAW_BUCKET_LIFECYCLE_DAYS:-}" ] && params="${params}RawBucketLifecycleDays=$RAW_BUCKET_LIFECYCLE_DAYS
+"
 
-exec "$SCRIPT_DIR/deploy-stack.sh" "$@"
+PARAMS="$params"
+
+export TEMPLATE_URL PARAMS FROM_STACKS MAPS
+
+exec "$SCRIPT_DIR/deploy-stack.sh"

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -5,11 +5,11 @@
 # Upstream:
 #   - satellite-infra-base : RawBucketName output -> RawBucketName param.
 #   - lakerunner-infra-base : LicenseSecretArn output -> LicenseSecretArn param.
-# Both output names match the parameter names, so plain --from-stack pulls wire
-# them up.  OtelReplicas defaults to 1 here (the collector config must change
+# Both output names match the parameter names, so plain FROM_STACKS pulls wire
+# them up.  OTEL_REPLICAS defaults to 1 here (the collector config must change
 # before scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
 #
-# Thin wrapper over deploy-stack.sh.
+# Thin wrapper over deploy-stack.sh.  Pure environment-variable interface.
 
 set -eu
 
@@ -17,95 +17,79 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-services.yaml"
 
-stack_name=""
-region=""
-version=""
-template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
-deployer_role_arn=""
-no_execute=""
-
-satellite_infra_base_stack=""
-infra_base_stack=""
-vpc_id=""
-alb_subnets_csv=""
-task_subnets_csv=""
-ecs_cluster_arn=""
-alb_scheme=""
-ingest_source_cidr=""
-otel_replicas="1"   # default: single replica; >1 needs a collector config change
-
 usage() {
-    cat <<'EOF'
-Usage: deploy-satellite-services.sh --stack-name NAME --region REGION --version VER \
-           --satellite-infra-base-stack NAME --infra-base-stack NAME [options]
+    cat <<EOF
+deploy-satellite-services.sh -- deploy the cardinal-satellite-services stack.
+
+All inputs come from environment variables (no flags).
 
 Required:
-  --stack-name NAME                  Stack to create/update.
-  --region REGION                    AWS region.
-  --version VERSION                  Published template tag.
-  --satellite-infra-base-stack NAME  Upstream (RawBucketName).
-  --infra-base-stack NAME            Upstream lakerunner-infra-base (LicenseSecretArn).
-  --vpc-id VPC
-  --alb-subnets-csv CSV              Subnets for the collector ALB.
-  --task-subnets-csv CSV             Subnets for the collector tasks.
-  --ecs-cluster-arn ARN              ECS cluster for the collector.
+  STACK_NAME                  Stack to create/update.
+  REGION                      AWS region (never defaulted; must be set explicitly).
+  VERSION                     Published template tag.
+  SATELLITE_INFRA_BASE_STACK  Upstream satellite-infra-base (RawBucketName).
+  INFRA_BASE_STACK            Upstream lakerunner-infra-base (LicenseSecretArn).
+  VPC_ID                      VPC for the collector.
+  ALB_SUBNETS                 Comma-separated subnets for the collector ALB.
+  TASK_SUBNETS                Comma-separated subnets for the collector tasks.
+  ECS_CLUSTER_ARN             ECS cluster for the collector.
 
-Add-ins (template defaults are fine if omitted):
-  --alb-scheme SCHEME                internet-facing | internal.
-  --ingest-source-cidr CIDR          Allowed source CIDR for the collector ALB.
-  --otel-replicas N                  Collector replica count (default 1; >1
-                                     requires a collector config change first).
-
-Common:
-  --template-base-url URL            Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
-  --deployer-role-arn ARN
-  --no-execute
+Optional (template defaults preserved when unset):
+  ALB_SCHEME           internet-facing | internal (default internal).
+  INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
+  OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
+                       collector config change first).
+  TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
+  DEPLOYER_ROLE_ARN    Passed to create-change-set.
+  NO_EXECUTE           Non-empty: change-set only, do not execute.
 EOF
 }
 
-while [ $# -gt 0 ]; do
-    case "$1" in
-        --stack-name) stack_name="$2"; shift 2 ;;
-        --region) region="$2"; shift 2 ;;
-        --version) version="$2"; shift 2 ;;
-        --template-base-url) template_base_url="$2"; shift 2 ;;
-        --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
-        --no-execute) no_execute="--no-execute"; shift ;;
-        --satellite-infra-base-stack) satellite_infra_base_stack="$2"; shift 2 ;;
-        --infra-base-stack) infra_base_stack="$2"; shift 2 ;;
-        --vpc-id) vpc_id="$2"; shift 2 ;;
-        --alb-subnets-csv) alb_subnets_csv="$2"; shift 2 ;;
-        --task-subnets-csv) task_subnets_csv="$2"; shift 2 ;;
-        --ecs-cluster-arn) ecs_cluster_arn="$2"; shift 2 ;;
-        --alb-scheme) alb_scheme="$2"; shift 2 ;;
-        --ingest-source-cidr) ingest_source_cidr="$2"; shift 2 ;;
-        --otel-replicas) otel_replicas="$2"; shift 2 ;;
-        -h|--help) usage; exit 0 ;;
-        *) echo "[deploy-satellite-services] ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
-    esac
-done
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    "") : ;;
+    *) echo "[deploy-satellite-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
+esac
 
-if [ -z "$stack_name" ] || [ -z "$region" ] || [ -z "$version" ] \
-    || [ -z "$satellite_infra_base_stack" ] || [ -z "$infra_base_stack" ]; then
+missing=""
+[ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
+[ -z "${REGION:-}" ] && missing="$missing REGION"
+[ -z "${VERSION:-}" ] && missing="$missing VERSION"
+[ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
+[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+[ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
+[ -z "${ALB_SUBNETS:-}" ] && missing="$missing ALB_SUBNETS"
+[ -z "${TASK_SUBNETS:-}" ] && missing="$missing TASK_SUBNETS"
+[ -z "${ECS_CLUSTER_ARN:-}" ] && missing="$missing ECS_CLUSTER_ARN"
+if [ -n "$missing" ]; then
     usage >&2
-    echo "[deploy-satellite-services] ERROR: --stack-name, --region, --version, --satellite-infra-base-stack, and --infra-base-stack are required" >&2
+    echo "[deploy-satellite-services] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
-template_url="$template_base_url/$version/$TEMPLATE_KEY"
+template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
-set -- --stack-name "$stack_name" --template-url "$template_url" --region "$region"
-set -- "$@" --from-stack "$satellite_infra_base_stack"
-set -- "$@" --from-stack "$infra_base_stack"
-[ -n "$deployer_role_arn" ] && set -- "$@" --deployer-role-arn "$deployer_role_arn"
-[ -n "$no_execute" ] && set -- "$@" "$no_execute"
+# OTEL_REPLICAS defaults to 1 here (single replica; >1 needs a collector config
+# change first).  Always passed so the wrapper default, not the template
+# default, governs.
+otel_replicas="${OTEL_REPLICAS:-1}"
 
-[ -n "$vpc_id" ] && set -- "$@" --param "VpcId=$vpc_id"
-[ -n "$alb_subnets_csv" ] && set -- "$@" --param "AlbSubnetsCsv=$alb_subnets_csv"
-[ -n "$task_subnets_csv" ] && set -- "$@" --param "TaskSubnetsCsv=$task_subnets_csv"
-[ -n "$ecs_cluster_arn" ] && set -- "$@" --param "EcsClusterArn=$ecs_cluster_arn"
-[ -n "$alb_scheme" ] && set -- "$@" --param "AlbScheme=$alb_scheme"
-[ -n "$ingest_source_cidr" ] && set -- "$@" --param "IngestSourceCidr=$ingest_source_cidr"
-[ -n "$otel_replicas" ] && set -- "$@" --param "OtelReplicas=$otel_replicas"
+TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+FROM_STACKS="$SATELLITE_INFRA_BASE_STACK $INFRA_BASE_STACK"
+MAPS=""
 
-exec "$SCRIPT_DIR/deploy-stack.sh" "$@"
+params="VpcId=$VPC_ID
+AlbSubnetsCsv=$ALB_SUBNETS
+TaskSubnetsCsv=$TASK_SUBNETS
+EcsClusterArn=$ECS_CLUSTER_ARN
+OtelReplicas=$otel_replicas"
+[ -n "${ALB_SCHEME:-}" ] && params="$params
+AlbScheme=$ALB_SCHEME"
+[ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
+IngestSourceCidr=$INGEST_SOURCE_CIDR"
+
+PARAMS="$params"
+
+export TEMPLATE_URL PARAMS FROM_STACKS MAPS
+
+exec "$SCRIPT_DIR/deploy-stack.sh"

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -55,6 +55,7 @@ no_execute=""
 # Repeatable collections, stored newline-delimited in shell variables.
 from_stacks=""      # one stack name per line
 param_overrides=""  # one Key=Value per line
+file_params=""      # one ParamName=/path/to/file per line
 maps=""             # one TargetParam=SourceOutputKey per line
 
 # FROM_STACKS is space-separated on input; normalize to one stack name per line.
@@ -64,8 +65,9 @@ if [ -n "${FROM_STACKS:-}" ]; then
 "
     done
 fi
-# PARAMS and MAPS are already newline-separated on input.
+# PARAMS, FILE_PARAMS, and MAPS are already newline-separated on input.
 [ -n "${PARAMS:-}" ] && param_overrides="$PARAMS"
+[ -n "${FILE_PARAMS:-}" ] && file_params="$FILE_PARAMS"
 [ -n "${MAPS:-}" ] && maps="$MAPS"
 
 # Internal test hook state: resolve parameters from local JSON fixtures and
@@ -96,6 +98,10 @@ Optional:
   PARAMS              Newline-separated Key=Value parameter overrides (highest
                       precedence).  Newline- (not semicolon-) separated so that
                       values containing semicolons are safe.
+  FILE_PARAMS         Newline-separated ParamName=/path/to/file entries.  Each
+                      file's full content (multi-line/PEM safe) becomes that
+                      parameter's value.  Same explicit-override tier as PARAMS;
+                      if both set the same parameter, PARAMS wins.
   MAPS                Newline-separated TargetParam=SourceOutputKey entries.
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
@@ -254,7 +260,10 @@ cleanup() {
 }
 
 # Build the merged upstream-values JSON object into "$1", in precedence order
-# (lowest first so later assignments win):  FROM_STACKS -> MAPS -> PARAMS.
+# (lowest first so later assignments win):
+#   FROM_STACKS -> MAPS -> FILE_PARAMS -> PARAMS.
+# FILE_PARAMS and PARAMS share the explicit-override tier; PARAMS is applied
+# last so a literal PARAMS value wins over a FILE_PARAMS file for the same key.
 build_upstream_values() {
     out_file="$1"
 
@@ -291,7 +300,7 @@ build_upstream_values() {
     # 2. MAPS TargetParam=SourceOutputKey: resolve SourceOutputKey from the
     #    already-merged from-stack outputs.
     if [ -n "$maps" ]; then
-        printf '%s' "$maps" | while IFS= read -r entry; do
+        printf '%s\n' "$maps" | while IFS= read -r entry; do
             [ -n "$entry" ] || continue
             tgt=${entry%%=*}
             src=${entry#*=}
@@ -313,9 +322,36 @@ build_upstream_values() {
         rm -f "$out_file.maps"
     fi
 
+    # 1b. FILE_PARAMS ParamName=/path/to/file: read each file's full content as
+    #     the value via jq --rawfile, so multi-line / PEM material is JSON-escaped
+    #     correctly.  Applied before PARAMS so a literal PARAMS value wins.
+    if [ -n "$file_params" ]; then
+        printf '%s\n' "$file_params" | while IFS= read -r entry; do
+            [ -n "$entry" ] || continue
+            key=${entry%%=*}
+            path=${entry#*=}
+            if [ "$key" = "$entry" ] || [ -z "$key" ] || [ -z "$path" ]; then
+                fail 2 "FILE_PARAMS expects ParamName=/path/to/file, got: $entry"
+            fi
+            if [ ! -r "$path" ]; then
+                fail 2 "FILE_PARAMS file not readable for $key: $path"
+            fi
+            printf '%s\t%s\n' "$key" "$path"
+        done >"$out_file.fileparams" || exit $?
+        while IFS="$(printf '\t')" read -r key path; do
+            [ -n "$key" ] || continue
+            merged=$(
+                jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
+                    $m + {($key): $val}
+                '
+            ) || fail 2 "failed reading FILE_PARAMS file for $key: $path"
+        done <"$out_file.fileparams"
+        rm -f "$out_file.fileparams"
+    fi
+
     # 1. PARAMS Key=Value: highest precedence.
     if [ -n "$param_overrides" ]; then
-        printf '%s' "$param_overrides" | while IFS= read -r entry; do
+        printf '%s\n' "$param_overrides" | while IFS= read -r entry; do
             [ -n "$entry" ] || continue
             key=${entry%%=*}
             val=${entry#*=}
@@ -337,6 +373,23 @@ build_upstream_values() {
 }
 
 main() {
+    # Internal test hook: build the merged upstream-values object from the
+    # env (PARAMS/FILE_PARAMS/MAPS) and print it, never touching AWS.  Only
+    # valid when FROM_STACKS is empty (FROM_STACKS would require AWS).  Used to
+    # unit-test FILE_PARAMS multi-line resolution.
+    if [ "${1:-}" = "--internal-build-upstream" ]; then
+        if ! command -v jq >/dev/null 2>&1; then
+            fail 2 "jq is required for --internal-build-upstream"
+        fi
+        if [ -n "$from_stacks" ]; then
+            fail 2 "--internal-build-upstream cannot be used with FROM_STACKS set"
+        fi
+        work_dir=$(mktemp -d)
+        build_upstream_values "$work_dir/upstream.json"
+        cat "$work_dir/upstream.json"
+        return 0
+    fi
+
     # Internal test hook: resolve from fixtures only, never touch AWS.  Engaged
     # by the positional --internal-resolve-params SUMMARY UPSTREAM CURRENT form.
     if [ "${1:-}" = "--internal-resolve-params" ]; then

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -7,14 +7,33 @@
 # Self-contained: depends only on a POSIX shell, the AWS CLI v2, and jq.  Does
 # not depend on the cardinal_cfn Python package.
 #
+# Pure environment-variable interface (no flags).  Inputs:
+#
+#   Required:
+#     STACK_NAME     Stack to create or upgrade.
+#     TEMPLATE_URL   S3 URL of the generated template.
+#     REGION         AWS region (never defaulted -- a wrong region is hard to
+#                    undo, so it must be set explicitly).
+#
+#   Optional:
+#     FROM_STACKS        Space-separated upstream stack names.  An Output whose
+#                        key equals a target parameter name supplies it.
+#     PARAMS             Newline-separated Key=Value parameter overrides
+#                        (highest precedence).  Newline-separated, not
+#                        semicolon-separated, because some values (e.g.
+#                        PubsubSqsEnv) contain semicolons.
+#     MAPS               Newline-separated TargetParam=SourceOutputKey entries.
+#     DEPLOYER_ROLE_ARN  Passed via --role-arn to create-change-set.
+#     NO_EXECUTE         Non-empty: create and describe the change set, then stop.
+#
 # Mode is auto-detected from describe-stacks: missing stack -> CREATE,
 # existing stack -> UPDATE.
 #
 # Per-parameter resolution precedence (from the target template's
 # get-template-summary Parameters list):
-#   1. --param Key=Value          explicit override (highest precedence)
-#   2. --map TargetParam=SrcKey   value of an upstream Output named SrcKey
-#   3. --from-stack output        an upstream Output whose key == the param name
+#   1. PARAMS Key=Value           explicit override (highest precedence)
+#   2. MAPS TargetParam=SrcKey    value of an upstream Output named SrcKey
+#   3. FROM_STACKS output         an upstream Output whose key == the param name
 #   4. UPDATE only: UsePreviousValue:true (carry the current stack value)
 #   5. the template's Default
 #   6. otherwise FAIL, listing the unresolved required parameters
@@ -26,20 +45,32 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
-stack_name=""
-template_url=""
-region=""
-deployer_role_arn=""
-no_execute="false"
+stack_name="${STACK_NAME:-}"
+template_url="${TEMPLATE_URL:-}"
+region="${REGION:-}"
+deployer_role_arn="${DEPLOYER_ROLE_ARN:-}"
+no_execute=""
+[ -n "${NO_EXECUTE:-}" ] && no_execute="true"
 
 # Repeatable collections, stored newline-delimited in shell variables.
 from_stacks=""      # one stack name per line
 param_overrides=""  # one Key=Value per line
 maps=""             # one TargetParam=SourceOutputKey per line
 
-# Internal test hook: resolve parameters from local JSON fixtures and print the
-# resolved list, without touching AWS.
-internal_resolve=""
+# FROM_STACKS is space-separated on input; normalize to one stack name per line.
+if [ -n "${FROM_STACKS:-}" ]; then
+    for sname in $FROM_STACKS; do
+        from_stacks="${from_stacks}${sname}
+"
+    done
+fi
+# PARAMS and MAPS are already newline-separated on input.
+[ -n "${PARAMS:-}" ] && param_overrides="$PARAMS"
+[ -n "${MAPS:-}" ] && maps="$MAPS"
+
+# Internal test hook state: resolve parameters from local JSON fixtures and
+# print the resolved list, without touching AWS.  Engaged only via the
+# positional --internal-resolve-params hook in main(); not an env-var input.
 internal_resolve_summary=""
 internal_resolve_upstream=""
 internal_resolve_current=""
@@ -50,22 +81,24 @@ work_dir=""
 
 usage() {
     cat <<'EOF'
-Usage: deploy-stack.sh --stack-name NAME --template-url URL --region REGION [options]
+deploy-stack.sh -- generic chained CloudFormation deploy driver.
+
+All inputs come from environment variables (no flags).
 
 Required:
-  --stack-name NAME           Stack to create or upgrade.
-  --template-url URL          S3 URL of the generated template.
-  --region    REGION          AWS region.
-
-Chaining (all repeatable):
-  --from-stack NAME           Pull Outputs from NAME; an Output whose key equals
-                              a target parameter name supplies that parameter.
-  --param Key=Value           Explicit parameter override (highest precedence).
-  --map TargetParam=SrcKey    Assign TargetParam from upstream Output SrcKey.
+  STACK_NAME      Stack to create or upgrade.
+  TEMPLATE_URL    S3 URL of the generated template.
+  REGION          AWS region (never defaulted; must be set explicitly).
 
 Optional:
-  --deployer-role-arn ARN     Pass via --role-arn to create-change-set.
-  --no-execute                Create and describe the change set, then stop.
+  FROM_STACKS         Space-separated upstream stack names; an Output whose key
+                      equals a target parameter name supplies that parameter.
+  PARAMS              Newline-separated Key=Value parameter overrides (highest
+                      precedence).  Newline- (not semicolon-) separated so that
+                      values containing semicolons are safe.
+  MAPS                Newline-separated TargetParam=SourceOutputKey entries.
+  DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
+  NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
 Exit codes:
   0  success or no-op
@@ -89,8 +122,8 @@ fail() {
 # Pure parameter resolver.  Reads three JSON files:
 #   summary_file  : the target template's get-template-summary Parameters array
 #   upstream_file : a JSON object {ParamName: Value} of all candidate upstream
-#                   values (from --from-stack outputs, --map'd outputs, and
-#                   --param overrides), already merged in precedence order by
+#                   values (from FROM_STACKS outputs, MAPS'd outputs, and
+#                   PARAMS overrides), already merged in precedence order by
 #                   the caller (later wins).  An object key present here is a
 #                   resolved value.
 #   current_file  : the current stack's Parameters array (UPDATE) or [] (CREATE)
@@ -145,7 +178,7 @@ resolve_params() {
 
     missing=$(printf '%s' "$resolved" | jq -r '[.[] | select(._missing == true) | .ParameterKey] | join(", ")')
     if [ -n "$missing" ]; then
-        fail 2 "no value (override, --map, upstream output, current value, or default) for required parameter(s): $missing"
+        fail 2 "no value (override, MAPS, upstream output, current value, or default) for required parameter(s): $missing"
     fi
 
     printf '%s\n' "$resolved" | jq '.'
@@ -220,41 +253,14 @@ cleanup() {
     exit "$rc"
 }
 
-parse_args() {
-    while [ $# -gt 0 ]; do
-        case "$1" in
-            --stack-name) stack_name="$2"; shift 2 ;;
-            --template-url) template_url="$2"; shift 2 ;;
-            --region) region="$2"; shift 2 ;;
-            --from-stack) from_stacks="${from_stacks}$2
-"; shift 2 ;;
-            --param) param_overrides="${param_overrides}$2
-"; shift 2 ;;
-            --map) maps="${maps}$2
-"; shift 2 ;;
-            --deployer-role-arn) deployer_role_arn="$2"; shift 2 ;;
-            --no-execute) no_execute="true"; shift ;;
-            --internal-resolve-params)
-                internal_resolve="true"
-                internal_resolve_summary="$2"
-                internal_resolve_upstream="$3"
-                internal_resolve_current="$4"
-                shift 4
-                ;;
-            -h|--help) usage; exit 0 ;;
-            *) fail 2 "unknown argument: $1" ;;
-        esac
-    done
-}
-
 # Build the merged upstream-values JSON object into "$1", in precedence order
-# (lowest first so later assignments win):  --from-stack -> --map -> --param.
+# (lowest first so later assignments win):  FROM_STACKS -> MAPS -> PARAMS.
 build_upstream_values() {
     out_file="$1"
 
     merged='{}'
 
-    # 3. --from-stack: every Output keyed by its OutputKey.
+    # 3. FROM_STACKS: every Output keyed by its OutputKey.
     if [ -n "$from_stacks" ]; then
         printf '%s' "$from_stacks" | while IFS= read -r sname; do
             [ -n "$sname" ] || continue
@@ -282,7 +288,7 @@ build_upstream_values() {
         rm -f "$out_file.fromstacks"
     fi
 
-    # 2. --map TargetParam=SourceOutputKey: resolve SourceOutputKey from the
+    # 2. MAPS TargetParam=SourceOutputKey: resolve SourceOutputKey from the
     #    already-merged from-stack outputs.
     if [ -n "$maps" ]; then
         printf '%s' "$maps" | while IFS= read -r entry; do
@@ -290,7 +296,7 @@ build_upstream_values() {
             tgt=${entry%%=*}
             src=${entry#*=}
             if [ "$tgt" = "$entry" ] || [ -z "$tgt" ] || [ -z "$src" ]; then
-                fail 2 "--map expects TargetParam=SourceOutputKey, got: $entry"
+                fail 2 "MAPS expects TargetParam=SourceOutputKey, got: $entry"
             fi
             printf '%s\t%s\n' "$tgt" "$src"
         done >"$out_file.maps"
@@ -300,21 +306,21 @@ build_upstream_values() {
                 | reduce $pairs[] as $p ($m;
                     ($p[1]) as $src
                     | if ($m | has($src)) then . + {($p[0]): $m[$src]}
-                      else error("--map source output not found upstream: " + $src + " (for " + $p[0] + ")")
+                      else error("MAPS source output not found upstream: " + $src + " (for " + $p[0] + ")")
                       end)
             '
-        ) || fail 2 "failed resolving --map entries (see message above)"
+        ) || fail 2 "failed resolving MAPS entries (see message above)"
         rm -f "$out_file.maps"
     fi
 
-    # 1. --param Key=Value: highest precedence.
+    # 1. PARAMS Key=Value: highest precedence.
     if [ -n "$param_overrides" ]; then
         printf '%s' "$param_overrides" | while IFS= read -r entry; do
             [ -n "$entry" ] || continue
             key=${entry%%=*}
             val=${entry#*=}
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
-                fail 2 "--param expects Key=Value, got: $entry"
+                fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
@@ -331,10 +337,12 @@ build_upstream_values() {
 }
 
 main() {
-    parse_args "$@"
-
-    # Internal test hook: resolve from fixtures only, never touch AWS.
-    if [ -n "$internal_resolve" ]; then
+    # Internal test hook: resolve from fixtures only, never touch AWS.  Engaged
+    # by the positional --internal-resolve-params SUMMARY UPSTREAM CURRENT form.
+    if [ "${1:-}" = "--internal-resolve-params" ]; then
+        internal_resolve_summary="$2"
+        internal_resolve_upstream="$3"
+        internal_resolve_current="$4"
         if ! command -v jq >/dev/null 2>&1; then
             fail 2 "jq is required for --internal-resolve-params"
         fi
@@ -354,9 +362,13 @@ main() {
 
     preflight
 
-    if [ -z "$stack_name" ] || [ -z "$template_url" ] || [ -z "$region" ]; then
+    missing_required=""
+    [ -z "$stack_name" ] && missing_required="$missing_required STACK_NAME"
+    [ -z "$template_url" ] && missing_required="$missing_required TEMPLATE_URL"
+    [ -z "$region" ] && missing_required="$missing_required REGION"
+    if [ -n "$missing_required" ]; then
         usage >&2
-        fail 2 "--stack-name, --template-url, and --region are required"
+        fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
 
     log "checking whether stack $stack_name exists in $region"
@@ -481,7 +493,7 @@ main() {
             --change-set-name "$change_set_name" \
             --region "$region" \
             --query 'ChangeSetId' --output text)
-        log "--no-execute set; leaving change set in place"
+        log "NO_EXECUTE set; leaving change set in place"
         log "change set name: $change_set_name"
         log "change set ARN:  $cs_arn"
         change_set_name=""
@@ -517,6 +529,11 @@ main() {
     log "deploy complete (mode=$mode)"
     return 0
 }
+
+# -h/--help short-circuit before the env-var path.
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+esac
 
 trap cleanup EXIT INT TERM HUP
 

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -47,9 +47,14 @@ def test_syntax_clean(script):
 
 
 @pytest.mark.parametrize("script", SCRIPTS, ids=lambda p: p.name)
-def test_no_args_prints_usage_and_fails(script):
-    """A bare invocation should print usage and exit non-zero (validation
-    failure), not blow up with a syntax error or silently succeed."""
+def test_missing_required_env_prints_usage_and_fails(script):
+    """With every required env var cleared, the script should print usage and
+    exit non-zero (validation failure), not blow up with a syntax error or
+    silently succeed.  The scripts are env-var driven (no flags), so a clean
+    env that omits the required vars is the failure path.
+
+    A minimal env (PATH only) clears STACK_NAME/REGION/VERSION/etc. for free.
+    """
     result = subprocess.run(
         ["sh", str(script)],
         capture_output=True,
@@ -57,10 +62,13 @@ def test_no_args_prints_usage_and_fails(script):
         env={"PATH": TEST_PATH},
     )
     assert result.returncode != 0, (
-        f"{script.name} should exit non-zero with no args, got 0"
+        f"{script.name} should exit non-zero with required env vars unset, got 0"
     )
-    assert "Usage:" in result.stderr, (
-        f"{script.name} should print usage to stderr with no args:\n{result.stderr}"
+    combined = result.stdout + result.stderr
+    assert ("REQUIRED" in combined.upper()) or ("missing required" in combined), (
+        f"{script.name} should print usage (a REQUIRED section) or a "
+        f"'missing required' line to stderr when required env vars are unset:\n"
+        f"{combined}"
     )
 
 

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -4,6 +4,7 @@ These tests soft-skip the shellcheck step when shellcheck is not on PATH so
 that contributors and CI runners without it installed are not blocked.
 """
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -193,3 +194,70 @@ def test_resolver_resolves_when_all_satisfied(tmp_path):
     assert result.returncode == 0, result.stderr
     assert '"ParameterValue": "aval"' in result.stdout
     assert '"ParameterValue": "bdef"' in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# FILE_PARAMS: a ParamName=/path entry resolves to the file's full (possibly
+# multi-line / PEM) content.  Exercised via the --internal-build-upstream hook
+# which builds the merged upstream-values object from the env without AWS.
+# ---------------------------------------------------------------------------
+
+PEM_CONTENT = (
+    "-----BEGIN CERTIFICATE-----\n"
+    "line-two-with-special=chars;and:more\n"
+    "line-three\n"
+    "-----END CERTIFICATE-----\n"
+)
+
+
+def _build_upstream(env_extra):
+    env = {"PATH": TEST_PATH}
+    env.update(env_extra)
+    return subprocess.run(
+        ["sh", str(SCRIPTS_DIR / "deploy-stack.sh"), "--internal-build-upstream"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_file_params_resolves_multiline_file_content(tmp_path):
+    pem = tmp_path / "cert.pem"
+    pem.write_text(PEM_CONTENT)
+
+    result = _build_upstream({"FILE_PARAMS": f"CertificateBody={pem}"})
+    assert result.returncode == 0, result.stderr
+
+    merged = json.loads(result.stdout)
+    assert merged["CertificateBody"] == PEM_CONTENT, (
+        f"FILE_PARAMS value should equal the file content verbatim, got:\n"
+        f"{merged.get('CertificateBody')!r}"
+    )
+
+
+def test_file_params_unreadable_file_fails(tmp_path):
+    result = _build_upstream(
+        {"FILE_PARAMS": f"CertificateBody={tmp_path / 'does-not-exist.pem'}"}
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 for unreadable FILE_PARAMS file, got "
+        f"{result.returncode}:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "FILE_PARAMS" in result.stderr
+
+
+def test_params_wins_over_file_params_for_same_key(tmp_path):
+    pem = tmp_path / "cert.pem"
+    pem.write_text(PEM_CONTENT)
+
+    result = _build_upstream(
+        {
+            "FILE_PARAMS": f"CertificateBody={pem}",
+            "PARAMS": "CertificateBody=literal-wins",
+        }
+    )
+    assert result.returncode == 0, result.stderr
+    merged = json.loads(result.stdout)
+    assert merged["CertificateBody"] == "literal-wins", (
+        "PARAMS should win over FILE_PARAMS for the same key"
+    )


### PR DESCRIPTION
## Summary

Converts the six chained deploy scripts from `--flag` to a **pure environment-variable** interface (per request: simpler, Jenkins-friendly), with required-before-optional usage and sane defaults.

## Rules applied

- **No flags** — all inputs are SCREAMING_SNAKE_CASE env vars.
- **`REGION` is required in every script** — never defaulted, no AWS-CLI region fallback (a wrong region is hard to undo).
- **Required vs Optional**: a var is REQUIRED only if it has no template default *and* no upstream-output fallback; everything defaultable stays OPTIONAL with its current default (behavior preserved).
- Missing required vars → print usage + `missing required: …` to stderr, exit 2 (collects all missing, fails before any AWS call).
- `usage()` lists REQUIRED above OPTIONAL (with defaults shown).

## Interface (required envs)

- `deploy-stack.sh`: `STACK_NAME`, `TEMPLATE_URL`, `REGION` (+ optional `FROM_STACKS`/`PARAMS`/`MAPS`/`DEPLOYER_ROLE_ARN`/`NO_EXECUTE`).
- `infra-base`: `STACK_NAME REGION VERSION VPC_ID CLUSTER_ARN LICENSE_DATA_FILE`.
- `infra-rds`: `STACK_NAME REGION VERSION INFRA_BASE_STACK VPC_ID PRIVATE_SUBNETS`.
- `satellite-infra-base`: `STACK_NAME REGION VERSION INFRA_BASE_STACK`.
- `satellite-services`: `STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK INFRA_BASE_STACK VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN` (OtelReplicas default 1).
- `lakerunner-services`: `STACK_NAME REGION VERSION INFRA_BASE_STACK INFRA_RDS_STACK SATELLITE_INFRA_BASE_STACK CLUSTER_ARN CLUSTER_NAME VPC_ID PRIVATE_SUBNETS` (computes `PubsubSqsEnv` from the satellite stack; OtelReplicas default 0; cert/dex optional with defaults).

Wrappers read friendly env, compose `TEMPLATE_URL`/`FROM_STACKS`/`PARAMS`/`MAPS`, and `exec deploy-stack.sh` (env inherited). `PARAMS` is newline-delimited to keep `PubsubSqsEnv`'s embedded `;` intact.

## Tests / docs

- `tests/unit/test_deploy_stack_lint.py`: "missing required env → usage + non-zero exit" + executable/`sh -n`/shellcheck-clean checks. `make test` green (451 passed, 1 skipped — unrelated groovy skip).
- `docs/operations/jenkins-chained-deploy.md` updated to the env-var model with a REQUIRED/OPTIONAL table + example invocation per job.

## Known limitation (pre-existing, unchanged)

Multi-line PEM cert values via `CERTIFICATE_*_FILE` split across the newline-delimited `PARAMS` parser (ACM `CERTIFICATE_ARN` is unaffected). Same limitation existed in the flag version. Can be addressed separately if PEM import is needed.