### PR TITLE
FARGATE on-demand fallback for singleton/critical services

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -35,7 +35,6 @@ from troposphere import (
 )
 from troposphere.ecs import (
     AwsvpcConfiguration,
-    CapacityProviderStrategyItem,
     ContainerDefinition,
     DeploymentCircuitBreaker,
     DeploymentConfiguration,
@@ -747,9 +746,10 @@ def build() -> Template:
         Service(
             "MaestroService",
             Cluster=Ref("ClusterArn"),
-            CapacityProviderStrategy=[
-                CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
-            ],
+            # Singleton: spot-preferred with an on-demand FARGATE fallback so a
+            # transient FARGATE_SPOT shortage can't block its task and trip the
+            # deploy circuit breaker.
+            CapacityProviderStrategy=services_common.capacity_provider_strategy("fallback"),
             DesiredCount=1,
             TaskDefinition=Ref(task_def),
             NetworkConfiguration=NetworkConfiguration(

--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -372,6 +372,7 @@ def build() -> Template:
         subnets_csv_param="PrivateSubnetsCsv",
         security_group_id_param="TaskSecurityGroupId",
         container_name="keepalive",
+        capacity="fallback",
     )
     t.add_resource(migrator_service)
 

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -213,6 +213,31 @@ def _coerce_size(value):
     return value
 
 
+def capacity_provider_strategy(capacity: str = "spot") -> list:
+    """Capacity-provider strategy for an ECS Service.
+
+    "spot" (scalable workers): pure FARGATE_SPOT — cheapest, and a transient
+    spot shortage only delays/skips an extra replica, never a deploy-critical
+    singleton task.
+
+    "fallback" (singletons/critical services): spot-preferred but with an
+    on-demand FARGATE fallback so a momentary FARGATE_SPOT capacity shortage
+    can't block the one new task a rolling deploy needs, which would otherwise
+    trip the circuit breaker and roll the whole stack back. Weights heavily
+    prefer spot; FARGATE is present purely as a fallback.
+    """
+    if capacity == "fallback":
+        return [
+            CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=4),
+            CapacityProviderStrategyItem(CapacityProvider="FARGATE", Weight=1),
+        ]
+    if capacity == "spot":
+        return [
+            CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
+        ]
+    raise ValueError(f"unknown capacity mode: {capacity!r}")
+
+
 def build_ecs_service(
     *,
     service_key: str,
@@ -226,6 +251,7 @@ def build_ecs_service(
     container_port: int | None = None,
     service_registry_ref=None,
     listener_rule_refs: list | None = None,
+    capacity: str = "spot",
 ) -> Service:
     """ECS Fargate Service with rolling deploy + circuit breaker.
 
@@ -241,9 +267,7 @@ def build_ecs_service(
     """
     kwargs: dict = dict(
         Cluster=Ref(cluster_arn_param),
-        CapacityProviderStrategy=[
-            CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
-        ],
+        CapacityProviderStrategy=capacity_provider_strategy(capacity),
         DesiredCount=desired_count,
         TaskDefinition=Ref(task_definition_ref),
         NetworkConfiguration=NetworkConfiguration(

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -389,6 +389,7 @@ def build() -> Template:
             container_port=admin_container_port,
             service_registry_ref=admin_discovery,
             listener_rule_refs=[admin_listener_rule],
+            capacity="fallback",
         )
     )
     t.add_output(Output("AdminApiServiceName", Value=GetAtt(admin_service, "Name")))
@@ -523,6 +524,7 @@ def _build_internal_service_block(
             subnets_csv_param="PrivateSubnetsCsv",
             security_group_id_param="TaskSecurityGroupId",
             container_name=service_key,
+            capacity="fallback",
         )
     )
 

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -386,6 +386,10 @@ def build() -> Template:
             "memory_mib": pubsub_cfg["memory_mib"],
             "desired_count": Ref("PubsubSqsReplicas"),
             "output_name": "PubsubSqsServiceName",
+            # Singleton (no autoscaler): give it an on-demand FARGATE fallback
+            # so a transient FARGATE_SPOT shortage can't block its one task and
+            # trip the deploy circuit breaker. process-* stay pure spot.
+            "capacity": "fallback",
             # pubsub-sqs alone consumes SQS. The lakerunner binary reads the
             # primary queue (group 0) from three plain env vars. The image is
             # distroless (no shell), so these must be real container env vars,
@@ -417,6 +421,7 @@ def build() -> Template:
             base_env=base_env,
             base_secrets=base_secrets,
             extra_env=spec.get("extra_env"),
+            capacity=spec.get("capacity", "spot"),
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
 
@@ -435,6 +440,7 @@ def _build_service_block(
     base_env: list,
     base_secrets: list,
     extra_env: list | None = None,
+    capacity: str = "spot",
 ):
     """Wire up the three resources (log group, task def, service) for one service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
@@ -467,6 +473,7 @@ def _build_service_block(
             subnets_csv_param="PrivateSubnetsCsv",
             security_group_id_param="TaskSecurityGroupId",
             container_name=service_key,
+            capacity=capacity,
         )
     )
 

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -355,3 +355,11 @@ def test_all_services_disable_public_ip(td):
         assert awsvpc["AssignPublicIp"] == "DISABLED", (
             f"AssignPublicIp must be DISABLED; got {awsvpc['AssignPublicIp']!r}"
         )
+
+
+def test_service_has_ondemand_fallback(td):
+    # Maestro is a deploy-critical singleton: spot-preferred with an on-demand
+    # FARGATE fallback so a transient FARGATE_SPOT shortage can't fail a deploy.
+    svc = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service")
+    providers = {s["CapacityProvider"] for s in svc["Properties"]["CapacityProviderStrategy"]}
+    assert providers == {"FARGATE_SPOT", "FARGATE"}

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -196,13 +196,18 @@ def test_creates_ecs_service(template_dict):
 def test_service_runs_one_fargate_task_no_lb(template_dict):
     svc = _service(template_dict)["Properties"]
     assert "LaunchType" not in svc
-    assert svc["CapacityProviderStrategy"] == [
-        {"CapacityProvider": "FARGATE_SPOT", "Weight": 1}
-    ]
     assert svc["DesiredCount"] == 1
     assert svc["TaskDefinition"] == {"Ref": "MigratorTaskDef"}
     assert "LoadBalancers" not in svc
     assert "ServiceRegistries" not in svc
+
+
+def test_service_has_ondemand_fallback(template_dict):
+    # Singleton: spot-preferred but with an on-demand FARGATE fallback so a
+    # transient FARGATE_SPOT shortage can't fail the deploy.
+    svc = _service(template_dict)["Properties"]
+    providers = {s["CapacityProvider"] for s in svc["CapacityProviderStrategy"]}
+    assert providers == {"FARGATE_SPOT", "FARGATE"}
 
 
 def test_service_disables_public_ip(template_dict):

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -380,3 +380,24 @@ def test_no_shared_resources_in_services_control(td):
     }
     found = {r["Type"] for r in td["Resources"].values()} & forbidden
     assert not found, f"services-control must not own shared resources; found {found}"
+
+
+def _service_strategy(td, suffix):
+    res = next(
+        r for lid, r in td["Resources"].items()
+        if r["Type"] == "AWS::ECS::Service" and lid.endswith(suffix)
+    )
+    return {s["CapacityProvider"] for s in res["Properties"]["CapacityProviderStrategy"]}
+
+
+def test_singleton_services_have_ondemand_fallback(td):
+    # sweeper, monitoring, admin-api, alert-evaluator are deploy-critical
+    # singletons: spot-preferred with an on-demand FARGATE fallback so a
+    # transient FARGATE_SPOT shortage can't fail a rolling deploy.
+    for suffix in (
+        "SweeperService",
+        "MonitoringService",
+        "AdminApiService",
+        "AlertEvaluatorService",
+    ):
+        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -389,3 +389,24 @@ def test_no_shared_resources_in_services_process(td):
     }
     found = {r["Type"] for r in td["Resources"].values()} & forbidden
     assert not found, f"services-process must not own shared resources; found {found}"
+
+
+def _service_strategy(td, suffix):
+    res = next(
+        r for lid, r in td["Resources"].items()
+        if r["Type"] == "AWS::ECS::Service" and lid.endswith(suffix)
+    )
+    return {s["CapacityProvider"] for s in res["Properties"]["CapacityProviderStrategy"]}
+
+
+def test_pubsub_sqs_has_ondemand_fallback(td):
+    # pubsub-sqs is a non-autoscaled singleton: spot-preferred with an
+    # on-demand FARGATE fallback so a transient FARGATE_SPOT shortage can't
+    # fail a rolling deploy.
+    assert _service_strategy(td, "PubsubSqsService") == {"FARGATE_SPOT", "FARGATE"}
+
+
+def test_process_workers_are_spot_only(td):
+    # process-* are scalable workers: pure FARGATE_SPOT.
+    for suffix in ("ProcessLogsService", "ProcessMetricsService", "ProcessTracesService"):
+        assert _service_strategy(td, suffix) == {"FARGATE_SPOT"}, suffix

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -310,3 +310,17 @@ def test_no_shared_resources_in_services_query(td):
     }
     found = {r["Type"] for r in td["Resources"].values()} & forbidden
     assert not found, f"services-query must not own shared resources; found {found}"
+
+
+def _service_strategy(td, suffix):
+    res = next(
+        r for lid, r in td["Resources"].items()
+        if r["Type"] == "AWS::ECS::Service" and lid.endswith(suffix)
+    )
+    return {s["CapacityProvider"] for s in res["Properties"]["CapacityProviderStrategy"]}
+
+
+def test_query_workers_are_spot_only(td):
+    # query-api and query-worker are scalable workers: pure FARGATE_SPOT.
+    for suffix in ("QueryApiService", "QueryWorkerService"):
+        assert _service_strategy(td, suffix) == {"FARGATE_SPOT"}, suffix

--- a/tests/unit/test_services_common.py
+++ b/tests/unit/test_services_common.py
@@ -139,3 +139,36 @@ def test_build_ecs_service_uses_fargate_spot():
     assert props["CapacityProviderStrategy"] == [
         {"CapacityProvider": "FARGATE_SPOT", "Weight": 1}
     ]
+
+
+def test_build_ecs_service_fallback_capacity():
+    svc = services_common.build_ecs_service(
+        service_key="sweeper",
+        cluster_arn_param="ClusterArn",
+        task_definition_ref="MyTaskDef",
+        desired_count=1,
+        subnets_csv_param="PrivateSubnetsCsv",
+        security_group_id_param="TaskSecurityGroupId",
+        container_name="sweeper",
+        capacity="fallback",
+    )
+    rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
+    strat = rendered["Properties"]["CapacityProviderStrategy"]
+    assert strat == [
+        {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
+        {"CapacityProvider": "FARGATE", "Weight": 1},
+    ]
+
+
+def test_capacity_provider_strategy_modes():
+    assert services_common.capacity_provider_strategy("spot")[0].to_dict() == {
+        "CapacityProvider": "FARGATE_SPOT",
+        "Weight": 1,
+    }
+    fallback = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
+    assert fallback == [
+        {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
+        {"CapacityProvider": "FARGATE", "Weight": 1},
+    ]
+    with pytest.raises(ValueError):
+        services_common.capacity_provider_strategy("nope")


### PR DESCRIPTION
Singleton services (migration, pubsub-sqs, sweeper, monitoring, admin-api, alert-evaluator, maestro) now use CapacityProviderStrategy FARGATE_SPOT:4 + FARGATE:1 so a transient spot shortage falls back to on-demand instead of failing the deploy (observed: SweeperService 'Capacity is unavailable' → whole-stack rollback). Scalable workers (query-api/worker, process-*) stay pure FARGATE_SPOT. 451 passed.