### PR TITLE
pubsub-sqs: plain SQS_* env vars (distroless image has no shell)

### DIFF
--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -43,7 +43,7 @@ runs it as a child so it can clean up an auto-generated cert temp dir on exit.
 | `TEMPLATE_URL` | required | S3 URL of the generated template. |
 | `REGION` | required | AWS region (never defaulted). |
 | `FROM_STACKS` | optional | Space-separated upstream stack names; an Output whose key equals a target parameter name supplies that parameter. |
-| `PARAMS` | optional | Newline-separated `Key=Value` overrides (highest precedence). Newline- (not semicolon-) separated so values like `PubsubSqsEnv` that contain semicolons are safe. |
+| `PARAMS` | optional | Newline-separated `Key=Value` overrides (highest precedence). Newline- (not semicolon-) separated so values that contain semicolons (e.g. some ARNs/URLs) are passed intact. |
 | `FILE_PARAMS` | optional | Newline-separated `ParamName=/path/to/file` entries. Each file's full content becomes that parameter's value, read via `jq --rawfile` so multi-line / PEM material is JSON-escaped correctly. Same explicit-override tier as `PARAMS`; if both set the same parameter, `PARAMS` wins. |
 | `MAPS` | optional | Newline-separated `TargetParam=SourceOutputKey` entries. |
 | `DEPLOYER_ROLE_ARN` | optional | Forwarded via `--role-arn` to `create-change-set`. |
@@ -71,7 +71,8 @@ lakerunner-infra-base
 ```
 
 `lakerunner-services` depends on both `lakerunner-infra-rds` and at least one
-`satellite-infra-base` (for the computed `PubsubSqsEnv`), so it runs last.
+`satellite-infra-base` (for the `QueueUrl` / `QueueRoleArn` params), so it runs
+last.
 
 ## Two non-automatic mappings
 
@@ -79,15 +80,11 @@ lakerunner-infra-base
   `lakerunner-infra-base` Output `ProcessRoleArn` (the satellite trusts the
   lakerunner process role to assume into the satellite access role). The
   wrapper sets `MAPS="LakerunnerPrincipal=ProcessRoleArn"`.
-- `lakerunner-services` parameter `PubsubSqsEnv` is **computed**, not a single
-  Output. The wrapper reads three Outputs from the `satellite-infra-base` stack
-  and assembles:
-
-  ```
-  SQS_QUEUE_URL=<RawQueueUrl>;SQS_REGION=<Region>;SQS_ROLE_ARN=<LakerunnerAccessRoleArn>
-  ```
-
-  then passes it as a `PARAMS` line.
+- `lakerunner-services` parameters `QueueUrl` and `QueueRoleArn` are read from
+  the `satellite-infra-base` stack Outputs `RawQueueUrl` and
+  `LakerunnerAccessRoleArn`, then passed as `PARAMS` lines. The pubsub-sqs
+  container sets them as plain `SQS_QUEUE_URL` / `SQS_ROLE_ARN` env vars
+  (`SQS_REGION` comes from the stack's own `AWS::Region`).
 
 ## Job 1: lakerunner-infra-base
 
@@ -224,8 +221,8 @@ INGEST_SOURCE_CIDR=10.0.0.0/8 \
 ## Job 5: lakerunner-services
 
 `scripts/deploy-lakerunner-services.sh` — pulls infra-base + infra-rds Outputs,
-computes `PubsubSqsEnv` from the satellite stack, and forwards `TemplateBaseUrl`
-so nested children load from the matching version prefix. `OTEL_REPLICAS`
+reads `QueueUrl` / `QueueRoleArn` from the satellite stack, and forwards
+`TemplateBaseUrl` so nested children load from the matching version prefix. `OTEL_REPLICAS`
 defaults to `0` here: the same-account satellite collector does ingest, so the
 lakerunner-tier collector is off by default.
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -8,11 +8,11 @@
 # All of those output names match the template's parameter names, so plain
 # FROM_STACKS pulls wire them up.
 #
-# Special case: PubsubSqsEnv is COMPUTED here.  It is not a single upstream
-# output -- we read three outputs from the satellite-infra-base stack and
-# assemble the env string the pubsub-sqs container expects:
-#   SQS_QUEUE_URL=<RawQueueUrl>;SQS_REGION=<Region>;SQS_ROLE_ARN=<LakerunnerAccessRoleArn>
-# then pass it via a PARAMS line (highest precedence).
+# Special case: QueueUrl and QueueRoleArn are pulled from the satellite-infra-
+# base stack outputs (RawQueueUrl / LakerunnerAccessRoleArn) and passed via
+# PARAMS lines (highest precedence). The pubsub-sqs container sets them as plain
+# SQS_QUEUE_URL / SQS_ROLE_ARN env vars; the region is the stack's own
+# AWS::Region, so no QueueRegion param is needed.
 #
 # OTEL_REPLICAS defaults to 0 here: in the satellite topology the same-account
 # satellite collector performs ingest, so the lakerunner-tier otel collector is
@@ -38,8 +38,8 @@ Required:
   VERSION                     Published template tag.
   INFRA_BASE_STACK            Upstream lakerunner-infra-base.
   INFRA_RDS_STACK             Upstream lakerunner-infra-rds.
-  SATELLITE_INFRA_BASE_STACK  Source of RawQueueUrl/Region/LakerunnerAccessRoleArn
-                              for the computed PubsubSqsEnv.
+  SATELLITE_INFRA_BASE_STACK  Source of RawQueueUrl / LakerunnerAccessRoleArn
+                              for the QueueUrl / QueueRoleArn params.
   CLUSTER_ARN                 ECS cluster ARN.
   CLUSTER_NAME                ECS cluster name (no upstream output for it).
   VPC_ID                      VPC for the services.
@@ -106,7 +106,7 @@ otel_replicas="${OTEL_REPLICAS:-0}"
 
 TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 
-# --- Compute PubsubSqsEnv from the satellite-infra-base stack outputs. -------
+# --- Read QueueUrl / QueueRoleArn from the satellite-infra-base stack. --------
 sat_outputs=$(aws cloudformation describe-stacks \
     --stack-name "$SATELLITE_INFRA_BASE_STACK" \
     --region "$REGION" \
@@ -114,23 +114,22 @@ sat_outputs=$(aws cloudformation describe-stacks \
     --output json)
 
 queue_url=$(printf '%s' "$sat_outputs" | jq -r '(.[] | select(.OutputKey == "RawQueueUrl") | .OutputValue) // ""')
-sqs_region=$(printf '%s' "$sat_outputs" | jq -r '(.[] | select(.OutputKey == "Region") | .OutputValue) // ""')
 role_arn=$(printf '%s' "$sat_outputs" | jq -r '(.[] | select(.OutputKey == "LakerunnerAccessRoleArn") | .OutputValue) // ""')
 
-if [ -z "$queue_url" ] || [ -z "$sqs_region" ] || [ -z "$role_arn" ]; then
-    echo "[deploy-lakerunner-services] ERROR: satellite-infra-base stack '$SATELLITE_INFRA_BASE_STACK' is missing one of RawQueueUrl/Region/LakerunnerAccessRoleArn outputs" >&2
+if [ -z "$queue_url" ] || [ -z "$role_arn" ]; then
+    echo "[deploy-lakerunner-services] ERROR: satellite-infra-base stack '$SATELLITE_INFRA_BASE_STACK' is missing one of RawQueueUrl/LakerunnerAccessRoleArn outputs" >&2
     exit 2
 fi
-
-pubsub_sqs_env="SQS_QUEUE_URL=$queue_url;SQS_REGION=$sqs_region;SQS_ROLE_ARN=$role_arn"
 
 # --- Compose the deploy-stack.sh environment. --------------------------------
 FROM_STACKS="$INFRA_BASE_STACK $INFRA_RDS_STACK"
 MAPS=""
 
-# PubsubSqsEnv and TemplateBaseUrl are always set.  TemplateBaseUrl must track
-# the version we deploy so nested children load from the matching prefix.
-params="PubsubSqsEnv=$pubsub_sqs_env
+# QueueUrl/QueueRoleArn and TemplateBaseUrl are always set.  TemplateBaseUrl
+# must track the version we deploy so nested children load from the matching
+# prefix.
+params="QueueUrl=$queue_url
+QueueRoleArn=$role_arn
 TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
 ClusterArn=$CLUSTER_ARN
 ClusterName=$CLUSTER_NAME

--- a/scripts/deploy-stack.sh
+++ b/scripts/deploy-stack.sh
@@ -20,8 +20,8 @@
 #                        key equals a target parameter name supplies it.
 #     PARAMS             Newline-separated Key=Value parameter overrides
 #                        (highest precedence).  Newline-separated, not
-#                        semicolon-separated, because some values (e.g.
-#                        PubsubSqsEnv) contain semicolons.
+#                        semicolon-separated, so values that contain semicolons
+#                        (e.g. some ARNs/URLs) are passed intact.
 #     MAPS               Newline-separated TargetParam=SourceOutputKey entries.
 #     DEPLOYER_ROLE_ARN  Passed via --role-arn to create-change-set.
 #     NO_EXECUTE         Non-empty: create and describe the change set, then stop.

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -14,8 +14,6 @@ at the max would triple the steady-state Fargate footprint on every deploy.
 CPU values come from cardinal-defaults.yaml directly.
 """
 
-import shlex
-
 from troposphere import (
     GetAtt,
     Output,
@@ -83,16 +81,30 @@ def build() -> Template:
     t.add_parameter(
         Parameter("BucketName", Type="String", Description="Name of the ingest S3 bucket.")
     )
+    # SQS inputs for the pubsub-sqs service's primary queue (group 0). The
+    # lakerunner binary reads SQS_QUEUE_URL / SQS_REGION / SQS_ROLE_ARN as three
+    # plain env vars; an empty queue URL idles the service. Multi-account
+    # fan-out (numbered SQS_*_N groups) will later use ECS environmentFiles from
+    # S3; this only handles the single primary queue.
     t.add_parameter(
         Parameter(
-            "PubsubSqsEnv",
+            "QueueUrl",
             Type="String",
             Default="",
             Description=(
-                "Driver-supplied SQS env for pubsub-sqs: a shell-evalable string "
-                "of SQS_QUEUE_URL[/REGION/ROLE_ARN] (+ numbered _N groups) the "
-                "container exports before start. The Jenkins driver builds this "
-                "from adopted-account queue/role/region knowledge."
+                "SQS queue URL for the pubsub-sqs primary queue (group 0). "
+                "Empty leaves the pubsub-sqs service idle."
+            ),
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "QueueRoleArn",
+            Type="String",
+            Default="",
+            Description=(
+                "IAM role ARN the pubsub-sqs service STS-assumes to read the "
+                "primary queue and its bucket (group 0)."
             ),
         )
     )
@@ -269,7 +281,7 @@ def build() -> Template:
             },
             {
                 "label": "Pubsub-SQS tunables",
-                "parameters": ["PubsubSqsReplicas", "PubsubSqsEnv"],
+                "parameters": ["PubsubSqsReplicas", "QueueUrl", "QueueRoleArn"],
             },
             {
                 "label": "Image overrides",
@@ -343,13 +355,17 @@ def build() -> Template:
             "memory_mib": pubsub_cfg["memory_mib"],
             "desired_count": Ref("PubsubSqsReplicas"),
             "output_name": "PubsubSqsServiceName",
-            # pubsub-sqs alone consumes SQS. CFN cannot expand the driver's
-            # arbitrary-count SQS_* env groups into container env vars, so the
-            # driver hands the whole set in as one shell-evalable blob
-            # (PUBSUB_SQS_ENV) which this container exports before exec'ing the
-            # binary. The other three process-* services never read SQS.
-            "extra_env": [Environment(Name="PUBSUB_SQS_ENV", Value=Ref("PubsubSqsEnv"))],
-            "command_override": _pubsub_wrapped_command(pubsub_cfg["command"]),
+            # pubsub-sqs alone consumes SQS. The lakerunner binary reads the
+            # primary queue (group 0) from three plain env vars. The image is
+            # distroless (no shell), so these must be real container env vars,
+            # not a shell-evalable blob. The other three process-* services
+            # never read SQS. Multi-account fan-out (numbered SQS_*_N groups)
+            # will later use ECS environmentFiles from S3.
+            "extra_env": [
+                Environment(Name="SQS_QUEUE_URL", Value=Ref("QueueUrl")),
+                Environment(Name="SQS_REGION", Value=Ref("AWS::Region")),
+                Environment(Name="SQS_ROLE_ARN", Value=Ref("QueueRoleArn")),
+            ],
         },
     ]
 
@@ -365,21 +381,10 @@ def build() -> Template:
             base_env=base_env,
             base_secrets=base_secrets,
             extra_env=spec.get("extra_env"),
-            command_override=spec.get("command_override"),
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
 
     return t
-
-
-def _pubsub_wrapped_command(command: list) -> list:
-    """Wrap the pubsub-sqs command so the container exports the driver-supplied
-    SQS env blob before exec'ing the binary.
-
-    Produces ["sh", "-c", 'set -a; eval "$PUBSUB_SQS_ENV"; set +a; exec <cmd>'].
-    """
-    joined = shlex.join(command)
-    return ["sh", "-c", f'set -a; eval "$PUBSUB_SQS_ENV"; set +a; exec {joined}']
 
 
 def _build_service_block(
@@ -394,7 +399,6 @@ def _build_service_block(
     base_env: list,
     base_secrets: list,
     extra_env: list | None = None,
-    command_override: list | None = None,
 ):
     """Wire up the three resources (log group, task def, service) for one service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
@@ -404,14 +408,13 @@ def _build_service_block(
         + _service_specific_env(config)
         + list(extra_env or [])
     )
-    command = command_override if command_override is not None else config.get("command")
     task_def = t.add_resource(
         services_common.build_task_definition(
             service_key=service_key,
             image_ref=image_ref,
             cpu=cpu,
             memory_mib=memory_mib,
-            command=command,
+            command=config.get("command"),
             execution_role_arn_param="ExecutionRoleArn",
             task_role_arn=Ref("TaskRoleArn"),
             environment=env,

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -17,9 +17,9 @@ is optional.
 
 - ALB minimization is deferred: query-api and admin-api still attach to the
   ALB (minimization would require child edits in services-query/control/alb).
-- The process-tier SQS is driver-supplied: the pubsub-sqs container exports
-  the ``PubsubSqsEnv`` blob (built by the Jenkins driver from adopted-account
-  queue/role/region knowledge) before starting. Empty idles the service.
+- The process-tier SQS primary queue (group 0) is driver-supplied via the
+  ``QueueUrl`` / ``QueueRoleArn`` parameters, set on the pubsub-sqs container as
+  plain ``SQS_QUEUE_URL`` / ``SQS_ROLE_ARN`` env vars. Empty idles the service.
 - The cooked bucket backs both otel-raw writes and cooked data in the
   single-account interim.
 """
@@ -154,11 +154,13 @@ _INFRA_SETUP_PARAMS = [
     ("CookedBucketName", "String", None,
      "Name of the S3 cooked bucket (base infra output). Backs both otel-raw "
      "writes and cooked data in the single-account interim."),
-    ("PubsubSqsEnv", "String", "",
-     "Driver-supplied SQS env for pubsub-sqs: a shell-evalable string of "
-     "SQS_QUEUE_URL[/REGION/ROLE_ARN] (+ numbered _N groups) the container "
-     "exports before start. The Jenkins driver builds this from adopted-account "
-     "queue/role/region knowledge. Empty idles the pubsub-sqs service."),
+    ("QueueUrl", "String", "",
+     "SQS queue URL for the pubsub-sqs primary queue (group 0). Set as the "
+     "SQS_QUEUE_URL env var on the pubsub-sqs container. Empty idles the "
+     "service."),
+    ("QueueRoleArn", "String", "",
+     "IAM role ARN the pubsub-sqs service STS-assumes for the primary queue "
+     "and its bucket (group 0). Set as the SQS_ROLE_ARN env var."),
     ("LicenseSecretArn", "String", None,
      "ARN of the cardinal-license secret (infra output)."),
     ("AdminKeySecretArn", "String", None,
@@ -609,7 +611,8 @@ def build() -> Template:
         task_sg=sec_process_sg, task_role=process_role,
     )
     services_process_params.update({
-        "PubsubSqsEnv": Ref("PubsubSqsEnv"),
+        "QueueUrl": Ref("QueueUrl"),
+        "QueueRoleArn": Ref("QueueRoleArn"),
         "ProcessLogsReplicas": Ref("ProcessLogsReplicas"),
         "ProcessLogsMemory": Ref("ProcessLogsMemory"),
         "ProcessMetricsReplicas": Ref("ProcessMetricsReplicas"),

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -80,22 +80,21 @@ def test_data_plane_params(td):
     # Removed/renamed sources
     assert "IngestBucketName" not in params
     assert "RdsSecurityGroupId" not in params
-    # Queue plumbing is fully purged -- pubsub-sqs gets the driver-supplied
-    # PubsubSqsEnv blob, and query/control never consumed SQS.
-    for n in ("QueueUrl", "QueueArn", "QueueRoleArn"):
-        assert n not in params, f"vestigial queue param present: {n}"
+    # QueueArn was never plumbed; QueueUrl/QueueRoleArn are the group-0 inputs.
+    assert "QueueArn" not in params, "vestigial queue param present: QueueArn"
 
 
-def test_pubsub_sqs_env_wired_to_process_child(td):
-    """The driver-supplied SQS env blob flows into the Process child, where the
-    pubsub-sqs container exports it before exec'ing the binary."""
-    assert "PubsubSqsEnv" in td["Parameters"]
-    assert td["Parameters"]["PubsubSqsEnv"]["Default"] == ""
+def test_pubsub_sqs_queue_wired_to_process_child(td):
+    """The group-0 SQS inputs (QueueUrl/QueueRoleArn) flow into the Process
+    child, where the pubsub-sqs container sets them as plain SQS_* env vars."""
+    assert "PubsubSqsEnv" not in td["Parameters"], "old shell-blob param still present"
+    for n in ("QueueUrl", "QueueRoleArn"):
+        assert n in td["Parameters"], f"missing queue param: {n}"
+        assert td["Parameters"][n]["Default"] == "", n
     process = td["Resources"]["Process"]["Properties"]["Parameters"]
-    assert process["PubsubSqsEnv"] == {"Ref": "PubsubSqsEnv"}
-    # The Process child no longer receives the raw queue inputs.
-    for n in ("QueueUrl", "QueueArn", "QueueRoleArn"):
-        assert n not in process, f"Process child should not receive {n}"
+    assert process["QueueUrl"] == {"Ref": "QueueUrl"}
+    assert process["QueueRoleArn"] == {"Ref": "QueueRoleArn"}
+    assert "PubsubSqsEnv" not in process, "Process child should not receive PubsubSqsEnv"
 
 
 def test_children_present(td):

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -30,7 +30,8 @@ def test_required_cross_stack_parameters(td):
         "DbPort",
         "DbSecretArn",
         "BucketName",
-        "PubsubSqsEnv",
+        "QueueUrl",
+        "QueueRoleArn",
         "LicenseSecretArn",
         "MigrationComplete",
         "LakerunnerImage",
@@ -38,11 +39,17 @@ def test_required_cross_stack_parameters(td):
         assert n in td["Parameters"], f"missing parameter: {n}"
 
 
-def test_removed_queue_parameters_are_gone(td):
-    """The raw queue/role inputs were replaced by the driver-supplied
-    PubsubSqsEnv blob; the process tier no longer declares them."""
-    for n in ("QueueUrl", "QueueArn", "QueueRoleArn"):
-        assert n not in td["Parameters"], f"removed parameter still present: {n}"
+def test_pubsub_queue_parameters_default_empty(td):
+    """The pubsub-sqs primary queue (group 0) is supplied via plain QueueUrl /
+    QueueRoleArn params; an empty QueueUrl leaves the service idle."""
+    for n in ("QueueUrl", "QueueRoleArn"):
+        assert n in td["Parameters"], f"missing parameter: {n}"
+        assert td["Parameters"][n]["Default"] == "", n
+
+
+def test_old_pubsub_sqs_env_parameter_is_gone(td):
+    """The shell-evalable PubsubSqsEnv blob is replaced by plain env vars."""
+    assert "PubsubSqsEnv" not in td["Parameters"]
 
 
 def test_no_alb_parameters(td):
@@ -274,7 +281,7 @@ def test_all_task_definitions_set_ssl_required(td):
 
 
 # ---------------------------------------------------------------------------
-# pubsub-sqs driver-supplied SQS env blob (PUBSUB_SQS_ENV)
+# pubsub-sqs plain SQS env vars (group 0)
 # ---------------------------------------------------------------------------
 
 
@@ -288,48 +295,37 @@ def _env(td, task_def_id):
     return {e["Name"]: e["Value"] for e in container.get("Environment", [])}
 
 
-def test_pubsub_sqs_takes_driver_env_blob(td):
-    """pubsub-sqs exports the driver-built PUBSUB_SQS_ENV blob; the static
-    per-group SQS_* env vars are gone."""
+def test_pubsub_sqs_has_plain_group0_env(td):
+    """pubsub-sqs sets the group-0 SQS env as three plain container env vars
+    (the distroless image has no shell to eval a blob)."""
     env = _env(td, "PubsubSqsTaskDef")
-    assert env["PUBSUB_SQS_ENV"] == {"Ref": "PubsubSqsEnv"}, env.get("PUBSUB_SQS_ENV")
-    for static in ("SQS_QUEUE_URL", "SQS_REGION", "SQS_ROLE_ARN"):
-        assert static not in env, f"static SQS env still present: {static}"
+    assert env["SQS_QUEUE_URL"] == {"Ref": "QueueUrl"}, env.get("SQS_QUEUE_URL")
+    assert env["SQS_REGION"] == {"Ref": "AWS::Region"}, env.get("SQS_REGION")
+    assert env["SQS_ROLE_ARN"] == {"Ref": "QueueRoleArn"}, env.get("SQS_ROLE_ARN")
+    assert "PUBSUB_SQS_ENV" not in env, "shell-evalable blob still present"
 
 
-def test_pubsub_sqs_command_wraps_eval_and_exec(td):
-    """The pubsub-sqs container exports the blob via `eval` before exec'ing the
-    original lakerunner command."""
-    command = _container(td, "PubsubSqsTaskDef")["Command"]
-    assert command[0] == "sh"
-    assert command[1] == "-c"
-    script = command[2]
-    assert 'eval "$PUBSUB_SQS_ENV"' in script, script
-    assert "set -a" in script and "set +a" in script, script
-    assert "exec /app/bin/lakerunner pubsub sqs" in script, script
-
-
-def test_process_services_have_no_pubsub_env_or_wrapper(td):
-    """process-logs/metrics/traces never consume SQS: no PUBSUB_SQS_ENV, and
-    their commands stay the original (unwrapped) lakerunner invocation."""
-    for task_def_id in ("ProcessLogsTaskDef", "ProcessMetricsTaskDef", "ProcessTracesTaskDef"):
-        env = _env(td, task_def_id)
-        assert "PUBSUB_SQS_ENV" not in env, f"{task_def_id} unexpectedly has PUBSUB_SQS_ENV"
-        command = _container(td, task_def_id).get("Command")
-        if command:
-            assert command[0] != "sh", f"{task_def_id} command unexpectedly wrapped: {command!r}"
-
-
-def test_no_static_sqs_env_anywhere(td):
-    """SQS_QUEUE_URL is no longer a static env entry on any container."""
+def test_no_container_command_uses_shell_wrapper(td):
+    """No container wraps its command in a shell (`sh -c ... eval`): the image
+    is distroless. Commands stay the plain lakerunner invocation from defaults."""
     for tdef in td["Resources"].values():
         if tdef["Type"] != "AWS::ECS::TaskDefinition":
             continue
         for container in tdef["Properties"]["ContainerDefinitions"]:
-            env = {e["Name"] for e in container.get("Environment", [])}
-            assert "SQS_QUEUE_URL" not in env, (
-                f"{container.get('Name')} still has static SQS_QUEUE_URL env"
+            command = container.get("Command") or []
+            assert "sh" not in command, f"{container.get('Name')} command uses sh: {command!r}"
+            joined = " ".join(str(c) for c in command)
+            assert "sh -c" not in joined and "eval" not in joined, (
+                f"{container.get('Name')} command wrapped in a shell: {command!r}"
             )
+
+
+def test_process_services_have_no_sqs_env(td):
+    """process-logs/metrics/traces never consume SQS: no SQS_* env vars."""
+    for task_def_id in ("ProcessLogsTaskDef", "ProcessMetricsTaskDef", "ProcessTracesTaskDef"):
+        env = _env(td, task_def_id)
+        for n in ("SQS_QUEUE_URL", "SQS_REGION", "SQS_ROLE_ARN", "PUBSUB_SQS_ENV"):
+            assert n not in env, f"{task_def_id} unexpectedly has {n}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -122,14 +122,14 @@ def test_satellite_infra_base_maps_lakerunner_principal():
     assert "LakerunnerPrincipal=ProcessRoleArn" in text
 
 
-def test_lakerunner_services_computes_pubsub_sqs_env():
-    """lakerunner-services must compute PubsubSqsEnv from the three satellite
-    outputs and pass it as an explicit --param."""
+def test_lakerunner_services_passes_queue_params():
+    """lakerunner-services must read the group-0 queue inputs from the satellite
+    outputs and pass them as plain QueueUrl/QueueRoleArn params (no shell blob)."""
     text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
     for token in ("RawQueueUrl", "LakerunnerAccessRoleArn",
-                  "SQS_QUEUE_URL=", "SQS_REGION=", "SQS_ROLE_ARN=",
-                  "PubsubSqsEnv="):
+                  "QueueUrl=", "QueueRoleArn="):
         assert token in text, f"deploy-lakerunner-services.sh missing {token}"
+    assert "PubsubSqsEnv" not in text, "old shell-blob PubsubSqsEnv still present"
 
 
 def test_resolver_precedence_param_over_upstream(tmp_path):


### PR DESCRIPTION
The lakerunner image is distroless (no /bin/sh), so the PubsubSqsEnv blob exported via 'sh -c eval' crash-looped (exec: sh not found). Replaced with plain ECS env on the pubsub-sqs container: SQS_QUEUE_URL=Ref(QueueUrl), SQS_REGION=Ref(AWS::Region), SQS_ROLE_ARN=Ref(QueueRoleArn). Driver computes QueueUrl + QueueRoleArn from the satellite stack. Multi-account fan-out (SQS_*_N) will use ECS environmentFiles later. 430 passed, cfn-lint clean.