### PR TITLE
Fix fallback capacity: Base=1 on-demand so singleton deploys never block on spot

### DIFF
--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -220,16 +220,31 @@ def capacity_provider_strategy(capacity: str = "spot") -> list:
     spot shortage only delays/skips an extra replica, never a deploy-critical
     singleton task.
 
-    "fallback" (singletons/critical services): spot-preferred but with an
-    on-demand FARGATE fallback so a momentary FARGATE_SPOT capacity shortage
-    can't block the one new task a rolling deploy needs, which would otherwise
-    trip the circuit breaker and roll the whole stack back. Weights heavily
-    prefer spot; FARGATE is present purely as a fallback.
+    "fallback" (singletons/critical services): on-demand FARGATE for the first
+    task, spot-preferred for any scale-out beyond it. The crux is Base=1 on
+    FARGATE, not the weights.
+
+    Weights ALONE do not fail over for a singleton. ECS capacity-provider
+    weights only distribute MULTIPLE tasks across providers; for a single task
+    (DesiredCount=1) ECS picks ONE provider by weight, and if that provider
+    (FARGATE_SPOT) has no capacity right now the task simply fails to place —
+    tripping the deployment circuit breaker and rolling the stack back. A
+    rolling deploy must place at least one NEW task before draining the old,
+    so every desired>=1 service hits this singleton-placement window on a dry
+    spot moment, regardless of steady-state replica count.
+
+    Base=1 on FARGATE guarantees the FIRST task of every service lands on
+    on-demand (reliable). For desired=1 singletons that one task is always on
+    on-demand. For scalable services (desired N>1) one task is on-demand and
+    the remaining N-1 are weighted 4:1 toward spot. Only one provider in a
+    strategy may carry Base>0; it lives on FARGATE here.
     """
     if capacity == "fallback":
         return [
+            CapacityProviderStrategyItem(
+                CapacityProvider="FARGATE", Base=1, Weight=1
+            ),
             CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=4),
-            CapacityProviderStrategyItem(CapacityProvider="FARGATE", Weight=1),
         ]
     if capacity == "spot":
         return [

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -421,7 +421,12 @@ def build() -> Template:
             base_env=base_env,
             base_secrets=base_secrets,
             extra_env=spec.get("extra_env"),
-            capacity=spec.get("capacity", "spot"),
+            # Every deploy-critical service needs a guaranteed on-demand first
+            # replica (Base=1) so a rolling upgrade can place its first NEW task
+            # even in a transient FARGATE_SPOT shortage; scale-out replicas stay
+            # spot-weighted. process-{logs,metrics,traces} default to fallback;
+            # pubsub already sets it explicitly.
+            capacity=spec.get("capacity", "fallback"),
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
 

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -296,6 +296,10 @@ def build() -> Template:
             subnets_csv_param="PrivateSubnetsCsv",
             security_group_id_param="TaskSecurityGroupId",
             container_name="query-worker",
+            # Base=1 guarantees the first NEW task of a rolling upgrade lands on
+            # on-demand even in a transient FARGATE_SPOT shortage; the remaining
+            # scale-out replicas stay spot-weighted (~85-90% spot).
+            capacity="fallback",
         )
     )
 
@@ -402,6 +406,9 @@ def build() -> Template:
             container_port=api_container_port,
             service_registry_ref=api_discovery,
             listener_rule_refs=[api_listener_rule],
+            # Base=1 on-demand first replica for reliable rolling upgrades;
+            # scale-out replicas stay spot-weighted.
+            capacity="fallback",
         )
     )
 

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -358,8 +358,11 @@ def test_all_services_disable_public_ip(td):
 
 
 def test_service_has_ondemand_fallback(td):
-    # Maestro is a deploy-critical singleton: spot-preferred with an on-demand
-    # FARGATE fallback so a transient FARGATE_SPOT shortage can't fail a deploy.
+    # Maestro is a deploy-critical singleton: on-demand FARGATE Base=1 so its
+    # one task always places on on-demand and a transient FARGATE_SPOT shortage
+    # can't fail a deploy.
     svc = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service")
-    providers = {s["CapacityProvider"] for s in svc["Properties"]["CapacityProviderStrategy"]}
-    assert providers == {"FARGATE_SPOT", "FARGATE"}
+    items = {s["CapacityProvider"]: s for s in svc["Properties"]["CapacityProviderStrategy"]}
+    assert set(items) == {"FARGATE_SPOT", "FARGATE"}
+    assert items["FARGATE"]["Base"] == 1
+    assert "Base" not in items["FARGATE_SPOT"]

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -203,11 +203,14 @@ def test_service_runs_one_fargate_task_no_lb(template_dict):
 
 
 def test_service_has_ondemand_fallback(template_dict):
-    # Singleton: spot-preferred but with an on-demand FARGATE fallback so a
-    # transient FARGATE_SPOT shortage can't fail the deploy.
+    # Singleton: on-demand FARGATE Base=1 so the migrator's one task always
+    # places on on-demand and a transient FARGATE_SPOT shortage can't fail the
+    # deploy.
     svc = _service(template_dict)["Properties"]
-    providers = {s["CapacityProvider"] for s in svc["CapacityProviderStrategy"]}
-    assert providers == {"FARGATE_SPOT", "FARGATE"}
+    items = {s["CapacityProvider"]: s for s in svc["CapacityProviderStrategy"]}
+    assert set(items) == {"FARGATE_SPOT", "FARGATE"}
+    assert items["FARGATE"]["Base"] == 1
+    assert "Base" not in items["FARGATE_SPOT"]
 
 
 def test_service_disables_public_ip(template_dict):

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -452,9 +452,13 @@ def test_no_shared_resources_in_services_control(td):
 
 
 def test_control_service_has_ondemand_fallback(td):
-    # The merged control service is a deploy-critical singleton: spot-preferred
-    # with an on-demand FARGATE fallback so a transient FARGATE_SPOT shortage
-    # can't fail the one task a rolling deploy needs.
+    # The merged control service is a deploy-critical singleton (desired=1):
+    # on-demand FARGATE Base=1 guarantees its only task places on on-demand so a
+    # transient FARGATE_SPOT shortage can't fail the rolling deploy. This is the
+    # exact service that failed an upgrade in production with weight-only
+    # fallback (weights don't spread a single task).
     svc = td["Resources"]["ControlService"]
-    strategy = {s["CapacityProvider"] for s in svc["Properties"]["CapacityProviderStrategy"]}
-    assert strategy == {"FARGATE_SPOT", "FARGATE"}
+    items = {s["CapacityProvider"]: s for s in svc["Properties"]["CapacityProviderStrategy"]}
+    assert set(items) == {"FARGATE_SPOT", "FARGATE"}
+    assert items["FARGATE"]["Base"] == 1
+    assert "Base" not in items["FARGATE_SPOT"]

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -399,14 +399,34 @@ def _service_strategy(td, suffix):
     return {s["CapacityProvider"] for s in res["Properties"]["CapacityProviderStrategy"]}
 
 
+def _service_items(td, suffix):
+    res = next(
+        r for lid, r in td["Resources"].items()
+        if r["Type"] == "AWS::ECS::Service" and lid.endswith(suffix)
+    )
+    return res["Properties"]["CapacityProviderStrategy"]
+
+
+def _assert_fallback(items):
+    # On-demand FARGATE with Base=1 (the first replica always places on
+    # on-demand) plus weighted FARGATE_SPOT for scale-out.
+    by_provider = {i["CapacityProvider"]: i for i in items}
+    assert by_provider["FARGATE"]["Base"] == 1
+    assert "FARGATE_SPOT" in by_provider
+    assert "Base" not in by_provider["FARGATE_SPOT"]
+
+
 def test_pubsub_sqs_has_ondemand_fallback(td):
-    # pubsub-sqs is a non-autoscaled singleton: spot-preferred with an
-    # on-demand FARGATE fallback so a transient FARGATE_SPOT shortage can't
-    # fail a rolling deploy.
+    # pubsub-sqs is a non-autoscaled singleton: on-demand FARGATE Base=1 so a
+    # transient FARGATE_SPOT shortage can't fail a rolling deploy.
     assert _service_strategy(td, "PubsubSqsService") == {"FARGATE_SPOT", "FARGATE"}
+    _assert_fallback(_service_items(td, "PubsubSqsService"))
 
 
-def test_process_workers_are_spot_only(td):
-    # process-* are scalable workers: pure FARGATE_SPOT.
+def test_process_workers_have_ondemand_fallback(td):
+    # process-* scale out to spot, but every rolling upgrade must place a first
+    # NEW task before draining the old; Base=1 on FARGATE guarantees that
+    # first replica places even in a transient FARGATE_SPOT shortage.
     for suffix in ("ProcessLogsService", "ProcessMetricsService", "ProcessTracesService"):
-        assert _service_strategy(td, suffix) == {"FARGATE_SPOT"}, suffix
+        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
+        _assert_fallback(_service_items(td, suffix))

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -320,7 +320,21 @@ def _service_strategy(td, suffix):
     return {s["CapacityProvider"] for s in res["Properties"]["CapacityProviderStrategy"]}
 
 
-def test_query_workers_are_spot_only(td):
-    # query-api and query-worker are scalable workers: pure FARGATE_SPOT.
+def _service_items(td, suffix):
+    res = next(
+        r for lid, r in td["Resources"].items()
+        if r["Type"] == "AWS::ECS::Service" and lid.endswith(suffix)
+    )
+    return res["Properties"]["CapacityProviderStrategy"]
+
+
+def test_query_workers_have_ondemand_fallback(td):
+    # query-api and query-worker scale out to spot, but a rolling upgrade must
+    # place a first NEW task before draining the old; Base=1 on FARGATE
+    # guarantees that first replica places even in a transient FARGATE_SPOT
+    # shortage. Scale-out replicas stay spot-weighted.
     for suffix in ("QueryApiService", "QueryWorkerService"):
-        assert _service_strategy(td, suffix) == {"FARGATE_SPOT"}, suffix
+        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
+        by_provider = {i["CapacityProvider"]: i for i in _service_items(td, suffix)}
+        assert by_provider["FARGATE"]["Base"] == 1, suffix
+        assert "Base" not in by_provider["FARGATE_SPOT"], suffix

--- a/tests/unit/test_services_common.py
+++ b/tests/unit/test_services_common.py
@@ -154,9 +154,12 @@ def test_build_ecs_service_fallback_capacity():
     )
     rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
     strat = rendered["Properties"]["CapacityProviderStrategy"]
+    # On-demand FARGATE carries Base=1 so a desired=1 singleton's only task is
+    # always placed on on-demand (reliable); FARGATE_SPOT is weighted for any
+    # scale-out replicas beyond the first.
     assert strat == [
+        {"CapacityProvider": "FARGATE", "Base": 1, "Weight": 1},
         {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
-        {"CapacityProvider": "FARGATE", "Weight": 1},
     ]
 
 
@@ -167,8 +170,23 @@ def test_capacity_provider_strategy_modes():
     }
     fallback = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
     assert fallback == [
+        {"CapacityProvider": "FARGATE", "Base": 1, "Weight": 1},
         {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
-        {"CapacityProvider": "FARGATE", "Weight": 1},
     ]
     with pytest.raises(ValueError):
         services_common.capacity_provider_strategy("nope")
+
+
+def test_fallback_fargate_carries_base_one():
+    """The crux of the singleton-placement bug: weights alone do not fail over
+    for a desired=1 service. Base=1 on the on-demand FARGATE provider is what
+    guarantees the first (and for singletons, only) task always places on
+    on-demand. Only one provider in a strategy may carry Base>0 — it's FARGATE.
+    """
+    items = services_common.capacity_provider_strategy("fallback")
+    by_provider = {i.to_dict()["CapacityProvider"]: i.to_dict() for i in items}
+    assert by_provider["FARGATE"]["Base"] == 1
+    assert "FARGATE_SPOT" in by_provider
+    assert "Base" not in by_provider["FARGATE_SPOT"]
+    bases = [d.get("Base", 0) for d in by_provider.values()]
+    assert sum(1 for b in bases if b) == 1


### PR DESCRIPTION
Weight-only capacity strategies (FARGATE_SPOT:4 + FARGATE:1) do NOT fail over for a single task — ECS picks one provider by weight, and a desired=1 service whose pick is spot dies when spot is dry, tripping the circuit breaker. This bit the merged ControlService on a v1.35.0 image upgrade ('Capacity is unavailable'). Fix: Base=1 on FARGATE guarantees the first/only task on on-demand; spot stays weighted 4:1 for scale-out (query-worker 7/8, process-* 9/10). Every deploy-critical lakerunner service switched to fallback so upgrades never block on spot. Tradeoff: singletons get no spot savings (effectively on-demand); durable savings path is combining roles into fewer, fatter tasks. 460 passed.