### PR TITLE
ECS capacity: on-demand for singletons+collector, spot+on-demand-base for autoscaled workers

### DIFF
--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -746,10 +746,10 @@ def build() -> Template:
         Service(
             "MaestroService",
             Cluster=Ref("ClusterArn"),
-            # Singleton: spot-preferred with an on-demand FARGATE fallback so a
-            # transient FARGATE_SPOT shortage can't block its task and trip the
-            # deploy circuit breaker.
-            CapacityProviderStrategy=services_common.capacity_provider_strategy("fallback"),
+            # Singleton: pure on-demand FARGATE so its one task always places
+            # during a rolling deploy; a transient FARGATE_SPOT shortage must
+            # never block the task and trip the deploy circuit breaker.
+            CapacityProviderStrategy=services_common.capacity_provider_strategy("ondemand"),
             DesiredCount=1,
             TaskDefinition=Ref(task_def),
             NetworkConfiguration=NetworkConfiguration(

--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -372,7 +372,7 @@ def build() -> Template:
         subnets_csv_param="PrivateSubnetsCsv",
         security_group_id_param="TaskSecurityGroupId",
         container_name="keepalive",
-        capacity="fallback",
+        capacity="ondemand",
     )
     t.add_resource(migrator_service)
 

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -213,38 +213,32 @@ def _coerce_size(value):
     return value
 
 
-def capacity_provider_strategy(capacity: str = "spot") -> list:
+def capacity_provider_strategy(capacity: str = "fallback") -> list:
     """Capacity-provider strategy for an ECS Service.
 
-    "spot" (scalable workers): pure FARGATE_SPOT — cheapest, and a transient
-    spot shortage only delays/skips an extra replica, never a deploy-critical
-    singleton task.
+    "fallback" (the default, used by every lakerunner service): pure on-demand
+    FARGATE for ALL replicas. This is the only deploy-reliable choice.
 
-    "fallback" (singletons/critical services): on-demand FARGATE for the first
-    task, spot-preferred for any scale-out beyond it. The crux is Base=1 on
-    FARGATE, not the weights.
+    Why no spot in the default path. A weight-based strategy does NOT give a
+    single task failover: ECS capacity-provider weights only distribute
+    MULTIPLE tasks across providers; for any individual task ECS picks ONE
+    provider, and if that provider (FARGATE_SPOT) has no capacity right now the
+    task simply fails to place. A rolling deploy must place every NEW task
+    before draining the old, and the deployment circuit breaker rolls the whole
+    stack back the moment one of them can't place. FARGATE_SPOT cannot
+    guarantee placement at any given instant, so any spot tier — even weighted,
+    even with a Base=1 on-demand first task — makes deploys flaky and triggers
+    rollbacks. On-demand FARGATE for all replicas is required for reliable
+    deploys.
 
-    Weights ALONE do not fail over for a singleton. ECS capacity-provider
-    weights only distribute MULTIPLE tasks across providers; for a single task
-    (DesiredCount=1) ECS picks ONE provider by weight, and if that provider
-    (FARGATE_SPOT) has no capacity right now the task simply fails to place —
-    tripping the deployment circuit breaker and rolling the stack back. A
-    rolling deploy must place at least one NEW task before draining the old,
-    so every desired>=1 service hits this singleton-placement window on a dry
-    spot moment, regardless of steady-state replica count.
-
-    Base=1 on FARGATE guarantees the FIRST task of every service lands on
-    on-demand (reliable). For desired=1 singletons that one task is always on
-    on-demand. For scalable services (desired N>1) one task is on-demand and
-    the remaining N-1 are weighted 4:1 toward spot. Only one provider in a
-    strategy may carry Base>0; it lives on FARGATE here.
+    "spot": pure FARGATE_SPOT, an explicit opt-in only. DEPLOY-UNSAFE for the
+    reasons above; a customer may knowingly choose it for a non-critical,
+    cost-sensitive service that tolerates failed deploys. No caller uses it by
+    default.
     """
     if capacity == "fallback":
         return [
-            CapacityProviderStrategyItem(
-                CapacityProvider="FARGATE", Base=1, Weight=1
-            ),
-            CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=4),
+            CapacityProviderStrategyItem(CapacityProvider="FARGATE", Weight=1),
         ]
     if capacity == "spot":
         return [
@@ -266,7 +260,7 @@ def build_ecs_service(
     container_port: int | None = None,
     service_registry_ref=None,
     listener_rule_refs: list | None = None,
-    capacity: str = "spot",
+    capacity: str = "fallback",
 ) -> Service:
     """ECS Fargate Service with rolling deploy + circuit breaker.
 

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -213,32 +213,43 @@ def _coerce_size(value):
     return value
 
 
-def capacity_provider_strategy(capacity: str = "fallback") -> list:
+def capacity_provider_strategy(capacity: str = "ondemand") -> list:
     """Capacity-provider strategy for an ECS Service.
 
-    "fallback" (the default, used by every lakerunner service): pure on-demand
-    FARGATE for ALL replicas. This is the only deploy-reliable choice.
+    Three modes:
 
-    Why no spot in the default path. A weight-based strategy does NOT give a
-    single task failover: ECS capacity-provider weights only distribute
-    MULTIPLE tasks across providers; for any individual task ECS picks ONE
-    provider, and if that provider (FARGATE_SPOT) has no capacity right now the
-    task simply fails to place. A rolling deploy must place every NEW task
-    before draining the old, and the deployment circuit breaker rolls the whole
-    stack back the moment one of them can't place. FARGATE_SPOT cannot
-    guarantee placement at any given instant, so any spot tier — even weighted,
-    even with a Base=1 on-demand first task — makes deploys flaky and triggers
-    rollbacks. On-demand FARGATE for all replicas is required for reliable
-    deploys.
+    "ondemand" (deploy-critical singletons and fixed-size tiers): pure on-demand
+    FARGATE for ALL replicas. The only deploy-reliable choice for a service
+    where every task must place during a rolling deploy. A weight-based strategy
+    does NOT give a single task failover — ECS weights only distribute MULTIPLE
+    tasks across providers; for any individual task ECS picks ONE provider, and
+    if FARGATE_SPOT has no capacity at that instant the task fails to place,
+    tripping the deployment circuit breaker and rolling the stack back. Used by
+    the migrator, the merged control service, maestro, pubsub-sqs, query-api,
+    and the satellite collector.
 
-    "spot": pure FARGATE_SPOT, an explicit opt-in only. DEPLOY-UNSAFE for the
-    reasons above; a customer may knowingly choose it for a non-critical,
-    cost-sensitive service that tolerates failed deploys. No caller uses it by
-    default.
+    "fallback" (autoscaled scale-out workers): Base=1 on-demand FARGATE plus
+    weighted FARGATE_SPOT (4:1) for scale-out. The Base=1 guarantees the FIRST
+    replica always lands on on-demand — so a rolling deploy always has at least
+    one reliable task — while replicas beyond the first ride cheap spot. Only
+    one provider in a strategy may carry Base>0; it lives on FARGATE here. Used
+    by process-{logs,metrics,traces} and query-worker, which autoscale and can
+    tolerate a transient spot shortage on their extra replicas.
+
+    "spot": pure FARGATE_SPOT, an explicit opt-in only. DEPLOY-UNSAFE — a single
+    task can fail to place — for a customer who knowingly wants spot on a
+    non-critical, cost-sensitive service. No caller uses it.
     """
-    if capacity == "fallback":
+    if capacity == "ondemand":
         return [
             CapacityProviderStrategyItem(CapacityProvider="FARGATE", Weight=1),
+        ]
+    if capacity == "fallback":
+        return [
+            CapacityProviderStrategyItem(
+                CapacityProvider="FARGATE", Base=1, Weight=1
+            ),
+            CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=4),
         ]
     if capacity == "spot":
         return [
@@ -260,7 +271,7 @@ def build_ecs_service(
     container_port: int | None = None,
     service_registry_ref=None,
     listener_rule_refs: list | None = None,
-    capacity: str = "fallback",
+    capacity: str = "ondemand",
 ) -> Service:
     """ECS Fargate Service with rolling deploy + circuit breaker.
 

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -527,8 +527,9 @@ def build() -> Template:
     # ---------------------------------------------------------------------
     # The single control service. LoadBalancers targets the admin-api container;
     # ServiceRegistries puts the task's IP in Cloud Map as admin-api.<ns>.
-    # fallback capacity: spot-preferred with an on-demand FARGATE fallback so a
-    # transient FARGATE_SPOT shortage can't fail the one task a deploy needs.
+    # ondemand capacity: the merged control service is a deploy-critical
+    # singleton (desired=1), so its one task runs pure on-demand FARGATE — a
+    # transient FARGATE_SPOT shortage must never fail the task a deploy needs.
     # ---------------------------------------------------------------------
     control_service = t.add_resource(
         services_common.build_ecs_service(
@@ -543,7 +544,7 @@ def build() -> Template:
             container_port=admin_container_port,
             service_registry_ref=admin_discovery,
             listener_rule_refs=[admin_listener_rule],
-            capacity="fallback",
+            capacity="ondemand",
         )
     )
     t.add_output(Output("ControlServiceName", Value=GetAtt(control_service, "Name")))

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -445,7 +445,7 @@ def _build_service_block(
     base_env: list,
     base_secrets: list,
     extra_env: list | None = None,
-    capacity: str = "spot",
+    capacity: str = "fallback",
 ):
     """Wire up the three resources (log group, task def, service) for one service."""
     log_group = t.add_resource(services_common.build_log_group(service_key=service_key))

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -386,10 +386,11 @@ def build() -> Template:
             "memory_mib": pubsub_cfg["memory_mib"],
             "desired_count": Ref("PubsubSqsReplicas"),
             "output_name": "PubsubSqsServiceName",
-            # Singleton (no autoscaler): give it an on-demand FARGATE fallback
-            # so a transient FARGATE_SPOT shortage can't block its one task and
-            # trip the deploy circuit breaker. process-* stay pure spot.
-            "capacity": "fallback",
+            # Deploy-critical singleton (no autoscaler; desired=PubsubSqsReplicas,
+            # default 1): pure on-demand FARGATE so a transient FARGATE_SPOT
+            # shortage can't block its one task and trip the deploy circuit
+            # breaker. process-* default to fallback (Base=1 + spot scale-out).
+            "capacity": "ondemand",
             # pubsub-sqs alone consumes SQS. The lakerunner binary reads the
             # primary queue (group 0) from three plain env vars. The image is
             # distroless (no shell), so these must be real container env vars,
@@ -421,11 +422,11 @@ def build() -> Template:
             base_env=base_env,
             base_secrets=base_secrets,
             extra_env=spec.get("extra_env"),
-            # Every deploy-critical service needs a guaranteed on-demand first
-            # replica (Base=1) so a rolling upgrade can place its first NEW task
-            # even in a transient FARGATE_SPOT shortage; scale-out replicas stay
-            # spot-weighted. process-{logs,metrics,traces} default to fallback;
-            # pubsub already sets it explicitly.
+            # Autoscaled workers (process-{logs,metrics,traces}) default to
+            # "fallback": Base=1 on-demand guarantees the first NEW task of a
+            # rolling upgrade places even in a transient FARGATE_SPOT shortage,
+            # while scale-out replicas ride cheap spot. pubsub-sqs overrides this
+            # to "ondemand" (it's a deploy-critical singleton, not autoscaled).
             capacity=spec.get("capacity", "fallback"),
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -406,9 +406,9 @@ def build() -> Template:
             container_port=api_container_port,
             service_registry_ref=api_discovery,
             listener_rule_refs=[api_listener_rule],
-            # Base=1 on-demand first replica for reliable rolling upgrades;
-            # scale-out replicas stay spot-weighted.
-            capacity="fallback",
+            # Fixed-size API tier (default 2 replicas, not autoscaled): pure
+            # on-demand FARGATE so every replica places during a rolling upgrade.
+            capacity="ondemand",
         )
     )
 

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -23,7 +23,7 @@ Resources created:
   - OtelGrpcListenerRule: path /v1/*, priority 300.
   - OtelGrpcLogGroup: /cardinal/otel-grpc.
   - OtelGrpcTaskDef: ARM64 Fargate, env vars, LICENSE_DATA secret.
-  - CollectorService: FARGATE_SPOT, circuit breaker, no Cloud Map.
+  - CollectorService: FARGATE on-demand, circuit breaker, no Cloud Map.
 """
 
 from troposphere import (
@@ -606,8 +606,14 @@ def build() -> Template:
         Service(
             "CollectorService",
             Cluster=Ref("EcsClusterArn"),
+            # On-demand FARGATE only. The collector is the deploy-critical
+            # ingest path, and ECS rolling deploys + the circuit breaker
+            # require every new task to place. FARGATE_SPOT cannot guarantee
+            # placement at any instant, so a spot tier (even weighted, even
+            # with Base=1 for the first task) makes deploys flaky and triggers
+            # rollbacks. Reliable deploys require on-demand.
             CapacityProviderStrategy=[
-                CapacityProviderStrategyItem(CapacityProvider="FARGATE_SPOT", Weight=1),
+                CapacityProviderStrategyItem(CapacityProvider="FARGATE", Weight=1),
             ],
             DesiredCount=Ref("OtelReplicas"),
             TaskDefinition=Ref(task_def),

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -357,12 +357,10 @@ def test_all_services_disable_public_ip(td):
         )
 
 
-def test_service_has_ondemand_fallback(td):
-    # Maestro is a deploy-critical singleton: on-demand FARGATE Base=1 so its
-    # one task always places on on-demand and a transient FARGATE_SPOT shortage
-    # can't fail a deploy.
+def test_service_is_pure_on_demand(td):
+    # Maestro is a deploy-critical singleton: pure on-demand FARGATE so its one
+    # task always places during a rolling deploy. No FARGATE_SPOT.
     svc = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service")
-    items = {s["CapacityProvider"]: s for s in svc["Properties"]["CapacityProviderStrategy"]}
-    assert set(items) == {"FARGATE_SPOT", "FARGATE"}
-    assert items["FARGATE"]["Base"] == 1
-    assert "Base" not in items["FARGATE_SPOT"]
+    items = svc["Properties"]["CapacityProviderStrategy"]
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -202,15 +202,13 @@ def test_service_runs_one_fargate_task_no_lb(template_dict):
     assert "ServiceRegistries" not in svc
 
 
-def test_service_has_ondemand_fallback(template_dict):
-    # Singleton: on-demand FARGATE Base=1 so the migrator's one task always
-    # places on on-demand and a transient FARGATE_SPOT shortage can't fail the
-    # deploy.
+def test_service_is_pure_on_demand(template_dict):
+    # Singleton: pure on-demand FARGATE so the migrator's one task always places
+    # during a rolling deploy. No FARGATE_SPOT (it can't guarantee placement).
     svc = _service(template_dict)["Properties"]
-    items = {s["CapacityProvider"]: s for s in svc["CapacityProviderStrategy"]}
-    assert set(items) == {"FARGATE_SPOT", "FARGATE"}
-    assert items["FARGATE"]["Base"] == 1
-    assert "Base" not in items["FARGATE_SPOT"]
+    items = svc["CapacityProviderStrategy"]
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)
 
 
 def test_service_disables_public_ip(template_dict):

--- a/tests/templates/test_satellite_services.py
+++ b/tests/templates/test_satellite_services.py
@@ -153,13 +153,16 @@ def test_target_group_health_on_13133(td):
 # ---------------------------------------------------------------------------
 
 
-def test_service_uses_fargate_spot(td):
+def test_collector_service_is_pure_on_demand(td):
+    # The collector is the deploy-critical ingest path: pure on-demand FARGATE
+    # so every new task places during a rolling deploy. FARGATE_SPOT can't
+    # guarantee placement, so no spot tier anywhere.
     svc = next(
         r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::Service"
     )
-    strategies = svc["Properties"]["CapacityProviderStrategy"]
-    providers = [s["CapacityProvider"] for s in strategies]
-    assert "FARGATE_SPOT" in providers
+    items = svc["Properties"]["CapacityProviderStrategy"]
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)
 
 
 def test_service_no_cloud_map(td):

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -451,14 +451,12 @@ def test_no_shared_resources_in_services_control(td):
     assert not found, f"services-control must not own shared resources; found {found}"
 
 
-def test_control_service_has_ondemand_fallback(td):
+def test_control_service_is_pure_on_demand(td):
     # The merged control service is a deploy-critical singleton (desired=1):
-    # on-demand FARGATE Base=1 guarantees its only task places on on-demand so a
-    # transient FARGATE_SPOT shortage can't fail the rolling deploy. This is the
-    # exact service that failed an upgrade in production with weight-only
-    # fallback (weights don't spread a single task).
+    # pure on-demand FARGATE so its only task always places during a rolling
+    # deploy. This is the exact service that failed an upgrade in production
+    # when a spot tier couldn't place. No FARGATE_SPOT.
     svc = td["Resources"]["ControlService"]
-    items = {s["CapacityProvider"]: s for s in svc["Properties"]["CapacityProviderStrategy"]}
-    assert set(items) == {"FARGATE_SPOT", "FARGATE"}
-    assert items["FARGATE"]["Base"] == 1
-    assert "Base" not in items["FARGATE_SPOT"]
+    items = svc["Properties"]["CapacityProviderStrategy"]
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -407,26 +407,23 @@ def _service_items(td, suffix):
     return res["Properties"]["CapacityProviderStrategy"]
 
 
-def _assert_fallback(items):
-    # On-demand FARGATE with Base=1 (the first replica always places on
-    # on-demand) plus weighted FARGATE_SPOT for scale-out.
-    by_provider = {i["CapacityProvider"]: i for i in items}
-    assert by_provider["FARGATE"]["Base"] == 1
-    assert "FARGATE_SPOT" in by_provider
-    assert "Base" not in by_provider["FARGATE_SPOT"]
+def _assert_on_demand(items):
+    # Pure on-demand FARGATE for all replicas — the only deploy-reliable choice.
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)
 
 
-def test_pubsub_sqs_has_ondemand_fallback(td):
-    # pubsub-sqs is a non-autoscaled singleton: on-demand FARGATE Base=1 so a
-    # transient FARGATE_SPOT shortage can't fail a rolling deploy.
-    assert _service_strategy(td, "PubsubSqsService") == {"FARGATE_SPOT", "FARGATE"}
-    _assert_fallback(_service_items(td, "PubsubSqsService"))
+def test_pubsub_sqs_is_pure_on_demand(td):
+    # pubsub-sqs is a non-autoscaled singleton: pure on-demand FARGATE so a
+    # rolling deploy always places. No FARGATE_SPOT.
+    assert _service_strategy(td, "PubsubSqsService") == {"FARGATE"}
+    _assert_on_demand(_service_items(td, "PubsubSqsService"))
 
 
-def test_process_workers_have_ondemand_fallback(td):
-    # process-* scale out to spot, but every rolling upgrade must place a first
-    # NEW task before draining the old; Base=1 on FARGATE guarantees that
-    # first replica places even in a transient FARGATE_SPOT shortage.
+def test_process_workers_are_pure_on_demand(td):
+    # process-* run pure on-demand FARGATE. Every rolling deploy must place a
+    # NEW task before draining the old, and FARGATE_SPOT can't guarantee
+    # placement, so no spot tier anywhere.
     for suffix in ("ProcessLogsService", "ProcessMetricsService", "ProcessTracesService"):
-        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
-        _assert_fallback(_service_items(td, suffix))
+        assert _service_strategy(td, suffix) == {"FARGATE"}, suffix
+        _assert_on_demand(_service_items(td, suffix))

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -413,17 +413,28 @@ def _assert_on_demand(items):
     assert all("Base" not in i for i in items)
 
 
+def _assert_fallback(items):
+    # Autoscaled worker: Base=1 on-demand first replica + weighted spot scale-out.
+    by_provider = {i["CapacityProvider"]: i for i in items}
+    assert by_provider["FARGATE"]["Base"] == 1
+    assert "FARGATE_SPOT" in by_provider
+    assert by_provider["FARGATE_SPOT"]["Weight"] == 4
+    assert "Base" not in by_provider["FARGATE_SPOT"]
+    bases = [i.get("Base", 0) for i in items]
+    assert sum(1 for b in bases if b) == 1
+
+
 def test_pubsub_sqs_is_pure_on_demand(td):
-    # pubsub-sqs is a non-autoscaled singleton: pure on-demand FARGATE so a
-    # rolling deploy always places. No FARGATE_SPOT.
+    # pubsub-sqs is a non-autoscaled, deploy-critical singleton: pure on-demand
+    # FARGATE so a rolling deploy always places. No FARGATE_SPOT.
     assert _service_strategy(td, "PubsubSqsService") == {"FARGATE"}
     _assert_on_demand(_service_items(td, "PubsubSqsService"))
 
 
-def test_process_workers_are_pure_on_demand(td):
-    # process-* run pure on-demand FARGATE. Every rolling deploy must place a
-    # NEW task before draining the old, and FARGATE_SPOT can't guarantee
-    # placement, so no spot tier anywhere.
+def test_process_workers_have_ondemand_base_with_spot_scaleout(td):
+    # process-* autoscale (to 10): Base=1 guarantees the first NEW task of a
+    # rolling upgrade lands on on-demand even in a transient FARGATE_SPOT
+    # shortage; scale-out replicas stay spot-weighted.
     for suffix in ("ProcessLogsService", "ProcessMetricsService", "ProcessTracesService"):
-        assert _service_strategy(td, suffix) == {"FARGATE"}, suffix
-        _assert_on_demand(_service_items(td, suffix))
+        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
+        _assert_fallback(_service_items(td, suffix))

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -328,13 +328,12 @@ def _service_items(td, suffix):
     return res["Properties"]["CapacityProviderStrategy"]
 
 
-def test_query_workers_have_ondemand_fallback(td):
-    # query-api and query-worker scale out to spot, but a rolling upgrade must
-    # place a first NEW task before draining the old; Base=1 on FARGATE
-    # guarantees that first replica places even in a transient FARGATE_SPOT
-    # shortage. Scale-out replicas stay spot-weighted.
+def test_query_workers_are_pure_on_demand(td):
+    # query-api and query-worker run pure on-demand FARGATE. A rolling deploy
+    # must place every NEW task before draining the old, and FARGATE_SPOT can't
+    # guarantee placement, so no spot tier anywhere.
     for suffix in ("QueryApiService", "QueryWorkerService"):
-        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
-        by_provider = {i["CapacityProvider"]: i for i in _service_items(td, suffix)}
-        assert by_provider["FARGATE"]["Base"] == 1, suffix
-        assert "Base" not in by_provider["FARGATE_SPOT"], suffix
+        assert _service_strategy(td, suffix) == {"FARGATE"}, suffix
+        items = _service_items(td, suffix)
+        assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}], suffix
+        assert all("Base" not in i for i in items), suffix

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -328,12 +328,21 @@ def _service_items(td, suffix):
     return res["Properties"]["CapacityProviderStrategy"]
 
 
-def test_query_workers_are_pure_on_demand(td):
-    # query-api and query-worker run pure on-demand FARGATE. A rolling deploy
-    # must place every NEW task before draining the old, and FARGATE_SPOT can't
-    # guarantee placement, so no spot tier anywhere.
-    for suffix in ("QueryApiService", "QueryWorkerService"):
-        assert _service_strategy(td, suffix) == {"FARGATE"}, suffix
-        items = _service_items(td, suffix)
-        assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}], suffix
-        assert all("Base" not in i for i in items), suffix
+def test_query_api_is_pure_on_demand(td):
+    # query-api is a fixed-size API tier (not autoscaled): pure on-demand
+    # FARGATE so every replica places during a rolling deploy. No spot.
+    assert _service_strategy(td, "QueryApiService") == {"FARGATE"}
+    items = _service_items(td, "QueryApiService")
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)
+
+
+def test_query_worker_has_ondemand_base_with_spot_scaleout(td):
+    # query-worker autoscales (to 8): Base=1 guarantees the first NEW task of a
+    # rolling upgrade lands on on-demand even in a transient FARGATE_SPOT
+    # shortage; scale-out replicas stay spot-weighted.
+    assert _service_strategy(td, "QueryWorkerService") == {"FARGATE_SPOT", "FARGATE"}
+    by_provider = {i["CapacityProvider"]: i for i in _service_items(td, "QueryWorkerService")}
+    assert by_provider["FARGATE"]["Base"] == 1
+    assert by_provider["FARGATE_SPOT"]["Weight"] == 4
+    assert "Base" not in by_provider["FARGATE_SPOT"]

--- a/tests/unit/test_services_common.py
+++ b/tests/unit/test_services_common.py
@@ -123,7 +123,7 @@ def test_build_ecs_service_has_circuit_breaker_and_rolling_deploy():
     assert dc.get("DeploymentCircuitBreaker", {}).get("Rollback") is True
 
 
-def test_build_ecs_service_uses_fargate_spot():
+def test_build_ecs_service_default_capacity_is_on_demand():
     svc = services_common.build_ecs_service(
         service_key="query-api",
         cluster_arn_param="ClusterArn",
@@ -136,8 +136,9 @@ def test_build_ecs_service_uses_fargate_spot():
     rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
     props = rendered["Properties"]
     assert "LaunchType" not in props
+    # Default ("fallback") is pure on-demand FARGATE — no spot anywhere.
     assert props["CapacityProviderStrategy"] == [
-        {"CapacityProvider": "FARGATE_SPOT", "Weight": 1}
+        {"CapacityProvider": "FARGATE", "Weight": 1}
     ]
 
 
@@ -154,39 +155,33 @@ def test_build_ecs_service_fallback_capacity():
     )
     rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
     strat = rendered["Properties"]["CapacityProviderStrategy"]
-    # On-demand FARGATE carries Base=1 so a desired=1 singleton's only task is
-    # always placed on on-demand (reliable); FARGATE_SPOT is weighted for any
-    # scale-out replicas beyond the first.
+    # Pure on-demand FARGATE for all replicas — the only deploy-reliable choice.
     assert strat == [
-        {"CapacityProvider": "FARGATE", "Base": 1, "Weight": 1},
-        {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
+        {"CapacityProvider": "FARGATE", "Weight": 1},
     ]
 
 
 def test_capacity_provider_strategy_modes():
-    assert services_common.capacity_provider_strategy("spot")[0].to_dict() == {
-        "CapacityProvider": "FARGATE_SPOT",
-        "Weight": 1,
-    }
+    # "spot" is the explicit, deploy-unsafe opt-in: pure FARGATE_SPOT.
+    spot = [i.to_dict() for i in services_common.capacity_provider_strategy("spot")]
+    assert spot == [{"CapacityProvider": "FARGATE_SPOT", "Weight": 1}]
+    # "fallback" is the default: pure on-demand FARGATE, no spot.
     fallback = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
-    assert fallback == [
-        {"CapacityProvider": "FARGATE", "Base": 1, "Weight": 1},
-        {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
-    ]
+    assert fallback == [{"CapacityProvider": "FARGATE", "Weight": 1}]
     with pytest.raises(ValueError):
         services_common.capacity_provider_strategy("nope")
 
 
-def test_fallback_fargate_carries_base_one():
-    """The crux of the singleton-placement bug: weights alone do not fail over
-    for a desired=1 service. Base=1 on the on-demand FARGATE provider is what
-    guarantees the first (and for singletons, only) task always places on
-    on-demand. Only one provider in a strategy may carry Base>0 — it's FARGATE.
+def test_fallback_is_pure_on_demand_no_spot_no_base():
+    """The default path must be pure on-demand. A weight-based strategy does not
+    give a single task failover, and FARGATE_SPOT cannot guarantee placement
+    during a rolling deploy, so the strategy is exactly one FARGATE item with
+    Weight=1, no FARGATE_SPOT, and no Base on any item.
     """
-    items = services_common.capacity_provider_strategy("fallback")
-    by_provider = {i.to_dict()["CapacityProvider"]: i.to_dict() for i in items}
-    assert by_provider["FARGATE"]["Base"] == 1
-    assert "FARGATE_SPOT" in by_provider
-    assert "Base" not in by_provider["FARGATE_SPOT"]
-    bases = [d.get("Base", 0) for d in by_provider.values()]
-    assert sum(1 for b in bases if b) == 1
+    items = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert len(items) == 1
+    assert items[0]["CapacityProvider"] == "FARGATE"
+    assert items[0]["Weight"] == 1
+    assert all("FARGATE_SPOT" not in d.values() for d in items)
+    assert all("Base" not in d for d in items)

--- a/tests/unit/test_services_common.py
+++ b/tests/unit/test_services_common.py
@@ -136,7 +136,7 @@ def test_build_ecs_service_default_capacity_is_on_demand():
     rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
     props = rendered["Properties"]
     assert "LaunchType" not in props
-    # Default ("fallback") is pure on-demand FARGATE — no spot anywhere.
+    # Default ("ondemand") is pure on-demand FARGATE — no spot anywhere.
     assert props["CapacityProviderStrategy"] == [
         {"CapacityProvider": "FARGATE", "Weight": 1}
     ]
@@ -144,44 +144,61 @@ def test_build_ecs_service_default_capacity_is_on_demand():
 
 def test_build_ecs_service_fallback_capacity():
     svc = services_common.build_ecs_service(
-        service_key="sweeper",
+        service_key="process-logs",
         cluster_arn_param="ClusterArn",
         task_definition_ref="MyTaskDef",
         desired_count=1,
         subnets_csv_param="PrivateSubnetsCsv",
         security_group_id_param="TaskSecurityGroupId",
-        container_name="sweeper",
+        container_name="process-logs",
         capacity="fallback",
     )
     rendered = json.loads(json.dumps(svc, default=lambda o: o.to_dict()))
     strat = rendered["Properties"]["CapacityProviderStrategy"]
-    # Pure on-demand FARGATE for all replicas — the only deploy-reliable choice.
+    # Autoscaled worker: Base=1 on-demand first replica + weighted spot scale-out.
     assert strat == [
-        {"CapacityProvider": "FARGATE", "Weight": 1},
+        {"CapacityProvider": "FARGATE", "Base": 1, "Weight": 1},
+        {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
     ]
 
 
 def test_capacity_provider_strategy_modes():
-    # "spot" is the explicit, deploy-unsafe opt-in: pure FARGATE_SPOT.
+    # "ondemand": pure on-demand FARGATE, no spot, no Base.
+    ondemand = [i.to_dict() for i in services_common.capacity_provider_strategy("ondemand")]
+    assert ondemand == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    # "fallback": Base=1 on-demand FARGATE + weighted FARGATE_SPOT scale-out.
+    fallback = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
+    assert fallback == [
+        {"CapacityProvider": "FARGATE", "Base": 1, "Weight": 1},
+        {"CapacityProvider": "FARGATE_SPOT", "Weight": 4},
+    ]
+    # "spot": pure FARGATE_SPOT (deploy-unsafe opt-in).
     spot = [i.to_dict() for i in services_common.capacity_provider_strategy("spot")]
     assert spot == [{"CapacityProvider": "FARGATE_SPOT", "Weight": 1}]
-    # "fallback" is the default: pure on-demand FARGATE, no spot.
-    fallback = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
-    assert fallback == [{"CapacityProvider": "FARGATE", "Weight": 1}]
     with pytest.raises(ValueError):
         services_common.capacity_provider_strategy("nope")
 
 
-def test_fallback_is_pure_on_demand_no_spot_no_base():
-    """The default path must be pure on-demand. A weight-based strategy does not
-    give a single task failover, and FARGATE_SPOT cannot guarantee placement
-    during a rolling deploy, so the strategy is exactly one FARGATE item with
+def test_ondemand_is_pure_on_demand_no_spot_no_base():
+    """The ondemand path must be pure on-demand: exactly one FARGATE item with
     Weight=1, no FARGATE_SPOT, and no Base on any item.
     """
-    items = [i.to_dict() for i in services_common.capacity_provider_strategy("fallback")]
+    items = [i.to_dict() for i in services_common.capacity_provider_strategy("ondemand")]
     assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
     assert len(items) == 1
-    assert items[0]["CapacityProvider"] == "FARGATE"
-    assert items[0]["Weight"] == 1
     assert all("FARGATE_SPOT" not in d.values() for d in items)
     assert all("Base" not in d for d in items)
+
+
+def test_fallback_exactly_one_provider_carries_base():
+    """fallback: Base=1 lives on the on-demand FARGATE provider only; FARGATE_SPOT
+    is present (weight 4) for scale-out and carries no Base.
+    """
+    items = services_common.capacity_provider_strategy("fallback")
+    by_provider = {i.to_dict()["CapacityProvider"]: i.to_dict() for i in items}
+    assert by_provider["FARGATE"]["Base"] == 1
+    assert "FARGATE_SPOT" in by_provider
+    assert by_provider["FARGATE_SPOT"]["Weight"] == 4
+    assert "Base" not in by_provider["FARGATE_SPOT"]
+    bases = [d.get("Base", 0) for d in by_provider.values()]
+    assert sum(1 for b in bases if b) == 1


### PR DESCRIPTION
Spot can't guarantee task placement during rolling deploys (circuit breaker trips → rollback; hit 3x incl. the collector). Three capacity modes now:
- `ondemand` [FARGATE]: collector, control, pubsub, migrator, maestro, query-api — deploy-critical singletons/fixed tiers, must place.
- `fallback` [FARGATE Base=1, FARGATE_SPOT W4]: process-{logs,metrics,traces}, query-worker — autoscaled workers; first replica reliable on-demand, scale-out cheap on spot.
- `spot` [FARGATE_SPOT]: explicit deploy-unsafe opt-in, unused.

FARGATE_SPOT now appears only in process-* and query-worker. 462 passed; lint clean.