### PR TITLE
Deploy fixes: exit-code propagation, DEX hash required, ALB_SCHEME, drop dead otel

### DIFF
--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Jenkins job 5: deploy the cardinal-lakerunner-services stack (the application
-# tier: query, process, control, otel, maestro).
+# tier: query, process, control, maestro).
 #
 # Upstream:
 #   - lakerunner-infra-base : roles, security groups, secrets, SSM param names.
@@ -13,10 +13,6 @@
 # PARAMS lines (highest precedence). The pubsub-sqs container sets them as plain
 # SQS_QUEUE_URL / SQS_ROLE_ARN env vars; the region is the stack's own
 # AWS::Region, so no QueueRegion param is needed.
-#
-# OTEL_REPLICAS defaults to 0 here: in the satellite topology the same-account
-# satellite collector performs ingest, so the lakerunner-tier otel collector is
-# off by default.
 #
 # Thin wrapper over deploy-stack.sh.  Pure environment-variable interface.
 
@@ -44,6 +40,10 @@ Required:
   CLUSTER_NAME                ECS cluster name (no upstream output for it).
   VPC_ID                      VPC for the services.
   PRIVATE_SUBNETS             Comma-separated private subnet ids.
+  DEX_ADMIN_PASSWORD_HASH     bcrypt hash for the Maestro/DEX admin login.
+                              REQUIRED: DEX will not start without it ("no
+                              password hash provided") and MaestroService rolls
+                              back.
 
 Optional (template defaults preserved when unset):
   CERTIFICATE_ARN             ACM/IAM cert ARN for the Maestro HTTPS listener.
@@ -56,13 +56,15 @@ Optional (template defaults preserved when unset):
   CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path).  Overrides auto-generation.
   CERTIFICATE_CHAIN_FILE      PEM chain (path).
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
-  DEX_ADMIN_PASSWORD_HASH     bcrypt hash; REQUIRED for Maestro UI login even
-                              though the template defaults it to ''.
   DEX_CLIENT_ID               (template default maestro-ui).
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
   SERVICE_NAMESPACE_NAME      Cloud Map namespace (template default cardinal.local).
   PUBLIC_SUBNETS              Comma-separated public subnet ids (template default '').
-  OTEL_REPLICAS               lakerunner-tier collector replicas (default 0).
+  ALB_SCHEME                  internet-facing | internal (template default:
+                              internal).  For internet-facing you must also set
+                              PUBLIC_SUBNETS, and the ALB SG internet ingress is
+                              enabled on the infra-base stack (its ALB_SCHEME /
+                              ALB_ALLOWED_CIDR* settings).
   LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
   DB_INIT_IMAGE               Image overrides (template defaults otherwise).
   TEMPLATE_BASE_URL           Default: $DEFAULT_TEMPLATE_BASE_URL.  Also
@@ -90,6 +92,7 @@ missing=""
 [ -z "${CLUSTER_NAME:-}" ] && missing="$missing CLUSTER_NAME"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${PRIVATE_SUBNETS:-}" ] && missing="$missing PRIVATE_SUBNETS"
+[ -z "${DEX_ADMIN_PASSWORD_HASH:-}" ] && missing="$missing DEX_ADMIN_PASSWORD_HASH"
 if [ -n "$missing" ]; then
     usage >&2
     echo "[deploy-lakerunner-services] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
@@ -102,7 +105,6 @@ if ! command -v aws >/dev/null 2>&1 || ! command -v jq >/dev/null 2>&1; then
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
-otel_replicas="${OTEL_REPLICAS:-0}"
 
 TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 
@@ -134,11 +136,12 @@ TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
 ClusterArn=$CLUSTER_ARN
 ClusterName=$CLUSTER_NAME
 VpcId=$VPC_ID
-PrivateSubnets=$PRIVATE_SUBNETS
-OtelReplicas=$otel_replicas"
+PrivateSubnets=$PRIVATE_SUBNETS"
 
 [ -n "${PUBLIC_SUBNETS:-}" ] && params="$params
 PublicSubnets=$PUBLIC_SUBNETS"
+[ -n "${ALB_SCHEME:-}" ] && params="$params
+AlbScheme=$ALB_SCHEME"
 [ -n "${SERVICE_NAMESPACE_NAME:-}" ] && params="$params
 ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 
@@ -172,8 +175,13 @@ DbInitImage=$DB_INIT_IMAGE"
 file_params=""
 cert_dir=""
 
+# Preserve and propagate the child's exit status: rm -rf would otherwise
+# overwrite $? with its own 0, false-greening a FAILED deploy.
 cleanup_cert() {
-    [ -n "$cert_dir" ] && [ -d "$cert_dir" ] && rm -rf "$cert_dir"
+    status=$?
+    [ -n "${cert_dir:-}" ] && rm -rf "$cert_dir"
+    trap - EXIT
+    exit "$status"
 }
 trap cleanup_cert EXIT INT TERM HUP
 

--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -9,9 +9,9 @@ Resources created:
 
 - 1 ALB SG (cardinal-alb-sg). Inbound 443 / 9443 / 4318 from the
   AlbAllowedCidr1/2/3 params; all egress.
-- 6 task SGs, one per child tier (migration/query/process/control/otel/
+- 5 task SGs, one per child tier (migration/query/process/control/
   maestro) with tier-specific inter-tier ingress; all egress.
-- 1 shared ECS task execution role + 6 per-tier task roles.
+- 1 shared ECS task execution role + 5 per-tier task roles.
 - 1 cooked bucket (durable; cooked-only output; Retain).
 - license + admin-key secrets (Retain, named cardinal-*).
 - storage-profiles + api-keys SSM params (operator-managed).
@@ -95,8 +95,6 @@ _QUERY_API_PORT = 8080
 _QUERY_WORKER_ARTIFACT_PORT = 8081
 _QUERY_WORKER_PORT = 8082
 _ADMIN_API_PORT = 9091
-_OTLP_HTTP_PORT = 4318
-_OTEL_HEALTH_PORT = 13133  # otel.py's target group sets HealthCheckPort=13133
 _MAESTRO_PORT = 4200
 _MAESTRO_DEX_PORT = 5556
 
@@ -403,11 +401,6 @@ def build() -> Template:
         component="svc-control-sg",
         description="Cardinal control tier (sweeper, monitoring, admin-api, alert-evaluator).",
     )
-    otel_sg = _task_sg(
-        "OtelSecurityGroup",
-        component="svc-otel-sg",
-        description="Cardinal otel collector tier.",
-    )
     maestro_sg = _task_sg(
         "MaestroSecurityGroup",
         component="svc-maestro-sg",
@@ -458,42 +451,6 @@ def build() -> Template:
         ToPort=_ADMIN_API_PORT,
         Description="ALB to admin-api",
     ))
-
-    # ALB -> otel on 4318 (data plane) and 13133 (health check).
-    t.add_resource(SecurityGroupIngress(
-        "OtelFromAlb",
-        GroupId=Ref(otel_sg),
-        SourceSecurityGroupId=Ref(alb_sg),
-        IpProtocol="tcp",
-        FromPort=_OTLP_HTTP_PORT,
-        ToPort=_OTLP_HTTP_PORT,
-        Description="ALB to otel-collector data plane",
-    ))
-    t.add_resource(SecurityGroupIngress(
-        "OtelHealthFromAlb",
-        GroupId=Ref(otel_sg),
-        SourceSecurityGroupId=Ref(alb_sg),
-        IpProtocol="tcp",
-        FromPort=_OTEL_HEALTH_PORT,
-        ToPort=_OTEL_HEALTH_PORT,
-        Description="ALB health probe to otel-collector",
-    ))
-    # Lakerunner tasks -> otel on 4318 (self-telemetry from each tier)
-    for tier_title, tier_ref in [
-        ("Query", query_sg),
-        ("Process", process_sg),
-        ("Control", control_sg),
-        ("Maestro", maestro_sg),
-    ]:
-        t.add_resource(SecurityGroupIngress(
-            f"OtelFrom{tier_title}",
-            GroupId=Ref(otel_sg),
-            SourceSecurityGroupId=Ref(tier_ref),
-            IpProtocol="tcp",
-            FromPort=_OTLP_HTTP_PORT,
-            ToPort=_OTLP_HTTP_PORT,
-            Description=f"{tier_title} to otel-collector self-telemetry",
-        ))
 
     # Maestro -> lakerunner cross-tier calls via Cloud Map service discovery
     # (query-api 8080, admin-api 9091), bypassing the ALB.
@@ -756,37 +713,6 @@ def build() -> Template:
         Tags=_tags(component="svc-control-role"),
     ))
 
-    otel_role = t.add_resource(Role(
-        "OtelRole",
-        AssumeRolePolicyDocument=_ecs_tasks_trust(),
-        Policies=[
-            Policy(
-                PolicyName="cardinal-svc-otel",
-                PolicyDocument={
-                    "Version": "2012-10-17",
-                    "Statement": [
-                        _stmt_secrets_read(),
-                        # OTel writes raw OTLP signals under otel-raw/ in the
-                        # cooked bucket via the awss3 exporter; restrict to that
-                        # write-side prefix. (security.py used the threaded
-                        # BucketName; here it is the cooked bucket base creates.)
-                        {
-                            "Sid": "OtelRawWrite",
-                            "Effect": "Allow",
-                            "Action": ["s3:PutObject"],
-                            "Resource": Sub(
-                                "arn:${AWS::Partition}:s3:::${BucketName}/otel-raw/*",
-                                BucketName=cooked_bucket_name_value,
-                            ),
-                        },
-                        _stmt_cw_logs(),
-                    ],
-                },
-            ),
-        ],
-        Tags=_tags(component="svc-otel-role"),
-    ))
-
     maestro_role = t.add_resource(Role(
         "MaestroRole",
         AssumeRolePolicyDocument=_ecs_tasks_trust(),
@@ -954,7 +880,6 @@ def build() -> Template:
     _emit("QuerySecurityGroupId", "Query tier SG id.", Ref(query_sg))
     _emit("ProcessSecurityGroupId", "Process tier SG id.", Ref(process_sg))
     _emit("ControlSecurityGroupId", "Control tier SG id.", Ref(control_sg))
-    _emit("OtelSecurityGroupId", "OTel tier SG id.", Ref(otel_sg))
     _emit("MaestroSecurityGroupId", "Maestro tier SG id.", Ref(maestro_sg))
 
     _emit("ExecutionRoleArn", "Shared ECS task execution role ARN.",
@@ -967,8 +892,6 @@ def build() -> Template:
           GetAtt(process_role, "Arn"))
     _emit("ControlRoleArn", "Control tier task role ARN.",
           GetAtt(control_role, "Arn"))
-    _emit("OtelRoleArn", "OTel tier task role ARN.",
-          GetAtt(otel_role, "Arn"))
     _emit("MaestroRoleArn", "Maestro tier task role ARN.",
           GetAtt(maestro_role, "Arn"))
 

--- a/tests/templates/test_lakerunner_infra_base.py
+++ b/tests/templates/test_lakerunner_infra_base.py
@@ -69,7 +69,7 @@ def test_cooked_bucket_default_name(td):
 # ---------------------------------------------------------------------------
 
 
-def test_seven_security_groups(td):
+def test_six_security_groups(td):
     sgs = {n for n, r in td["Resources"].items()
            if r["Type"] == "AWS::EC2::SecurityGroup"}
     assert sgs == {
@@ -78,7 +78,6 @@ def test_seven_security_groups(td):
         "QuerySecurityGroup",
         "ProcessSecurityGroup",
         "ControlSecurityGroup",
-        "OtelSecurityGroup",
         "MaestroSecurityGroup",
     }
 
@@ -141,7 +140,7 @@ def test_sibling_ingress_rule_exists(td):
 
 
 # ---------------------------------------------------------------------------
-# Task 4: exec role + 6 task roles with name-pattern IAM
+# Task 4: exec role + 5 task roles with name-pattern IAM
 # ---------------------------------------------------------------------------
 
 
@@ -173,7 +172,7 @@ def test_exec_role_ssm_scoped_to_cardinal(td):
 def test_all_task_roles_use_name_pattern_secrets(td):
     """No task role references a threaded secret ARN param."""
     for role in ("MigrationRole", "QueryRole", "ProcessRole", "ControlRole",
-                 "OtelRole", "MaestroRole"):
+                 "MaestroRole"):
         stmts = _role_statements(td, role)
         secrets = next(s for s in stmts if s["Sid"] == "ReadSecrets")
         res = secrets["Resource"]
@@ -303,14 +302,12 @@ def test_all_outputs_present(td):
         "QuerySecurityGroupId",
         "ProcessSecurityGroupId",
         "ControlSecurityGroupId",
-        "OtelSecurityGroupId",
         "MaestroSecurityGroupId",
         "ExecutionRoleArn",
         "MigrationRoleArn",
         "QueryRoleArn",
         "ProcessRoleArn",
         "ControlRoleArn",
-        "OtelRoleArn",
         "MaestroRoleArn",
         "CookedBucketName",
         "LicenseSecretArn",

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -132,6 +132,60 @@ def test_lakerunner_services_passes_queue_params():
     assert "PubsubSqsEnv" not in text, "old shell-blob PubsubSqsEnv still present"
 
 
+def test_lakerunner_services_requires_dex_admin_password_hash():
+    """Maestro/DEX will not start without DEX_ADMIN_PASSWORD_HASH, so the
+    wrapper must validate it as a REQUIRED env var (collect-all-missing)."""
+    text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
+    assert 'missing="$missing DEX_ADMIN_PASSWORD_HASH"' in text, (
+        "DEX_ADMIN_PASSWORD_HASH is not in the required-vars validation"
+    )
+
+
+def test_lakerunner_services_supports_alb_scheme():
+    """The services wrapper forwards an optional ALB_SCHEME -> AlbScheme param,
+    mirroring the infra-base wrapper."""
+    text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
+    assert "AlbScheme=$ALB_SCHEME" in text
+
+
+def test_lakerunner_services_drops_otel_replicas():
+    """The lakerunner-services template no longer has an OtelReplicas param;
+    the wrapper must not pass it (dead plumbing)."""
+    text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
+    assert "OTEL_REPLICAS" not in text
+    assert "OtelReplicas" not in text
+
+
+def test_lakerunner_services_cleanup_cert_propagates_status():
+    """The cleanup_cert EXIT trap must preserve the child's exit status: it
+    captures $? first, then rm -rf, then exits with the captured status -- so a
+    FAILED deploy (non-zero child) does not false-green to 0 via rm's success.
+
+    Verified behaviorally with a tiny sh harness reproducing the trap idiom:
+    the body exits 3 and the harness must exit 3, not 0.
+    """
+    text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
+    # Static: the corrected idiom is present (capture-first, clear, re-exit).
+    assert "status=$?" in text
+    assert "trap - EXIT" in text
+    assert 'exit "$status"' in text
+
+    # Behavioral: the same trap idiom must propagate a non-zero child status.
+    harness = (
+        "cleanup() { status=$?; rm -rf /tmp/nonexistent-xyzzy; "
+        'trap - EXIT; exit "$status"; }\n'
+        "trap cleanup EXIT INT TERM HUP\n"
+        "exit 3\n"
+    )
+    result = subprocess.run(
+        ["sh", "-c", harness], capture_output=True, text=True
+    )
+    assert result.returncode == 3, (
+        f"trap idiom must propagate the child's non-zero status, got "
+        f"{result.returncode}"
+    )
+
+
 def test_resolver_precedence_param_over_upstream(tmp_path):
     """End-to-end of the pure resolver via the internal hook: --param-class
     upstream value wins, a default fills gaps, and an unsatisfied required


### PR DESCRIPTION
Fixes from the live install test: (1) deploy-lakerunner-services.sh cleanup_cert trap no longer masks a failed deploy as exit 0 (Jenkins false-green); (2) DEX_ADMIN_PASSWORD_HASH now required (maestro won't start without it); (3) added ALB_SCHEME env to the services wrapper for internet-facing; (4) removed the now-unused OtelRole/OtelSecurityGroup/ingress/outputs from infra-base and OTEL_REPLICAS from the services wrapper. 434 passed.