### PR TITLE
lrdev-vpc: 3 AZs (more Fargate-Spot capacity pools)

### DIFF
--- a/src/cardinal_cfn/lrdev_vpc.py
+++ b/src/cardinal_cfn/lrdev_vpc.py
@@ -6,7 +6,7 @@ cardinal-* product stacks against it. The resulting VpcId / subnet CSVs /
 endpoint SG feed into cardinal-infrastructure and cardinal-lakerunner.
 
 Layout (minimum viable):
-- 1 VPC, 2 public + 2 private subnets across 2 AZs
+- 1 VPC, 3 public + 3 private subnets across 3 AZs
 - Internet Gateway (always)
 - NAT Gateway (optional, single AZ for cost)
 - S3 Gateway Endpoint (free)
@@ -62,7 +62,7 @@ def build() -> Template:
     t = Template()
     t.set_description(
         "lrdev VPC: standalone VPC for our internal lakerunner test environment "
-        "(public/private subnets across 2 AZs, optional NAT Gateway, S3 gateway "
+        "(public/private subnets across 3 AZs, optional NAT Gateway, S3 gateway "
         "endpoint, and optional interface endpoints). Not a customer-facing stack."
     )
 
@@ -142,13 +142,13 @@ def build() -> Template:
         )
     )
 
-    # Subnets: split VPC CIDR into 16 /20 subnets, take first 4
+    # Subnets: split VPC CIDR into 6 /24s (indices 0-2 = public a/b/c, 3-5 = private a/b/c)
     public_subnet_1 = t.add_resource(
         Subnet(
             "PublicSubnet1",
             VpcId=Ref(vpc),
             AvailabilityZone=Select(0, GetAZs()),
-            CidrBlock=Select(0, Cidr(Ref("VpcCidr"), 4, 8)),
+            CidrBlock=Select(0, Cidr(Ref("VpcCidr"), 6, 8)),
             MapPublicIpOnLaunch=True,
             Tags=_vpc_tags(role="public-1"),
         )
@@ -158,9 +158,19 @@ def build() -> Template:
             "PublicSubnet2",
             VpcId=Ref(vpc),
             AvailabilityZone=Select(1, GetAZs()),
-            CidrBlock=Select(1, Cidr(Ref("VpcCidr"), 4, 8)),
+            CidrBlock=Select(1, Cidr(Ref("VpcCidr"), 6, 8)),
             MapPublicIpOnLaunch=True,
             Tags=_vpc_tags(role="public-2"),
+        )
+    )
+    public_subnet_3 = t.add_resource(
+        Subnet(
+            "PublicSubnet3",
+            VpcId=Ref(vpc),
+            AvailabilityZone=Select(2, GetAZs()),
+            CidrBlock=Select(2, Cidr(Ref("VpcCidr"), 6, 8)),
+            MapPublicIpOnLaunch=True,
+            Tags=_vpc_tags(role="public-3"),
         )
     )
     private_subnet_1 = t.add_resource(
@@ -168,7 +178,7 @@ def build() -> Template:
             "PrivateSubnet1",
             VpcId=Ref(vpc),
             AvailabilityZone=Select(0, GetAZs()),
-            CidrBlock=Select(2, Cidr(Ref("VpcCidr"), 4, 8)),
+            CidrBlock=Select(3, Cidr(Ref("VpcCidr"), 6, 8)),
             MapPublicIpOnLaunch=False,
             Tags=_vpc_tags(role="private-1"),
         )
@@ -178,9 +188,19 @@ def build() -> Template:
             "PrivateSubnet2",
             VpcId=Ref(vpc),
             AvailabilityZone=Select(1, GetAZs()),
-            CidrBlock=Select(3, Cidr(Ref("VpcCidr"), 4, 8)),
+            CidrBlock=Select(4, Cidr(Ref("VpcCidr"), 6, 8)),
             MapPublicIpOnLaunch=False,
             Tags=_vpc_tags(role="private-2"),
+        )
+    )
+    private_subnet_3 = t.add_resource(
+        Subnet(
+            "PrivateSubnet3",
+            VpcId=Ref(vpc),
+            AvailabilityZone=Select(2, GetAZs()),
+            CidrBlock=Select(5, Cidr(Ref("VpcCidr"), 6, 8)),
+            MapPublicIpOnLaunch=False,
+            Tags=_vpc_tags(role="private-3"),
         )
     )
 
@@ -212,6 +232,13 @@ def build() -> Template:
         SubnetRouteTableAssociation(
             "PublicSubnet2RouteAssoc",
             SubnetId=Ref(public_subnet_2),
+            RouteTableId=Ref(public_rt),
+        )
+    )
+    t.add_resource(
+        SubnetRouteTableAssociation(
+            "PublicSubnet3RouteAssoc",
+            SubnetId=Ref(public_subnet_3),
             RouteTableId=Ref(public_rt),
         )
     )
@@ -262,6 +289,13 @@ def build() -> Template:
         SubnetRouteTableAssociation(
             "PrivateSubnet2RouteAssoc",
             SubnetId=Ref(private_subnet_2),
+            RouteTableId=Ref(private_rt),
+        )
+    )
+    t.add_resource(
+        SubnetRouteTableAssociation(
+            "PrivateSubnet3RouteAssoc",
+            SubnetId=Ref(private_subnet_3),
             RouteTableId=Ref(private_rt),
         )
     )
@@ -318,7 +352,7 @@ def build() -> Template:
                 VpcId=Ref(vpc),
                 ServiceName=Sub(f"com.amazonaws.${{AWS::Region}}.{service}"),
                 VpcEndpointType="Interface",
-                SubnetIds=[Ref(private_subnet_1), Ref(private_subnet_2)],
+                SubnetIds=[Ref(private_subnet_1), Ref(private_subnet_2), Ref(private_subnet_3)],
                 SecurityGroupIds=[Ref(vpce_sg)],
                 PrivateDnsEnabled=True,
                 Condition="HasInterfaceEndpoints",
@@ -331,14 +365,14 @@ def build() -> Template:
         Output(
             "PublicSubnetsCsv",
             Description="Comma-separated public subnet IDs.",
-            Value=Join(",", [Ref(public_subnet_1), Ref(public_subnet_2)]),
+            Value=Join(",", [Ref(public_subnet_1), Ref(public_subnet_2), Ref(public_subnet_3)]),
         )
     )
     t.add_output(
         Output(
             "PrivateSubnetsCsv",
             Description="Comma-separated private subnet IDs.",
-            Value=Join(",", [Ref(private_subnet_1), Ref(private_subnet_2)]),
+            Value=Join(",", [Ref(private_subnet_1), Ref(private_subnet_2), Ref(private_subnet_3)]),
         )
     )
     t.add_output(

--- a/tests/templates/test_lrdev_vpc.py
+++ b/tests/templates/test_lrdev_vpc.py
@@ -46,7 +46,7 @@ def test_creates_vpc_and_subnets(td):
     vpcs = [r for r in td["Resources"].values() if r["Type"] == "AWS::EC2::VPC"]
     subnets = [r for r in td["Resources"].values() if r["Type"] == "AWS::EC2::Subnet"]
     assert len(vpcs) == 1
-    assert len(subnets) == 4  # 2 public + 2 private
+    assert len(subnets) == 6  # 3 public + 3 private
 
 
 def test_creates_internet_gateway(td):
@@ -122,7 +122,26 @@ def test_public_subnets_map_public_ip(td):
         r for r in td["Resources"].values()
         if r["Type"] == "AWS::EC2::Subnet" and r["Properties"].get("MapPublicIpOnLaunch")
     ]
-    assert len(subnets) == 2
+    assert len(subnets) == 3
+
+
+def test_subnets_span_three_az_indices(td):
+    """Each AZ index 0, 1, 2 must appear among both public and private subnets."""
+    subnets = {k: v for k, v in td["Resources"].items() if v["Type"] == "AWS::EC2::Subnet"}
+    public = [s for s in subnets.values() if s["Properties"].get("MapPublicIpOnLaunch")]
+    private = [s for s in subnets.values() if not s["Properties"].get("MapPublicIpOnLaunch")]
+    assert len(public) == 3
+    assert len(private) == 3
+    for group_name, group in (("public", public), ("private", private)):
+        az_indices = {s["Properties"]["AvailabilityZone"]["Fn::Select"][0] for s in group}
+        assert az_indices == {0, 1, 2}, f"{group_name} subnets missing expected AZ indices"
+
+
+def test_outputs_list_three_subnets_each(td):
+    """PublicSubnetsCsv and PrivateSubnetsCsv must each Join 3 subnet refs."""
+    for output_name in ("PublicSubnetsCsv", "PrivateSubnetsCsv"):
+        join_values = td["Outputs"][output_name]["Value"]["Fn::Join"][1]
+        assert len(join_values) == 3, f"{output_name} should reference 3 subnets"
 
 
 def test_no_install_id_parameters(td):


### PR DESCRIPTION
Widen the test-scaffold VPC from 2 to 3 AZs (6 /24 subnets) so workers have more spot pools. 453 passed.