### PR TITLE
CFN: opt-in pubsub-sqs storage-profile auto-register env vars

### DIFF
--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -78,6 +78,15 @@ Optional (template defaults preserved when unset):
                               ALB_ALLOWED_CIDR* settings).
   LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
   DB_INIT_IMAGE               Image overrides (template defaults otherwise).
+  PUBSUB_AUTOREGISTER         Set to "true" to enable pubsub-sqs auto-
+                              registration of satellite buckets (default false).
+                              When true, unseen satellite raw-bucket orgs are
+                              registered and cooked output is routed to the
+                              central instance.
+  PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE
+                              Central cooked-bucket instance_num that auto-
+                              registered orgs write to (default 1). Required
+                              when PUBSUB_AUTOREGISTER=true.
   TEMPLATE_BASE_URL           Default: $DEFAULT_TEMPLATE_BASE_URL.  Also
                               forwarded as the TemplateBaseUrl param (nested
                               children load from the matching prefix).
@@ -265,6 +274,11 @@ DexAdminPasswordHash=$DEX_ADMIN_PASSWORD_HASH"
 DexClientId=$DEX_CLIENT_ID"
 [ -n "${OIDC_SUPERADMIN_EMAILS:-}" ] && params="$params
 OidcSuperadminEmails=$OIDC_SUPERADMIN_EMAILS"
+
+[ -n "${PUBSUB_AUTOREGISTER:-}" ] && params="$params
+PubsubAutoRegister=$PUBSUB_AUTOREGISTER"
+[ -n "${PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE:-}" ] && params="$params
+PubsubAutoRegisterWritesToInstance=$PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE"
 
 PARAMS="$params"
 FILE_PARAMS="$file_params"

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -242,6 +242,31 @@ def build() -> Template:
             Description="Desired replicas for lakerunner-pubsub-sqs.",
         )
     )
+    t.add_parameter(
+        Parameter(
+            "PubsubAutoRegister",
+            Type="String",
+            Default="false",
+            AllowedValues=["true", "false"],
+            Description=(
+                "Enable pubsub-sqs auto-registration of unseen satellite raw "
+                "buckets. When true, the worker registers new orgs and routes "
+                "cooked output to PubsubAutoRegisterWritesToInstance."
+            ),
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "PubsubAutoRegisterWritesToInstance",
+            Type="String",
+            Default="1",
+            Description=(
+                "Central cooked-bucket instance_num that pubsub-sqs auto-"
+                "registered orgs write to. Required when PubsubAutoRegister "
+                "is true."
+            ),
+        )
+    )
 
     # ---------------------------------------------------------------------
     # Console parameter grouping
@@ -281,7 +306,13 @@ def build() -> Template:
             },
             {
                 "label": "Pubsub-SQS tunables",
-                "parameters": ["PubsubSqsReplicas", "QueueUrl", "QueueRoleArn"],
+                "parameters": [
+                    "PubsubSqsReplicas",
+                    "QueueUrl",
+                    "QueueRoleArn",
+                    "PubsubAutoRegister",
+                    "PubsubAutoRegisterWritesToInstance",
+                ],
             },
             {
                 "label": "Image overrides",
@@ -365,6 +396,11 @@ def build() -> Template:
                 Environment(Name="SQS_QUEUE_URL", Value=Ref("QueueUrl")),
                 Environment(Name="SQS_REGION", Value=Ref("AWS::Region")),
                 Environment(Name="SQS_ROLE_ARN", Value=Ref("QueueRoleArn")),
+                Environment(Name="LAKERUNNER_PUBSUB_AUTOREGISTER", Value=Ref("PubsubAutoRegister")),
+                Environment(
+                    Name="LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE",
+                    Value=Ref("PubsubAutoRegisterWritesToInstance"),
+                ),
             ],
         },
     ]

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -110,6 +110,14 @@ def _sizing_param_specs(defaults: dict) -> list[dict]:
          "description": "Fargate memory (MiB) for lakerunner-process-traces."},
         {"name": "PubsubSqsReplicas", "type": "Number", "default": int(pubsub["replicas"]),
          "min": 1, "description": "Desired replicas for lakerunner-pubsub-sqs."},
+        {"name": "PubsubAutoRegister", "type": "String", "default": "false",
+         "allowed_values": ["true", "false"],
+         "description": "Enable pubsub-sqs auto-registration of unseen satellite raw buckets."},
+        {"name": "PubsubAutoRegisterWritesToInstance", "type": "String", "default": "1",
+         "description": (
+             "Central cooked-bucket instance_num pubsub-sqs auto-registered orgs write to. "
+             "Required when PubsubAutoRegister is true."
+         )},
         # Maestro
         {"name": "MaestroTaskCpu", "type": "String", "default": str(maestro_cfg["task"]["cpu"]),
          "description": "Fargate CPU units for the maestro task definition."},
@@ -622,6 +630,8 @@ def build() -> Template:
         "ProcessTracesReplicas": Ref("ProcessTracesReplicas"),
         "ProcessTracesMemory": Ref("ProcessTracesMemory"),
         "PubsubSqsReplicas": Ref("PubsubSqsReplicas"),
+        "PubsubAutoRegister": Ref("PubsubAutoRegister"),
+        "PubsubAutoRegisterWritesToInstance": Ref("PubsubAutoRegisterWritesToInstance"),
     })
     services_process_stack = _add_child(
         t, "Process", "services-process.yaml",

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -97,6 +97,21 @@ def test_pubsub_sqs_queue_wired_to_process_child(td):
     assert "PubsubSqsEnv" not in process, "Process child should not receive PubsubSqsEnv"
 
 
+def test_process_child_params_match_declared(td):
+    """Every parameter declared by services-process.yaml is supplied by the
+    root, and no extra parameters are passed that the child doesn't declare.
+    missing [] extra [] means the invariant holds."""
+    from cardinal_cfn.children import services_process
+    child_td = json.loads(services_process.build().to_json())
+    declared = set(child_td["Parameters"].keys())
+    passed = set(td["Resources"]["Process"]["Properties"]["Parameters"].keys())
+    missing = sorted(declared - passed)
+    extra = sorted(passed - declared)
+    assert missing == [] and extra == [], (
+        f"Process child param mismatch: missing {missing}  extra {extra}"
+    )
+
+
 def test_children_present(td):
     nested = _nested_logical_ids(td)
     expected = {
@@ -137,6 +152,35 @@ def test_self_telemetry_on_condition(td):
     assert cond == {
         "Fn::Not": [{"Fn::Equals": [{"Ref": "SelfTelemetryEndpoint"}, ""]}]
     }
+
+
+def test_pubsub_autoregister_params_present_with_defaults(td):
+    """PubsubAutoRegister and PubsubAutoRegisterWritesToInstance exist on the
+    root with the correct defaults."""
+    params = td["Parameters"]
+    assert "PubsubAutoRegister" in params
+    assert params["PubsubAutoRegister"]["Default"] == "false"
+    assert params["PubsubAutoRegister"]["AllowedValues"] == ["true", "false"]
+    assert "PubsubAutoRegisterWritesToInstance" in params
+    assert params["PubsubAutoRegisterWritesToInstance"]["Default"] == "1"
+
+
+def test_pubsub_autoregister_wired_to_process_child(td):
+    """The two auto-registration params are forwarded as Refs to the Process
+    child and are absent from all other children."""
+    process = td["Resources"]["Process"]["Properties"]["Parameters"]
+    assert process.get("PubsubAutoRegister") == {"Ref": "PubsubAutoRegister"}
+    assert process.get("PubsubAutoRegisterWritesToInstance") == (
+        {"Ref": "PubsubAutoRegisterWritesToInstance"}
+    )
+    for child in ("Query", "Control", "Migration", "Maestro", "Alb", "Cert"):
+        p = td["Resources"][child]["Properties"]["Parameters"]
+        assert "PubsubAutoRegister" not in p, (
+            f"{child} unexpectedly receives PubsubAutoRegister"
+        )
+        assert "PubsubAutoRegisterWritesToInstance" not in p, (
+            f"{child} unexpectedly receives PubsubAutoRegisterWritesToInstance"
+        )
 
 
 def test_self_telemetry_wired_to_tiers_only(td):

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -329,6 +329,46 @@ def test_process_services_have_no_sqs_env(td):
 
 
 # ---------------------------------------------------------------------------
+# pubsub-sqs auto-registration env vars
+# ---------------------------------------------------------------------------
+
+
+def test_pubsub_autoregister_params_exist_with_defaults(td):
+    """PubsubAutoRegister and PubsubAutoRegisterWritesToInstance are declared
+    with the expected defaults."""
+    params = td["Parameters"]
+    assert "PubsubAutoRegister" in params
+    assert params["PubsubAutoRegister"]["Default"] == "false"
+    assert params["PubsubAutoRegister"]["AllowedValues"] == ["true", "false"]
+    assert "PubsubAutoRegisterWritesToInstance" in params
+    assert params["PubsubAutoRegisterWritesToInstance"]["Default"] == "1"
+
+
+def test_pubsub_sqs_has_autoregister_env_vars(td):
+    """pubsub-sqs container carries the two auto-registration env vars wired
+    to their respective parameters."""
+    env = _env(td, "PubsubSqsTaskDef")
+    assert env.get("LAKERUNNER_PUBSUB_AUTOREGISTER") == {"Ref": "PubsubAutoRegister"}, (
+        env.get("LAKERUNNER_PUBSUB_AUTOREGISTER")
+    )
+    assert env.get("LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE") == (
+        {"Ref": "PubsubAutoRegisterWritesToInstance"}
+    ), env.get("LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE")
+
+
+def test_process_services_have_no_autoregister_env(td):
+    """process-logs/metrics/traces must NOT carry the auto-registration env vars."""
+    for task_def_id in ("ProcessLogsTaskDef", "ProcessMetricsTaskDef", "ProcessTracesTaskDef"):
+        env = _env(td, task_def_id)
+        assert "LAKERUNNER_PUBSUB_AUTOREGISTER" not in env, (
+            f"{task_def_id} unexpectedly has LAKERUNNER_PUBSUB_AUTOREGISTER"
+        )
+        assert "LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE" not in env, (
+            f"{task_def_id} unexpectedly has LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE"
+        )
+
+
+# ---------------------------------------------------------------------------
 # B → C boundary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds PubsubAutoRegister + PubsubAutoRegisterWritesToInstance params, wired as LAKERUNNER_PUBSUB_AUTOREGISTER / LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE on the pubsub-sqs container only, to enable the lakerunner SQS auto-registration feature (cardinalhq/lakerunner#820). Driver: PUBSUB_AUTOREGISTER / PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE. Default off. 443 passed.