### PR TITLE
Fix stale template base URL default in deploy scripts

### DIFF
--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -12,7 +12,7 @@
 set -eu
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
-DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-base.yaml"
 
 usage() {

--- a/scripts/deploy-lakerunner-infra-rds.sh
+++ b/scripts/deploy-lakerunner-infra-rds.sh
@@ -11,7 +11,7 @@
 set -eu
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
-DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-rds.yaml"
 
 usage() {

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -19,7 +19,7 @@
 set -eu
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
-DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-services.yaml"
 
 usage() {

--- a/scripts/deploy-lakerunner.sh
+++ b/scripts/deploy-lakerunner.sh
@@ -15,7 +15,7 @@
 
 set -eu
 
-DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
 # There is no "latest" tag in the published template bucket -- only versioned
@@ -63,7 +63,7 @@ Required:
   --version   VERSION         Published template tag, e.g. v0.0.38.
 
 Optional (both modes):
-  --template-base-url URL     Default: https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner
+  --template-base-url URL     Default: https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner
   --deployer-role-arn ARN     Pass via --role-arn to create-change-set.
   --no-refresh-image-defaults UPDATE only: carry image params forward.
   --no-execute                Create and describe the change set, then stop.

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -12,7 +12,7 @@
 set -eu
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
-DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-infra-base.yaml"
 
 usage() {

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -14,7 +14,7 @@
 set -eu
 
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
-DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner"
+DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-services.yaml"
 
 usage() {


### PR DESCRIPTION
All deploy-*.sh defaulted TEMPLATE_BASE_URL to the old `cardinal-cfn.s3.us-east-2` bucket, which 404s — the release workflow and cleanup-lakerunner.sh both use `cardinal-cfn-us-east-1.s3.us-east-1`. A customer running the deploy scripts with defaults would hit 404s on every template fetch. Aligns the deploy scripts with the actual publish bucket.