### PR TITLE
Merge control singletons (sweeper/admin-api/alert-eval/monitoring) into one ECS task

### DIFF
--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -1,17 +1,23 @@
-"""services-control.yaml nested stack: lakerunner control-plane ECS services.
+"""services-control.yaml nested stack: lakerunner control-plane ECS service.
 
-Owns four ECS Fargate services:
+Owns a SINGLE ECS Fargate service running one task with four containers:
 
 - admin-api (ALB-attached on dedicated 9443 listener; path catch-all `/*`,
   also registered in Cloud Map as `admin-api.<namespace>:9091` so peers
   inside the cluster — currently just maestro — can reach it without
   hairpinning through the ALB and tripping the self-signed cert path)
 - sweeper (internal)
-- monitoring (internal; gRPC port not exposed on the ALB)
+- monitoring (internal; gRPC port not exposed on the ALB; drives ECS
+  autoscaling of the process-* services via ecs:UpdateService)
 - alert-evaluator (internal)
 
-These services run at fixed shape; CPU, memory, and replicas all come from
-cardinal-defaults.yaml. No per-service tunables are exposed at deployment time.
+These four control-plane components are tiny (~1-3 millicores, ~20-25 MiB
+each). Four separate Fargate tasks would each pay the 0.25 vCPU / 0.5 GB
+per-task floor; co-locating them in one task cuts that ~4x and means one task
+to place instead of four (a real win under spot scarcity). The task runs at a
+small fixed shape (256 CPU / 512 MiB); their combined real usage is ~7m / ~90Mi.
+All four containers are essential. CPU/memory/replicas are not exposed as
+deployment-time tunables.
 """
 
 from troposphere import (
@@ -22,7 +28,15 @@ from troposphere import (
     Sub,
     Template,
 )
-from troposphere.ecs import Environment, Secret
+from troposphere.ecs import (
+    ContainerDefinition,
+    Environment,
+    LogConfiguration,
+    PortMapping,
+    RuntimePlatform,
+    Secret,
+    TaskDefinition,
+)
 from troposphere.servicediscovery import (
     DnsConfig,
     DnsRecord,
@@ -32,17 +46,24 @@ from troposphere.servicediscovery import (
 from cardinal_cfn.children import services_common
 from cardinal_cfn.defaults import load_defaults
 from cardinal_cfn.images import add_image_override
+from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import (
     add_install_id_parameters,
     add_parameter_group_metadata,
 )
 
+# Task-level shape for the merged control service. Fargate's smallest valid
+# size; the four containers' combined steady-state usage is ~7m CPU / ~90Mi.
+CONTROL_TASK_CPU = "256"
+CONTROL_TASK_MEMORY = "512"
+
 
 def build() -> Template:
     t = Template()
     t.set_description(
-        "Cardinal services-control: lakerunner admin-api (ALB-attached), "
-        "sweeper, monitoring, and alert-evaluator ECS services."
+        "Cardinal services-control: a single ECS service running one task with "
+        "four containers — admin-api (ALB-attached), sweeper, monitoring, and "
+        "alert-evaluator."
     )
 
     defaults = load_defaults()
@@ -307,29 +328,11 @@ def build() -> Template:
     ]
 
     # ---------------------------------------------------------------------
-    # admin-api: ALB-attached
+    # Per-container env. Each container keeps EXACTLY the env it had when these
+    # were four separate services: base DB env + per-component OTel env +
+    # YAML-declared env + any component-specific extras.
     # ---------------------------------------------------------------------
-    admin_lg = t.add_resource(services_common.build_log_group(service_key="admin-api"))
-    admin_tg = t.add_resource(
-        services_common.build_target_group(
-            service_key="admin-api",
-            vpc_id_param="VpcId",
-            port=admin_container_port,
-            health_check_path=admin_health_path,
-        )
-    )
-    # admin-api gets a dedicated HTTPS listener (9443) so the lakerunner
-    # binary's mux sees request paths verbatim (no /admin/ prefix to strip).
-    # This is the only rule on that listener; the listener's default action
-    # is a 503 fixed response.
-    admin_listener_rule = t.add_resource(
-        services_common.build_listener_rule(
-            service_key="admin-api-https",
-            target_group_ref=admin_tg,
-            listener_arn_param="AdminHttpsListenerArn",
-            path_patterns=["/*"],
-        )
-    )
+    # admin-api: ALB-attached, owns the admin-key secret.
     admin_env = (
         list(base_env)
         + services_common.lakerunner_otel_env(service_key="admin-api")
@@ -345,21 +348,109 @@ def build() -> Template:
             ValueFrom=Sub("${AdminApiKeySecretArn}:key::"),
         ),
     ]
-    admin_task = t.add_resource(
-        services_common.build_task_definition(
+
+    sweeper_env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key="sweeper")
+        + _service_specific_env(sweeper_cfg)
+    )
+
+    # alert-evaluator reaches query-api over the in-cluster Cloud Map DNS.
+    # Container port is 8080 (matches lakerunner-query-api.ingress.container_port).
+    alert_env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key="alert-evaluator")
+        + _service_specific_env(alert_cfg)
+        + [
+            Environment(
+                Name="ALERT_EVALUATOR_QUERY_API_URL",
+                Value=Sub("http://query-api.${ServiceNamespaceName}:8080"),
+            ),
+        ]
+    )
+
+    # The monitoring container drives ECS autoscaling of the process-* services.
+    # Env vars match cmd/monitoring.go + config/autoscaler.go in the lakerunner
+    # repo; the shared TaskRole (ControlRole) carries the ecs:UpdateService /
+    # DescribeServices grant it needs.
+    # The lakerunner binary defaults Autoscaler.ObserveOnly=true and per-service
+    # MinReplicas=0, which would log decisions but never scale and would scale
+    # services to zero on idle. Override both: the customer set max replicas to
+    # opt into actual scaling, and 1 is the documented floor (lakerunner
+    # docs/guides/admin/autoscaling.md: "Set to 1 to prevent scale-to-zero").
+    monitoring_env = (
+        list(base_env)
+        + services_common.lakerunner_otel_env(service_key="monitoring")
+        + _service_specific_env(monitoring_cfg)
+        + [
+            Environment(Name="LAKERUNNER_AUTOSCALER_ENABLED", Value="true"),
+            Environment(Name="LAKERUNNER_AUTOSCALER_OBSERVE_ONLY", Value="false"),
+            Environment(Name="LAKERUNNER_AUTOSCALER_PLATFORM", Value="ecs"),
+            Environment(Name="ECS_CLUSTER", Value=Ref("ClusterName")),
+            Environment(
+                Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT",
+                Value=Ref("ProcessLogsServiceName"),
+            ),
+            Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS", Value="1"),
+            Environment(
+                Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS",
+                Value=Ref("ProcessLogsReplicas"),
+            ),
+            Environment(
+                Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT",
+                Value=Ref("ProcessMetricsServiceName"),
+            ),
+            Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS", Value="1"),
+            Environment(
+                Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS",
+                Value=Ref("ProcessMetricsReplicas"),
+            ),
+            Environment(
+                Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT",
+                Value=Ref("ProcessTracesServiceName"),
+            ),
+            Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS", Value="1"),
+            Environment(
+                Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS",
+                Value=Ref("ProcessTracesReplicas"),
+            ),
+        ]
+    )
+
+    # ---------------------------------------------------------------------
+    # Per-container log groups. KEEP the four familiar /cardinal/<svc> paths so
+    # operators' log queries don't change — one log group per container, four
+    # resources, one task.
+    # ---------------------------------------------------------------------
+    admin_lg = t.add_resource(services_common.build_log_group(service_key="admin-api"))
+    sweeper_lg = t.add_resource(services_common.build_log_group(service_key="sweeper"))
+    monitoring_lg = t.add_resource(services_common.build_log_group(service_key="monitoring"))
+    alert_lg = t.add_resource(services_common.build_log_group(service_key="alert-evaluator"))
+
+    # ---------------------------------------------------------------------
+    # ALB attachment for admin-api: dedicated HTTPS listener (9443) so the
+    # lakerunner binary's mux sees request paths verbatim (no /admin/ prefix to
+    # strip). This is the only rule on that listener; the listener's default
+    # action is a 503 fixed response. The ECS Service's LoadBalancers block
+    # (below) targets the admin-api CONTAINER inside the merged task.
+    # ---------------------------------------------------------------------
+    admin_tg = t.add_resource(
+        services_common.build_target_group(
             service_key="admin-api",
-            image_ref=image_ref,
-            cpu=admin_cfg["cpu"],
-            memory_mib=admin_cfg["memory_mib"],
-            command=admin_cfg.get("command"),
-            execution_role_arn_param="ExecutionRoleArn",
-            task_role_arn=Ref("TaskRoleArn"),
-            environment=admin_env,
-            secrets=admin_secrets,
-            log_group_ref=admin_lg,
-            container_port=admin_container_port,
+            vpc_id_param="VpcId",
+            port=admin_container_port,
+            health_check_path=admin_health_path,
         )
     )
+    admin_listener_rule = t.add_resource(
+        services_common.build_listener_rule(
+            service_key="admin-api-https",
+            target_group_ref=admin_tg,
+            listener_arn_param="AdminHttpsListenerArn",
+            path_patterns=["/*"],
+        )
+    )
+
     # Register admin-api in Cloud Map so peers in the cluster (maestro) can
     # reach it at http://admin-api.<namespace>:9091 without hairpinning out
     # to the ALB's 9443 HTTPS listener. The ALB attachment stays for the
@@ -376,12 +467,75 @@ def build() -> Template:
             ),
         )
     )
-    admin_service = t.add_resource(
+
+    # ---------------------------------------------------------------------
+    # One task definition, four essential containers. admin-api alone exposes a
+    # PortMapping (it's the LB target); the other three have no ports / no LB.
+    # ---------------------------------------------------------------------
+    control_task = t.add_resource(
+        TaskDefinition(
+            "ControlTaskDef",
+            RequiresCompatibilities=["FARGATE"],
+            NetworkMode="awsvpc",
+            RuntimePlatform=RuntimePlatform(
+                CpuArchitecture="ARM64",
+                OperatingSystemFamily="LINUX",
+            ),
+            Cpu=CONTROL_TASK_CPU,
+            Memory=CONTROL_TASK_MEMORY,
+            ExecutionRoleArn=Ref("ExecutionRoleArn"),
+            TaskRoleArn=Ref("TaskRoleArn"),
+            ContainerDefinitions=[
+                _container(
+                    name="admin-api",
+                    config=admin_cfg,
+                    image_ref=image_ref,
+                    environment=admin_env,
+                    secrets=admin_secrets,
+                    log_group_ref=admin_lg,
+                    container_port=admin_container_port,
+                ),
+                _container(
+                    name="sweeper",
+                    config=sweeper_cfg,
+                    image_ref=image_ref,
+                    environment=sweeper_env,
+                    secrets=base_secrets,
+                    log_group_ref=sweeper_lg,
+                ),
+                _container(
+                    name="monitoring",
+                    config=monitoring_cfg,
+                    image_ref=image_ref,
+                    environment=monitoring_env,
+                    secrets=base_secrets,
+                    log_group_ref=monitoring_lg,
+                ),
+                _container(
+                    name="alert-evaluator",
+                    config=alert_cfg,
+                    image_ref=image_ref,
+                    environment=alert_env,
+                    secrets=base_secrets,
+                    log_group_ref=alert_lg,
+                ),
+            ],
+            Tags=cardinal_tags(component="compute", role="control"),
+        )
+    )
+
+    # ---------------------------------------------------------------------
+    # The single control service. LoadBalancers targets the admin-api container;
+    # ServiceRegistries puts the task's IP in Cloud Map as admin-api.<ns>.
+    # fallback capacity: spot-preferred with an on-demand FARGATE fallback so a
+    # transient FARGATE_SPOT shortage can't fail the one task a deploy needs.
+    # ---------------------------------------------------------------------
+    control_service = t.add_resource(
         services_common.build_ecs_service(
-            service_key="admin-api",
+            service_key="control",
             cluster_arn_param="ClusterArn",
-            task_definition_ref=admin_task,
-            desired_count=int(admin_cfg["replicas"]),
+            task_definition_ref=control_task,
+            desired_count=1,
             subnets_csv_param="PrivateSubnetsCsv",
             security_group_id_param="TaskSecurityGroupId",
             target_group_ref=admin_tg,
@@ -392,141 +546,49 @@ def build() -> Template:
             capacity="fallback",
         )
     )
-    t.add_output(Output("AdminApiServiceName", Value=GetAtt(admin_service, "Name")))
-
-    # ---------------------------------------------------------------------
-    # Internal services (no ALB attachment)
-    # ---------------------------------------------------------------------
-    # alert-evaluator reaches query-api over the in-cluster Cloud Map DNS.
-    # Container port is 8080 (matches lakerunner-query-api.ingress.container_port).
-    alert_extra_env = [
-        Environment(
-            Name="ALERT_EVALUATOR_QUERY_API_URL",
-            Value=Sub("http://query-api.${ServiceNamespaceName}:8080"),
-        ),
-    ]
-
-    # The monitoring service drives ECS autoscaling of the process-* services.
-    # Env vars match cmd/monitoring.go + config/autoscaler.go in the lakerunner
-    # repo; IAM is scoped per-service to UpdateService/DescribeServices.
-    # The lakerunner binary defaults Autoscaler.ObserveOnly=true and per-service
-    # MinReplicas=0, which would log decisions but never scale and would scale
-    # services to zero on idle. Override both: the customer set max replicas to
-    # opt into actual scaling, and 1 is the documented floor (lakerunner
-    # docs/guides/admin/autoscaling.md: "Set to 1 to prevent scale-to-zero").
-    monitoring_extra_env = [
-        Environment(Name="LAKERUNNER_AUTOSCALER_ENABLED", Value="true"),
-        Environment(Name="LAKERUNNER_AUTOSCALER_OBSERVE_ONLY", Value="false"),
-        Environment(Name="LAKERUNNER_AUTOSCALER_PLATFORM", Value="ecs"),
-        Environment(Name="ECS_CLUSTER", Value=Ref("ClusterName")),
-        Environment(
-            Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_DEPLOYMENT",
-            Value=Ref("ProcessLogsServiceName"),
-        ),
-        Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MIN_REPLICAS", Value="1"),
-        Environment(
-            Name="LAKERUNNER_AUTOSCALER_SERVICES_LOGS_MAX_REPLICAS",
-            Value=Ref("ProcessLogsReplicas"),
-        ),
-        Environment(
-            Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_DEPLOYMENT",
-            Value=Ref("ProcessMetricsServiceName"),
-        ),
-        Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MIN_REPLICAS", Value="1"),
-        Environment(
-            Name="LAKERUNNER_AUTOSCALER_SERVICES_METRICS_MAX_REPLICAS",
-            Value=Ref("ProcessMetricsReplicas"),
-        ),
-        Environment(
-            Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_DEPLOYMENT",
-            Value=Ref("ProcessTracesServiceName"),
-        ),
-        Environment(Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MIN_REPLICAS", Value="1"),
-        Environment(
-            Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS",
-            Value=Ref("ProcessTracesReplicas"),
-        ),
-    ]
-    internal_services = [
-        {
-            "service_key": "sweeper",
-            "config": sweeper_cfg,
-            "output_name": "SweeperServiceName",
-            "extra_env": [],
-        },
-        {
-            "service_key": "monitoring",
-            "config": monitoring_cfg,
-            "output_name": "MonitoringServiceName",
-            "extra_env": monitoring_extra_env,
-        },
-        {
-            "service_key": "alert-evaluator",
-            "config": alert_cfg,
-            "output_name": "AlertEvaluatorServiceName",
-            "extra_env": alert_extra_env,
-        },
-    ]
-
-    for spec in internal_services:
-        ecs_service = _build_internal_service_block(
-            t,
-            service_key=spec["service_key"],
-            config=spec["config"],
-            image_ref=image_ref,
-            base_env=base_env,
-            base_secrets=base_secrets,
-            extra_env=spec["extra_env"],
-        )
-        t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
+    t.add_output(Output("ControlServiceName", Value=GetAtt(control_service, "Name")))
 
     return t
 
 
-def _build_internal_service_block(
-    t: Template,
+def _container(
     *,
-    service_key: str,
+    name: str,
     config: dict,
     image_ref,
-    base_env: list,
-    base_secrets: list,
-    extra_env: list | None = None,
-):
-    """Wire up log group, task def, and ECS service for one internal service."""
-    log_group = t.add_resource(services_common.build_log_group(service_key=service_key))
-    env = (
-        list(base_env)
-        + services_common.lakerunner_otel_env(service_key=service_key)
-        + _service_specific_env(config)
-        + list(extra_env or [])
+    environment: list,
+    secrets: list,
+    log_group_ref,
+    container_port: int | None = None,
+) -> ContainerDefinition:
+    """One essential container in the merged control task.
+
+    Each container keeps its own command (from cardinal-defaults.yaml), env,
+    secrets, and a LogConfiguration pointing at its own /cardinal/<name> log
+    group. container_port is set only for admin-api (the LB target); the other
+    three expose no ports.
+    """
+    kwargs = dict(
+        Name=name,
+        Image=image_ref,
+        Essential=True,
+        Environment=environment,
+        Secrets=secrets,
+        LogConfiguration=LogConfiguration(
+            LogDriver="awslogs",
+            Options={
+                "awslogs-group": Ref(log_group_ref),
+                "awslogs-region": Ref("AWS::Region"),
+                "awslogs-stream-prefix": name,
+            },
+        ),
     )
-    task_def = t.add_resource(
-        services_common.build_task_definition(
-            service_key=service_key,
-            image_ref=image_ref,
-            cpu=config["cpu"],
-            memory_mib=config["memory_mib"],
-            command=config.get("command"),
-            execution_role_arn_param="ExecutionRoleArn",
-            task_role_arn=Ref("TaskRoleArn"),
-            environment=env,
-            secrets=base_secrets,
-            log_group_ref=log_group,
-        )
-    )
-    return t.add_resource(
-        services_common.build_ecs_service(
-            service_key=service_key,
-            cluster_arn_param="ClusterArn",
-            task_definition_ref=task_def,
-            desired_count=int(config["replicas"]),
-            subnets_csv_param="PrivateSubnetsCsv",
-            security_group_id_param="TaskSecurityGroupId",
-            container_name=service_key,
-            capacity="fallback",
-        )
-    )
+    command = config.get("command")
+    if command:
+        kwargs["Command"] = command
+    if container_port is not None:
+        kwargs["PortMappings"] = [PortMapping(ContainerPort=container_port, Protocol="tcp")]
+    return ContainerDefinition(**kwargs)
 
 
 def _service_specific_env(service_cfg: dict) -> list:

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -84,24 +84,51 @@ def test_no_per_service_tunable_parameters(td):
 # ---------------------------------------------------------------------------
 
 
-def test_creates_four_ecs_services(td):
+def test_creates_single_merged_ecs_service(td):
+    """The four control-plane singletons are co-located in ONE ECS service
+    running ONE task with four containers — cutting the per-task Fargate floor
+    ~4x and leaving one task to place instead of four."""
     services = [r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service"]
-    assert len(services) == 4
+    assert len(services) == 1
 
 
-def test_expected_service_logical_ids_present(td):
-    expected_suffixes = {
-        "AdminApiService",
-        "SweeperService",
-        "MonitoringService",
-        "AlertEvaluatorService",
-    }
+def test_control_service_logical_id_present(td):
     found = {
         logical_id
         for logical_id, res in td["Resources"].items()
         if res["Type"] == "AWS::ECS::Service"
     }
-    assert expected_suffixes <= found, f"missing services; got: {found}"
+    assert found == {"ControlService"}, f"expected only ControlService; got: {found}"
+
+
+def test_single_task_has_four_essential_containers(td):
+    task_defs = [r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"]
+    assert len(task_defs) == 1
+    containers = task_defs[0]["Properties"]["ContainerDefinitions"]
+    names = {c["Name"] for c in containers}
+    assert names == {"admin-api", "sweeper", "monitoring", "alert-evaluator"}
+    for c in containers:
+        assert c["Essential"] is True, f"{c['Name']} must be essential"
+
+
+def test_merged_task_uses_fixed_minimum_shape(td):
+    """256 CPU / 512 MiB — Fargate's floor; the four containers' combined real
+    usage is ~7m / ~90Mi. ARM64/LINUX, awsvpc, FARGATE."""
+    task = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    props = task["Properties"]
+    assert props["Cpu"] == "256"
+    assert props["Memory"] == "512"
+    assert props["NetworkMode"] == "awsvpc"
+    assert props["RequiresCompatibilities"] == ["FARGATE"]
+    assert props["RuntimePlatform"]["CpuArchitecture"] == "ARM64"
+    assert props["RuntimePlatform"]["OperatingSystemFamily"] == "LINUX"
+
+
+def test_merged_task_uses_shared_exec_and_control_roles(td):
+    task = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    props = task["Properties"]
+    assert props["ExecutionRoleArn"] == {"Ref": "ExecutionRoleArn"}
+    assert props["TaskRoleArn"] == {"Ref": "TaskRoleArn"}
 
 
 def test_only_one_target_group_and_one_listener_rule(td):
@@ -164,13 +191,14 @@ def test_admin_api_discovery_service_registered(td):
     assert any(r["Type"] == "A" for r in records)
 
 
-def test_admin_api_service_has_service_registries(td):
-    """The admin-api ECS service must reference the discovery service so
-    its task IPs land in DNS."""
+def test_control_service_has_service_registries(td):
+    """The merged control ECS service registers in Cloud Map (its admin-api
+    container's IP) so peers in the cluster (maestro) can reach it without
+    going through the ALB."""
     svc = next(
         res
         for logical_id, res in td["Resources"].items()
-        if res["Type"] == "AWS::ECS::Service" and logical_id.endswith("AdminApiService")
+        if res["Type"] == "AWS::ECS::Service" and logical_id == "ControlService"
     )
     assert "ServiceRegistries" in svc["Properties"]
     arn = svc["Properties"]["ServiceRegistries"][0]["RegistryArn"]
@@ -182,15 +210,15 @@ def test_admin_api_service_has_service_registries(td):
 # ---------------------------------------------------------------------------
 
 
-def _service_by_logical_id(td, suffix):
-    for logical_id, res in td["Resources"].items():
-        if res["Type"] == "AWS::ECS::Service" and logical_id.endswith(suffix):
-            return res
-    raise AssertionError(f"no ECS service with logical id ending in {suffix}")
+def _control_service(td):
+    return td["Resources"]["ControlService"]
 
 
-def test_admin_api_service_has_load_balancers(td):
-    svc = _service_by_logical_id(td, "AdminApiService")
+def test_control_service_load_balancer_targets_admin_api_container(td):
+    """The single merged service's LoadBalancers block targets the admin-api
+    CONTAINER (and only it) inside the task; the other three containers have no
+    ports and no LB attachment."""
+    svc = _control_service(td)
     assert "LoadBalancers" in svc["Properties"]
     assert len(svc["Properties"]["LoadBalancers"]) == 1
     lb = svc["Properties"]["LoadBalancers"][0]
@@ -198,12 +226,13 @@ def test_admin_api_service_has_load_balancers(td):
     assert lb["ContainerPort"] == 9091
 
 
-def test_internal_services_have_no_load_balancers(td):
-    for suffix in ("SweeperService", "MonitoringService", "AlertEvaluatorService"):
-        svc = _service_by_logical_id(td, suffix)
-        assert "LoadBalancers" not in svc["Properties"], (
-            f"{suffix} unexpectedly has LoadBalancers"
-        )
+def test_only_admin_api_container_exposes_a_port(td):
+    task = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    for c in task["Properties"]["ContainerDefinitions"]:
+        if c["Name"] == "admin-api":
+            assert c.get("PortMappings") == [{"ContainerPort": 9091, "Protocol": "tcp"}]
+        else:
+            assert "PortMappings" not in c, f"{c['Name']} unexpectedly has a port"
 
 
 # ---------------------------------------------------------------------------
@@ -211,13 +240,33 @@ def test_internal_services_have_no_load_balancers(td):
 # ---------------------------------------------------------------------------
 
 
-def test_each_service_has_unique_log_group_with_14_day_retention(td):
+def test_each_container_has_unique_log_group_with_14_day_retention(td):
+    """Per-container log groups are KEPT (one task, four groups) so operators'
+    familiar /cardinal/<svc> log paths don't change."""
     log_groups = [r for r in td["Resources"].values() if r["Type"] == "AWS::Logs::LogGroup"]
     assert len(log_groups) == 4
     for lg in log_groups:
         assert lg["Properties"]["RetentionInDays"] == 14
-    names = {json.dumps(lg["Properties"].get("LogGroupName")) for lg in log_groups}
-    assert len(names) == 4, "log groups must have distinct names"
+    names = {lg["Properties"]["LogGroupName"] for lg in log_groups}
+    assert names == {
+        "/cardinal/admin-api",
+        "/cardinal/sweeper",
+        "/cardinal/monitoring",
+        "/cardinal/alert-evaluator",
+    }
+
+
+def test_each_container_logs_to_its_own_group(td):
+    """Each container's awslogs LogConfiguration points at its own group."""
+    task = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    for c in task["Properties"]["ContainerDefinitions"]:
+        opts = c["LogConfiguration"]["Options"]
+        assert opts["awslogs-group"] == {"Ref": _log_group_id(c["Name"])}
+        assert opts["awslogs-stream-prefix"] == c["Name"]
+
+
+def _log_group_id(container_name):
+    return "".join(p.capitalize() for p in container_name.split("-")) + "LogGroup"
 
 
 def test_no_internally_managed_iam_roles(td):
@@ -231,19 +280,36 @@ def test_no_internally_managed_iam_roles(td):
 # ---------------------------------------------------------------------------
 
 
-def test_four_task_definitions(td):
+def test_single_task_definition(td):
     task_defs = [r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"]
-    assert len(task_defs) == 4
+    assert len(task_defs) == 1
 
 
-def test_task_definition_cpu_and_memory_come_from_yaml(td):
-    """All four control-plane services use YAML-fixed Cpu and Memory."""
-    task_defs = [r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"]
-    for td_res in task_defs:
-        cpu = td_res["Properties"]["Cpu"]
-        mem = td_res["Properties"]["Memory"]
-        assert not isinstance(cpu, dict), f"Cpu unexpectedly templated: {cpu!r}"
-        assert not isinstance(mem, dict), f"Memory unexpectedly templated: {mem!r}"
+def test_task_definition_cpu_and_memory_are_fixed(td):
+    """The merged control task uses a fixed minimum Cpu/Memory (not templated)."""
+    task = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
+    cpu = task["Properties"]["Cpu"]
+    mem = task["Properties"]["Memory"]
+    assert not isinstance(cpu, dict), f"Cpu unexpectedly templated: {cpu!r}"
+    assert not isinstance(mem, dict), f"Memory unexpectedly templated: {mem!r}"
+
+
+def test_admin_api_container_has_admin_key_secret(td):
+    """The admin-api container keeps its ADMIN_INITIAL_API_KEY secret sourced
+    from the AdminApiKeySecretArn parameter."""
+    _, container = _task_def_for(td, "admin-api")
+    secrets = {s["Name"]: s["ValueFrom"] for s in container.get("Secrets", [])}
+    assert "ADMIN_INITIAL_API_KEY" in secrets
+    assert secrets["ADMIN_INITIAL_API_KEY"] == {
+        "Fn::Sub": "${AdminApiKeySecretArn}:key::"
+    }
+
+
+def test_only_admin_api_container_has_admin_key_secret(td):
+    for name in ("sweeper", "monitoring", "alert-evaluator"):
+        _, container = _task_def_for(td, name)
+        names = {s["Name"] for s in container.get("Secrets", [])}
+        assert "ADMIN_INITIAL_API_KEY" not in names, f"{name} unexpectedly has admin key"
 
 
 # ---------------------------------------------------------------------------
@@ -251,14 +317,17 @@ def test_task_definition_cpu_and_memory_come_from_yaml(td):
 # ---------------------------------------------------------------------------
 
 
-def test_outputs_required(td):
+def test_outputs_reduced_to_single_control_service_name(td):
+    """The four per-service-name outputs collapse to one ControlServiceName.
+    The root consumes none of the old per-service outputs, so this is safe."""
+    assert "ControlServiceName" in td["Outputs"]
     for n in (
         "AdminApiServiceName",
         "SweeperServiceName",
         "MonitoringServiceName",
         "AlertEvaluatorServiceName",
     ):
-        assert n in td["Outputs"], f"missing output: {n}"
+        assert n not in td["Outputs"], f"vestigial per-service output present: {n}"
 
 
 # ---------------------------------------------------------------------------
@@ -382,22 +451,10 @@ def test_no_shared_resources_in_services_control(td):
     assert not found, f"services-control must not own shared resources; found {found}"
 
 
-def _service_strategy(td, suffix):
-    res = next(
-        r for lid, r in td["Resources"].items()
-        if r["Type"] == "AWS::ECS::Service" and lid.endswith(suffix)
-    )
-    return {s["CapacityProvider"] for s in res["Properties"]["CapacityProviderStrategy"]}
-
-
-def test_singleton_services_have_ondemand_fallback(td):
-    # sweeper, monitoring, admin-api, alert-evaluator are deploy-critical
-    # singletons: spot-preferred with an on-demand FARGATE fallback so a
-    # transient FARGATE_SPOT shortage can't fail a rolling deploy.
-    for suffix in (
-        "SweeperService",
-        "MonitoringService",
-        "AdminApiService",
-        "AlertEvaluatorService",
-    ):
-        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
+def test_control_service_has_ondemand_fallback(td):
+    # The merged control service is a deploy-critical singleton: spot-preferred
+    # with an on-demand FARGATE fallback so a transient FARGATE_SPOT shortage
+    # can't fail the one task a rolling deploy needs.
+    svc = td["Resources"]["ControlService"]
+    strategy = {s["CapacityProvider"] for s in svc["Properties"]["CapacityProviderStrategy"]}
+    assert strategy == {"FARGATE_SPOT", "FARGATE"}


### PR DESCRIPTION
Collapses the four tiny control services (~7m CPU / ~90Mi total) into one ControlService with 4 containers: ~4x cheaper (Fargate 0.25vCPU/0.5GB floor x4 -> x1) and 1 task to place instead of 4 under spot scarcity. admin-api keeps its ALB target; ControlRole unchanged; per-container log groups kept. 457 passed. Charts equivalent: cardinalhq/charts#176.