### PR TITLE
services: ALB health checks target lakerunner v1.39 health port 8090

### DIFF
--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -149,6 +149,7 @@ def build_task_definition(
     secrets: list | None = None,
     log_group_ref,
     container_port: int | None = None,
+    health_check_port: int | None = None,
 ) -> TaskDefinition:
     """ECS Fargate task definition for a service.
 
@@ -165,6 +166,11 @@ def build_task_definition(
     the container in a LoadBalancer/TargetGroup attachment — without the
     PortMapping CFN rejects the Service with "container ... did not have a
     container port N defined."
+
+    health_check_port: if provided, the container exposes an ADDITIONAL tcp
+    PortMapping at that port (lakerunner's dedicated health server, port 8090
+    as of v1.39). Needed so the ALB target group can probe the health server
+    on a port distinct from the traffic port.
     """
     container_kwargs = dict(
         Name=service_key,
@@ -184,10 +190,13 @@ def build_task_definition(
         container_kwargs["Command"] = command
     if secrets:
         container_kwargs["Secrets"] = secrets
+    port_mappings = []
     if container_port is not None:
-        container_kwargs["PortMappings"] = [
-            PortMapping(ContainerPort=container_port, Protocol="tcp")
-        ]
+        port_mappings.append(PortMapping(ContainerPort=container_port, Protocol="tcp"))
+    if health_check_port is not None:
+        port_mappings.append(PortMapping(ContainerPort=health_check_port, Protocol="tcp"))
+    if port_mappings:
+        container_kwargs["PortMappings"] = port_mappings
 
     return TaskDefinition(
         _resource_title(service_key, "TaskDef"),
@@ -272,6 +281,7 @@ def build_ecs_service(
     service_registry_ref=None,
     listener_rule_refs: list | None = None,
     capacity: str = "ondemand",
+    health_check_grace_period: int | None = None,
 ) -> Service:
     """ECS Fargate Service with rolling deploy + circuit breaker.
 
@@ -284,6 +294,11 @@ def build_ecs_service(
     already attached to a listener; without an explicit DependsOn, CFN may
     create the Service before the ListenerRule attaches the TG, producing
     "target group does not have an associated load balancer" failures.
+
+    health_check_grace_period: seconds ECS ignores ELB health-check failures
+    after a task starts. Only valid on a service with a LoadBalancers block;
+    gives the lakerunner health server (port 8090) a margin to come up before
+    the ALB starts failing the task.
     """
     kwargs: dict = dict(
         Cluster=Ref(cluster_arn_param),
@@ -316,6 +331,8 @@ def build_ecs_service(
                 TargetGroupArn=Ref(target_group_ref),
             )
         ]
+        if health_check_grace_period is not None:
+            kwargs["HealthCheckGracePeriodSeconds"] = health_check_grace_period
 
     if service_registry_ref is not None:
         kwargs["ServiceRegistries"] = [

--- a/src/cardinal_cfn/children/services_control.py
+++ b/src/cardinal_cfn/children/services_control.py
@@ -333,10 +333,15 @@ def build() -> Template:
     # YAML-declared env + any component-specific extras.
     # ---------------------------------------------------------------------
     # admin-api: ALB-attached, owns the admin-key secret.
+    # All four containers share the merged task's network namespace, so they
+    # CANNOT all bind the default health port (8090). Give each a DISTINCT
+    # HEALTH_CHECK_PORT. admin-api keeps 8090 (the ALB-probed one); the other
+    # three move to 8091/8092/8093 to avoid a port collision in the namespace.
     admin_env = (
         list(base_env)
         + services_common.lakerunner_otel_env(service_key="admin-api")
         + _service_specific_env(admin_cfg)
+        + [Environment(Name="HEALTH_CHECK_PORT", Value="8090")]
     )
     # Seed the lakerunner admin-api binary's first valid admin key. Without
     # this, every Authorization: Bearer <key> request fails validation
@@ -353,6 +358,7 @@ def build() -> Template:
         list(base_env)
         + services_common.lakerunner_otel_env(service_key="sweeper")
         + _service_specific_env(sweeper_cfg)
+        + [Environment(Name="HEALTH_CHECK_PORT", Value="8091")]
     )
 
     # alert-evaluator reaches query-api over the in-cluster Cloud Map DNS.
@@ -366,6 +372,7 @@ def build() -> Template:
                 Name="ALERT_EVALUATOR_QUERY_API_URL",
                 Value=Sub("http://query-api.${ServiceNamespaceName}:8080"),
             ),
+            Environment(Name="HEALTH_CHECK_PORT", Value="8093"),
         ]
     )
 
@@ -414,6 +421,7 @@ def build() -> Template:
                 Name="LAKERUNNER_AUTOSCALER_SERVICES_TRACES_MAX_REPLICAS",
                 Value=Ref("ProcessTracesReplicas"),
             ),
+            Environment(Name="HEALTH_CHECK_PORT", Value="8092"),
         ]
     )
 
@@ -440,6 +448,9 @@ def build() -> Template:
             vpc_id_param="VpcId",
             port=admin_container_port,
             health_check_path=admin_health_path,
+            # lakerunner v1.39: /healthz lives on the dedicated health server
+            # (port 8090), not the 9091 API port. Probe 8090.
+            health_check_port=8090,
         )
     )
     admin_listener_rule = t.add_resource(
@@ -494,6 +505,7 @@ def build() -> Template:
                     secrets=admin_secrets,
                     log_group_ref=admin_lg,
                     container_port=admin_container_port,
+                    health_check_port=8090,
                 ),
                 _container(
                     name="sweeper",
@@ -545,6 +557,9 @@ def build() -> Template:
             service_registry_ref=admin_discovery,
             listener_rule_refs=[admin_listener_rule],
             capacity="ondemand",
+            # Margin for admin-api's health server (8090) to come up before the
+            # ALB starts failing the task.
+            health_check_grace_period=60,
         )
     )
     t.add_output(Output("ControlServiceName", Value=GetAtt(control_service, "Name")))
@@ -561,13 +576,15 @@ def _container(
     secrets: list,
     log_group_ref,
     container_port: int | None = None,
+    health_check_port: int | None = None,
 ) -> ContainerDefinition:
     """One essential container in the merged control task.
 
     Each container keeps its own command (from cardinal-defaults.yaml), env,
     secrets, and a LogConfiguration pointing at its own /cardinal/<name> log
     group. container_port is set only for admin-api (the LB target); the other
-    three expose no ports.
+    three expose no ports. health_check_port adds an additional PortMapping for
+    the dedicated health server (admin-api only, port 8090, ALB-probed).
     """
     kwargs = dict(
         Name=name,
@@ -587,8 +604,13 @@ def _container(
     command = config.get("command")
     if command:
         kwargs["Command"] = command
+    port_mappings = []
     if container_port is not None:
-        kwargs["PortMappings"] = [PortMapping(ContainerPort=container_port, Protocol="tcp")]
+        port_mappings.append(PortMapping(ContainerPort=container_port, Protocol="tcp"))
+    if health_check_port is not None:
+        port_mappings.append(PortMapping(ContainerPort=health_check_port, Protocol="tcp"))
+    if port_mappings:
+        kwargs["PortMappings"] = port_mappings
     return ContainerDefinition(**kwargs)
 
 

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -325,6 +325,10 @@ def build() -> Template:
         Environment(Name="QUERY_WORKER_CLUSTER_NAME", Value=Ref("ClusterName")),
         Environment(Name="QUERY_WORKER_SERVICE_NAME", Value=GetAtt(worker_service, "Name")),
         Environment(Name="QUERY_WORKER_PORT", Value=str(worker_port)),
+        # lakerunner v1.39 serves /healthz on a dedicated health server (port
+        # 8090, env HEALTH_CHECK_PORT) — no longer on the API port. Set it
+        # explicitly (it's the default) and probe it from the ALB below.
+        Environment(Name="HEALTH_CHECK_PORT", Value="8090"),
     ]
     api_tg = t.add_resource(
         services_common.build_target_group(
@@ -332,6 +336,7 @@ def build() -> Template:
             vpc_id_param="VpcId",
             port=api_container_port,
             health_check_path=api_health_path,
+            health_check_port=8090,
         )
     )
     # The binary serves /api/v1/{logs,metrics,spans,promql,logql}/... plus
@@ -377,6 +382,7 @@ def build() -> Template:
             secrets=base_secrets,
             log_group_ref=api_lg,
             container_port=api_container_port,
+            health_check_port=8090,
         )
     )
     # Register query-api in Cloud Map so other services in the cluster can
@@ -409,6 +415,9 @@ def build() -> Template:
             # Fixed-size API tier (default 2 replicas, not autoscaled): pure
             # on-demand FARGATE so every replica places during a rolling upgrade.
             capacity="ondemand",
+            # Margin for the health server (8090) to come up before the ALB
+            # starts failing the task.
+            health_check_grace_period=60,
         )
     )
 

--- a/tests/templates/test_services_control.py
+++ b/tests/templates/test_services_control.py
@@ -227,12 +227,57 @@ def test_control_service_load_balancer_targets_admin_api_container(td):
 
 
 def test_only_admin_api_container_exposes_a_port(td):
+    """admin-api exposes the 9091 API port plus the 8090 lakerunner v1.39 health
+    server (ALB-probed). The other three containers expose no ports — they share
+    the task namespace and would collide on the health port if it were exposed."""
     task = next(r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition")
     for c in task["Properties"]["ContainerDefinitions"]:
         if c["Name"] == "admin-api":
-            assert c.get("PortMappings") == [{"ContainerPort": 9091, "Protocol": "tcp"}]
+            assert c.get("PortMappings") == [
+                {"ContainerPort": 9091, "Protocol": "tcp"},
+                {"ContainerPort": 8090, "Protocol": "tcp"},
+            ]
         else:
             assert "PortMappings" not in c, f"{c['Name']} unexpectedly has a port"
+
+
+# ---------------------------------------------------------------------------
+# lakerunner v1.39 health server (port 8090) wiring
+# ---------------------------------------------------------------------------
+
+
+def test_each_container_has_distinct_health_check_port(td):
+    """All four containers share the merged task's network namespace, so they
+    cannot all bind the default health port (8090). admin-api keeps 8090 (the
+    ALB-probed one); the other three move to 8091/8092/8093 to avoid collision."""
+    expected = {
+        "admin-api": "8090",
+        "sweeper": "8091",
+        "monitoring": "8092",
+        "alert-evaluator": "8093",
+    }
+    for name, port in expected.items():
+        _, container = _task_def_for(td, name)
+        env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+        assert env.get("HEALTH_CHECK_PORT") == port, (
+            f"{name} HEALTH_CHECK_PORT must be {port}; got {env.get('HEALTH_CHECK_PORT')!r}"
+        )
+
+
+def test_admin_api_target_group_probes_health_port_8090(td):
+    """The ALB target group probes /healthz on the dedicated health server
+    (8090), not the 9091 API port where /healthz no longer lives (v1.39)."""
+    tg = next(r for r in td["Resources"].values()
+              if r["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup")
+    assert tg["Properties"]["HealthCheckPort"] == "8090"
+    assert tg["Properties"]["HealthCheckPath"] == "/healthz"
+
+
+def test_control_service_has_health_check_grace_period(td):
+    """60s margin for admin-api's health server (8090) to come up before the
+    ALB starts failing the task."""
+    svc = td["Resources"]["ControlService"]
+    assert svc["Properties"]["HealthCheckGracePeriodSeconds"] == 60
 
 
 # ---------------------------------------------------------------------------

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -209,6 +209,54 @@ def test_query_worker_service_has_no_load_balancers(td):
 
 
 # ---------------------------------------------------------------------------
+# lakerunner v1.39 health server (port 8090) wiring
+# ---------------------------------------------------------------------------
+
+
+def _query_api_container(td):
+    for res in td["Resources"].values():
+        if res["Type"] != "AWS::ECS::TaskDefinition":
+            continue
+        for container in res["Properties"]["ContainerDefinitions"]:
+            if container["Name"] == "query-api":
+                return container
+    raise AssertionError("no query-api container")
+
+
+def test_query_api_sets_health_check_port_env(td):
+    """v1.39 moved /healthz to a dedicated health server (port 8090, env
+    HEALTH_CHECK_PORT). Set it explicitly even though 8090 is the default."""
+    container = _query_api_container(td)
+    env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+    assert env.get("HEALTH_CHECK_PORT") == "8090"
+
+
+def test_query_api_container_exposes_api_and_health_ports(td):
+    """query-api exposes its API/traffic port plus the 8090 health server so
+    the ALB target group can probe /healthz on 8090."""
+    container = _query_api_container(td)
+    ports = [pm["ContainerPort"] for pm in container.get("PortMappings", [])]
+    assert 8090 in ports, f"expected 8090 health port mapping; got {ports}"
+    assert len(ports) == 2, f"expected API + health port mappings; got {ports}"
+
+
+def test_query_api_target_group_probes_health_port_8090(td):
+    """The ALB target group probes /healthz on 8090, not the API/traffic port
+    where /healthz no longer lives (v1.39)."""
+    tg = next(r for r in td["Resources"].values()
+              if r["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup")
+    assert tg["Properties"]["HealthCheckPort"] == "8090"
+    assert tg["Properties"]["HealthCheckPath"] == "/healthz"
+
+
+def test_query_api_service_has_health_check_grace_period(td):
+    """60s margin for the health server (8090) to come up before the ALB
+    starts failing the task."""
+    svc = _service_by_logical_id(td, "QueryApiService")
+    assert svc["Properties"]["HealthCheckGracePeriodSeconds"] == 60
+
+
+# ---------------------------------------------------------------------------
 # Task-to-task ingress for query-worker port
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
v1.39.0 moved health endpoints to a dedicated server on port 8090 (HEALTH_CHECK_PORT, /healthz); the admin UI removal took /healthz off the API port. ALB target groups for admin-api and query-api now probe 8090 instead of the traffic port (was failing → circuit-breaker rollback). Merged control task: distinct HEALTH_CHECK_PORT per container (8090/8091/8092/8093) to avoid an awsvpc port collision. Added HealthCheckGracePeriodSeconds=60 on the LB-fronted services. 472 passed; lint clean.