### PR TITLE
satellite-services: require OrganizationId, auto-generate unique collector name

### DIFF
--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -193,6 +193,7 @@ collector config must change before scaling past one replica.
 | `VERSION` | required | — |
 | `SATELLITE_INFRA_BASE_STACK` | required | upstream satellite-infra-base (`RawBucketName`) |
 | `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base (`LicenseSecretArn`) |
+| `ORGANIZATION_ID` | required | org UUID this satellite's telemetry is attributed to |
 | `VPC_ID` | required | — |
 | `ALB_SUBNETS` | required | comma-separated subnets for the collector ALB |
 | `TASK_SUBNETS` | required | comma-separated subnets for the collector tasks |
@@ -210,6 +211,7 @@ REGION=us-east-1 \
 VERSION=v0.0.70 \
 SATELLITE_INFRA_BASE_STACK=cardinal-satellite-infra-base \
 INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
+ORGANIZATION_ID=12340000-0000-0000-0000-000000000000 \
 VPC_ID=vpc-0abc \
 ALB_SUBNETS=subnet-a,subnet-b \
 TASK_SUBNETS=subnet-1,subnet-2 \

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -29,6 +29,7 @@ Required:
   VERSION                     Published template tag.
   SATELLITE_INFRA_BASE_STACK  Upstream satellite-infra-base (RawBucketName).
   INFRA_BASE_STACK            Upstream lakerunner-infra-base (LicenseSecretArn).
+  ORGANIZATION_ID             Org UUID this satellite's telemetry is attributed to.
   VPC_ID                      VPC for the collector.
   ALB_SUBNETS                 Comma-separated subnets for the collector ALB.
   TASK_SUBNETS                Comma-separated subnets for the collector tasks.
@@ -57,6 +58,7 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${ALB_SUBNETS:-}" ] && missing="$missing ALB_SUBNETS"
 [ -z "${TASK_SUBNETS:-}" ] && missing="$missing TASK_SUBNETS"
@@ -78,7 +80,8 @@ TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 FROM_STACKS="$SATELLITE_INFRA_BASE_STACK $INFRA_BASE_STACK"
 MAPS=""
 
-params="VpcId=$VPC_ID
+params="OrganizationId=$ORGANIZATION_ID
+VpcId=$VPC_ID
 AlbSubnetsCsv=$ALB_SUBNETS
 TaskSubnetsCsv=$TASK_SUBNETS
 EcsClusterArn=$ECS_CLUSTER_ARN

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -73,6 +73,7 @@ from troposphere.logs import LogGroup
 
 from cardinal_cfn.defaults import load_defaults, load_otel_default_config
 from cardinal_cfn.images import add_image_override
+from cardinal_cfn.install_id import install_id_short
 from cardinal_cfn.parameters import add_parameter_group_metadata
 from cardinal_cfn.policies import apply_policy
 
@@ -138,6 +139,23 @@ def build() -> Template:
             Description=(
                 "ARN of the Cardinal license secret in this account. "
                 "The collector validates it at startup."
+            ),
+        )
+    )
+    t.add_parameter(
+        Parameter(
+            "OrganizationId",
+            Type="String",
+            AllowedPattern=(
+                r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            ),
+            Description=(
+                "UUID of the organization this satellite's telemetry is "
+                "attributed to. Known at base-install time; supplied by the "
+                "operator. Must be unique per satellite so cooked-bucket "
+                "storage-profile resolution does not collide with the "
+                "operator's write-destination seed."
             ),
         )
     )
@@ -257,6 +275,7 @@ def build() -> Template:
                 "parameters": [
                     "RawBucketName",
                     "LicenseSecretArn",
+                    "OrganizationId",
                     "EcsClusterArn",
                 ],
             },
@@ -525,17 +544,12 @@ def build() -> Template:
     # Task definition (inlined — exec/task roles are in-stack resources,
     # so we use GetAtt(..., "Arn") instead of Ref(param)).
     # ------------------------------------------------------------------
-    storage_profiles = defaults.get("storage_profiles") or []
-    default_org = (
-        storage_profiles[0].get("organization_id")
-        if storage_profiles else "default"
-    )
-    default_collector = (
-        otel_cfg.get("collector_name")
-        or (storage_profiles[0].get("collector_name") if storage_profiles else None)
-        or "lakerunner"
-    )
-
+    # ORG is the operator-supplied org id this satellite is attributed to.
+    # COLLECTOR is an auto-generated, stable, alpha-prefixed name unique to
+    # this stack (a<8-hex> from AWS::StackId). satellite-services is a
+    # standalone root stack, so Ref(AWS::StackId) is its own id. A unique
+    # (ORG, COLLECTOR) keeps the storage-profile resolver from mis-routing
+    # cooked writes into the operator's seed identity.
     env = [
         Environment(
             Name="CHQ_COLLECTOR_CONFIG_YAML",
@@ -547,8 +561,8 @@ def build() -> Template:
         ),
         Environment(Name="LRDB_S3_BUCKET", Value=Ref("RawBucketName")),
         Environment(Name="LRDB_S3_REGION", Value=Ref("AWS::Region")),
-        Environment(Name="ORG", Value=default_org),
-        Environment(Name="COLLECTOR", Value=default_collector),
+        Environment(Name="ORG", Value=Ref("OrganizationId")),
+        Environment(Name="COLLECTOR", Value=Sub("a${Short}", Short=install_id_short())),
     ]
 
     # Add service-specific env vars from defaults (e.g. OTEL_RESOURCE_ATTRIBUTES)

--- a/tests/templates/test_satellite_services.py
+++ b/tests/templates/test_satellite_services.py
@@ -21,6 +21,7 @@ def test_required_parameters(td):
     for n in (
         "RawBucketName",
         "LicenseSecretArn",
+        "OrganizationId",
         "VpcId",
         "AlbSubnetsCsv",
         "TaskSubnetsCsv",
@@ -34,6 +35,17 @@ def test_alb_scheme_allowed_values(td):
     p = td["Parameters"]["AlbScheme"]
     assert p["AllowedValues"] == ["internal", "internet-facing"]
     assert p["Default"] == "internal"
+
+
+def test_organization_id_required_uuid(td):
+    """OrganizationId is required (no Default) and constrained to a UUID."""
+    p = td["Parameters"]["OrganizationId"]
+    assert p["Type"] == "String"
+    assert "Default" not in p, "OrganizationId must be required (no Default)"
+    assert p["AllowedPattern"] == (
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +201,36 @@ def test_taskdef_writes_bucket_env(td):
     container = task_def["Properties"]["ContainerDefinitions"][0]
     env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
     assert env.get("LRDB_S3_BUCKET") == {"Ref": "RawBucketName"}
+
+
+def test_org_env_is_organization_id_param(td):
+    """ORG comes from the operator-supplied OrganizationId param, not storage_profiles."""
+    task_def = next(
+        r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
+    )
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+    assert env.get("ORG") == {"Ref": "OrganizationId"}
+
+
+def test_collector_env_is_stackid_derived_sub(td):
+    """COLLECTOR is an auto-generated a${...} Sub tied to AWS::StackId, never 'lakerunner'."""
+    task_def = next(
+        r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
+    )
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+    collector = env.get("COLLECTOR")
+    assert isinstance(collector, dict) and "Fn::Sub" in collector, (
+        f"COLLECTOR must be a Fn::Sub, got: {collector!r}"
+    )
+    sub = collector["Fn::Sub"]
+    # Sub with named substitution: [template, {Short: <stackid expr>}]
+    template, subs = sub
+    assert template == "a${Short}"
+    assert collector != "lakerunner"
+    # The substitution must derive from AWS::StackId.
+    assert "AWS::StackId" in json.dumps(subs)
 
 
 def test_service_assigns_no_public_ip(td):


### PR DESCRIPTION
Fixes the storage-profile identity collision: the satellite collector was tagging telemetry as org 12340000 + collector 'lakerunner' — identical to the operator's cooked-bucket write-destination seed — so the resolver mis-routed cooked writes (traces wrote into the raw bucket with the read role -> 403).

- OrganizationId is now a REQUIRED param (no default); ORG env = Ref(OrganizationId). Org ids are created at base-install time.
- COLLECTOR env is an auto-generated, stable, unique alpha-prefixed name a${install_id_short} (derived from the satellite stack's AWS::StackId), never 'lakerunner'. Read-bucket collectors no longer collide with the write-destination seed; no disposable name to choose.
- deploy-satellite-services.sh requires ORGANIZATION_ID; chained-deploy doc updated.

Complements the lakerunner-side fixes (unique collector enforcement, no auto-org-creation, <=5min storage-profile cache TTL). 465 passed; lint clean.