### PR TITLE
Self-telemetry to the collector, on by default

### DIFF
--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -58,6 +58,14 @@ Optional (template defaults preserved when unset):
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
   DEX_CLIENT_ID               (template default maestro-ui).
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
+  SATELLITE_SERVICES_STACK    Source of CollectorEndpoint for lakerunner self-
+                              telemetry.  When set, the wrapper reads the stack's
+                              CollectorEndpoint output and passes it as
+                              SelfTelemetryEndpoint.  When unset, self-telemetry
+                              stays disabled (SelfTelemetryEndpoint defaults '').
+  SELF_TELEMETRY_ENDPOINT     Direct OTLP/HTTP endpoint override for self-
+                              telemetry (e.g. http://<alb>:4318).  Takes
+                              precedence over the SATELLITE_SERVICES_STACK pull.
   SERVICE_NAMESPACE_NAME      Cloud Map namespace (template default cardinal.local).
   PUBLIC_SUBNETS              Comma-separated public subnet ids (template default '').
   ALB_SCHEME                  internet-facing | internal (template default:
@@ -123,6 +131,25 @@ if [ -z "$queue_url" ] || [ -z "$role_arn" ]; then
     exit 2
 fi
 
+# --- Resolve the self-telemetry OTLP/HTTP endpoint. --------------------------
+# A direct SELF_TELEMETRY_ENDPOINT override wins; otherwise, when
+# SATELLITE_SERVICES_STACK is set, pull its CollectorEndpoint output.  When
+# neither is set, leave self_telemetry_endpoint empty so the template default
+# (disabled) is preserved.
+self_telemetry_endpoint="${SELF_TELEMETRY_ENDPOINT:-}"
+if [ -z "$self_telemetry_endpoint" ] && [ -n "${SATELLITE_SERVICES_STACK:-}" ]; then
+    sat_services_outputs=$(aws cloudformation describe-stacks \
+        --stack-name "$SATELLITE_SERVICES_STACK" \
+        --region "$REGION" \
+        --query 'Stacks[0].Outputs' \
+        --output json)
+    self_telemetry_endpoint=$(printf '%s' "$sat_services_outputs" | jq -r '(.[] | select(.OutputKey == "CollectorEndpoint") | .OutputValue) // ""')
+    if [ -z "$self_telemetry_endpoint" ]; then
+        echo "[deploy-lakerunner-services] ERROR: satellite-services stack '$SATELLITE_SERVICES_STACK' is missing the CollectorEndpoint output" >&2
+        exit 2
+    fi
+fi
+
 # --- Compose the deploy-stack.sh environment. --------------------------------
 FROM_STACKS="$INFRA_BASE_STACK $INFRA_RDS_STACK"
 MAPS=""
@@ -144,6 +171,8 @@ PublicSubnets=$PUBLIC_SUBNETS"
 AlbScheme=$ALB_SCHEME"
 [ -n "${SERVICE_NAMESPACE_NAME:-}" ] && params="$params
 ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
+[ -n "$self_telemetry_endpoint" ] && params="$params
+SelfTelemetryEndpoint=$self_telemetry_endpoint"
 
 [ -n "${LAKERUNNER_IMAGE:-}" ] && params="$params
 LakerunnerImage=$LAKERUNNER_IMAGE"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -59,13 +59,16 @@ Optional (template defaults preserved when unset):
   DEX_CLIENT_ID               (template default maestro-ui).
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
   SATELLITE_SERVICES_STACK    Source of CollectorEndpoint for lakerunner self-
-                              telemetry.  When set, the wrapper reads the stack's
-                              CollectorEndpoint output and passes it as
-                              SelfTelemetryEndpoint.  When unset, self-telemetry
-                              stays disabled (SelfTelemetryEndpoint defaults '').
+                              telemetry (default cardinal-satellite-services).
+                              Self-telemetry is on by default: the wrapper reads
+                              this stack's CollectorEndpoint output and passes it
+                              as SelfTelemetryEndpoint.  If the stack or its
+                              CollectorEndpoint output is absent, it warns and
+                              leaves self-telemetry off (never blocks the deploy).
   SELF_TELEMETRY_ENDPOINT     Direct OTLP/HTTP endpoint override for self-
-                              telemetry (e.g. http://<alb>:4318).  Takes
-                              precedence over the SATELLITE_SERVICES_STACK pull.
+                              telemetry (e.g. http://<alb>:4318).  When non-empty,
+                              takes precedence over the SATELLITE_SERVICES_STACK
+                              pull.
   SERVICE_NAMESPACE_NAME      Cloud Map namespace (template default cardinal.local).
   PUBLIC_SUBNETS              Comma-separated public subnet ids (template default '').
   ALB_SCHEME                  internet-facing | internal (template default:
@@ -132,21 +135,25 @@ if [ -z "$queue_url" ] || [ -z "$role_arn" ]; then
 fi
 
 # --- Resolve the self-telemetry OTLP/HTTP endpoint. --------------------------
-# A direct SELF_TELEMETRY_ENDPOINT override wins; otherwise, when
-# SATELLITE_SERVICES_STACK is set, pull its CollectorEndpoint output.  When
-# neither is set, leave self_telemetry_endpoint empty so the template default
-# (disabled) is preserved.
+# Self-telemetry is on by default: the lakerunner account always runs a
+# satellite collector, so a standard deploy gets data flowing with no extra
+# operator config.  A non-empty SELF_TELEMETRY_ENDPOINT override wins; otherwise
+# pull the CollectorEndpoint output from SATELLITE_SERVICES_STACK (default
+# cardinal-satellite-services).  Resolution is GRACEFUL: a missing stack or a
+# missing CollectorEndpoint output warns and leaves self-telemetry off -- it
+# must never block the app deploy.
+satellite_services_stack="${SATELLITE_SERVICES_STACK:-cardinal-satellite-services}"
 self_telemetry_endpoint="${SELF_TELEMETRY_ENDPOINT:-}"
-if [ -z "$self_telemetry_endpoint" ] && [ -n "${SATELLITE_SERVICES_STACK:-}" ]; then
-    sat_services_outputs=$(aws cloudformation describe-stacks \
-        --stack-name "$SATELLITE_SERVICES_STACK" \
-        --region "$REGION" \
-        --query 'Stacks[0].Outputs' \
-        --output json)
-    self_telemetry_endpoint=$(printf '%s' "$sat_services_outputs" | jq -r '(.[] | select(.OutputKey == "CollectorEndpoint") | .OutputValue) // ""')
+if [ -z "$self_telemetry_endpoint" ]; then
+    if sat_services_outputs=$(aws cloudformation describe-stacks \
+            --stack-name "$satellite_services_stack" \
+            --region "$REGION" \
+            --query 'Stacks[0].Outputs' \
+            --output json 2>/dev/null); then
+        self_telemetry_endpoint=$(printf '%s' "$sat_services_outputs" | jq -r '(.[] | select(.OutputKey == "CollectorEndpoint") | .OutputValue) // ""')
+    fi
     if [ -z "$self_telemetry_endpoint" ]; then
-        echo "[deploy-lakerunner-services] ERROR: satellite-services stack '$SATELLITE_SERVICES_STACK' is missing the CollectorEndpoint output" >&2
-        exit 2
+        echo "[deploy-lakerunner-services] satellite collector endpoint not found in $satellite_services_stack; self-telemetry disabled" >&2
     fi
 fi
 

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -36,6 +36,7 @@ from troposphere import (
     Sub,
     Equals,
     If,
+    Not,
 )
 from troposphere.cloudformation import Stack
 from troposphere.servicediscovery import PrivateDnsNamespace
@@ -391,15 +392,13 @@ def build() -> Template:
         ),
     ))
     t.add_parameter(Parameter(
-        "SelfTelemetry",
+        "SelfTelemetryEndpoint",
         Type="String",
-        Default="No",
-        AllowedValues=["No"],
+        Default="",
         Description=(
-            "Self-telemetry to an in-stack otel-collector is no longer "
-            "available -- the in-stack otel child was removed; the satellite "
-            "collector handles all ingest. This toggle is retained for the "
-            "console surface but only 'No' (disabled) is supported."
+            "OTLP/HTTP endpoint for lakerunner self-telemetry (e.g. the "
+            "satellite collector's CollectorEndpoint, http://<alb>:4318). "
+            "Empty disables self-telemetry."
         ),
     ))
 
@@ -448,14 +447,15 @@ def build() -> Template:
                             "CertificateBody", "CertificatePrivateKey",
                             "CertificateChain"]},
             {"label": "Infrastructure-stack outputs",
-             "parameters": [name for name, *_ in _INFRA_SETUP_PARAMS]},
+             "parameters": ([name for name, *_ in _INFRA_SETUP_PARAMS]
+                            + ["SelfTelemetryEndpoint"])},
             {"label": "Security-tier inputs",
              "parameters": ([name for name, _ in _SECURITY_GROUP_PARAMS]
                             + [name for name, _ in _ROLE_PARAMS])},
             {"label": "Sizing", "parameters": sizing_param_names},
             {"label": "Images", "parameters": image_param_names},
             {"label": "Advanced",
-             "parameters": ["DeployMaestro", "SelfTelemetry",
+             "parameters": ["DeployMaestro",
                             "DexAdminEmail", "DexAdminPasswordHash",
                             "OidcSuperadminEmails",
                             "OrganizationId", "OrgName",
@@ -468,11 +468,13 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     t.add_condition("DeployMaestroEnabled", Equals(Ref("DeployMaestro"), "Yes"))
 
-    # The in-stack otel-collector was removed; there is no self-telemetry
-    # target. Tier children always run with telemetry disabled and an empty
-    # endpoint (their own defaults match these values).
-    self_telemetry_endpoint = ""
-    self_telemetry_enabled = "false"
+    # Self-telemetry exports to a driver-supplied OTLP/HTTP endpoint (typically
+    # the satellite collector's CollectorEndpoint). An empty endpoint disables
+    # it; the tier children receive the endpoint and the derived enabled flag.
+    t.add_condition(
+        "SelfTelemetryOn", Not(Equals(Ref("SelfTelemetryEndpoint"), "")))
+    self_telemetry_endpoint = Ref("SelfTelemetryEndpoint")
+    self_telemetry_enabled = If("SelfTelemetryOn", "true", "false")
 
     # ---------------------------------------------------------------------
     # Install-id derivation (computed inline; not a parameter on root)

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -118,3 +118,37 @@ def test_cooked_bucket_wired_to_children(td):
     assert migration["IngestBucketName"] == ref
     query = td["Resources"]["Query"]["Properties"]["Parameters"]
     assert query["BucketName"] == ref
+
+
+def test_self_telemetry_endpoint_param(td):
+    """The locked SelfTelemetry=[No] toggle is gone; a real configurable
+    SelfTelemetryEndpoint (String, default "") takes its place."""
+    params = td["Parameters"]
+    assert "SelfTelemetry" not in params, "vestigial SelfTelemetry toggle still present"
+    assert "SelfTelemetryEndpoint" in params
+    p = params["SelfTelemetryEndpoint"]
+    assert p["Type"] == "String"
+    assert p["Default"] == ""
+
+
+def test_self_telemetry_on_condition(td):
+    """SelfTelemetryOn is true exactly when the endpoint is non-empty."""
+    cond = td["Conditions"]["SelfTelemetryOn"]
+    assert cond == {
+        "Fn::Not": [{"Fn::Equals": [{"Ref": "SelfTelemetryEndpoint"}, ""]}]
+    }
+
+
+def test_self_telemetry_wired_to_tiers_only(td):
+    """Query/Process/Control receive the endpoint Ref and the If-derived enabled
+    flag; Maestro and the other children do not."""
+    endpoint_ref = {"Ref": "SelfTelemetryEndpoint"}
+    enabled_if = {"Fn::If": ["SelfTelemetryOn", "true", "false"]}
+    for tier in ("Query", "Process", "Control"):
+        p = td["Resources"][tier]["Properties"]["Parameters"]
+        assert p["SelfTelemetryEndpoint"] == endpoint_ref, tier
+        assert p["SelfTelemetryEnabled"] == enabled_if, tier
+    for other in ("Maestro", "Migration", "Alb", "Cert"):
+        p = td["Resources"][other]["Properties"]["Parameters"]
+        assert "SelfTelemetryEndpoint" not in p, other
+        assert "SelfTelemetryEnabled" not in p, other


### PR DESCRIPTION
Re-enables lakerunner self-telemetry (removed when the in-stack otel child was dropped) and points it at the satellite collector's CollectorEndpoint (OTLP/HTTP :4318). lakerunner_services exposes SelfTelemetryEndpoint (default '') + SelfTelemetryOn condition, wired to query/process/control tiers. The services wrapper defaults SATELLITE_SERVICES_STACK=cardinal-satellite-services and pulls CollectorEndpoint → on by default, graceful-off if the collector stack/output is absent, overridable via SELF_TELEMETRY_ENDPOINT. 437 passed.