### PR TITLE
cleanup: optional --alb-sg-id to sweep the customer-supplied ALB SG

### DIFF
--- a/docs/operations/cleanup.md
+++ b/docs/operations/cleanup.md
@@ -40,6 +40,16 @@ scripts/cleanup-lakerunner.sh \
 
 Without `--yes` the script prints the plan and exits with code 2 so Jenkins can show the operator the blast radius before confirming.
 
+### Deleting the ALB security group
+
+`cardinal-alb-sg` is customer-supplied and owned by neither the `cardinal-lakerunner` nor the `cardinal-infrastructure` stack, so neither stack-delete reaches it. Pass `--alb-sg-id sg-...` to have the step-4 sweep delete it too (omit to leave it in place):
+
+```sh
+    --alb-sg-id sg-0ffe4f191fee82022 \
+```
+
+The ALB itself lives in the lakerunner stack and is gone by the time the sweep runs (step 1), so the delete is safe — **unless** another surviving security group still references `cardinal-alb-sg` as an ingress source (e.g. the v1.39 ALB-to-query/control health-port rules on port 8090). In that case AWS returns `DependencyViolation`; clear those ingress rules first, then re-run (every step is idempotent). The cleanup task role already holds `ec2:DeleteSecurityGroup` for the RDS SG, so no IAM change is needed.
+
 ## What happens
 
 1. Driver creates `cardinal-cleanup` (`--role-arn cardinal-cfn-deployer`) from the published `cardinal-cleanup.yaml`. The stack provisions a `cardinal-cleanup` task definition and a log group.

--- a/scripts/cleanup-lakerunner.sh
+++ b/scripts/cleanup-lakerunner.sh
@@ -36,6 +36,7 @@ infra_stack_name="cardinal-infrastructure"
 cleanup_stack_name="cardinal-cleanup"
 template_base_url="$DEFAULT_TEMPLATE_BASE_URL"
 wait_self_delete="false"
+alb_sg_id=""
 
 # --- internal test hooks (pure data transforms; no AWS) ---
 internal_plan_text=""
@@ -61,6 +62,10 @@ Optional:
                                         The cleanup task discovers retained
                                         resources from this stack.
   --cleanup-stack-name NAME             Default: cardinal-cleanup.
+  --alb-sg-id SG_ID                     Optional. Customer-supplied ALB
+                                        security group (cardinal-alb-sg) to
+                                        delete in the step-4 sweep. Owned by
+                                        neither stack. Skipped when omitted.
   --template-base-url URL               Default: cardinal-cfn-us-east-1 bucket.
   --wait-self-delete                    Wait for the cleanup stack's own
                                         delete-complete (off by default).
@@ -88,6 +93,7 @@ while [ $# -gt 0 ]; do
         --lakerunner-stack-name)        lakerunner_stack_name="$2";        shift 2 ;;
         --infra-stack-name)             infra_stack_name="$2";             shift 2 ;;
         --cleanup-stack-name)           cleanup_stack_name="$2";           shift 2 ;;
+        --alb-sg-id)                    alb_sg_id="$2";                    shift 2 ;;
         --template-base-url)            template_base_url="$2";            shift 2 ;;
         --wait-self-delete)             wait_self_delete="true";           shift   ;;
         --yes)                          yes_flag="true";                   shift   ;;
@@ -127,6 +133,8 @@ if [ -n "$required_missing" ]; then
 fi
 
 if [ "$yes_flag" != "true" ]; then
+    alb_sg_line="  alb sg:        (none; --alb-sg-id not set)"
+    [ -n "$alb_sg_id" ] && alb_sg_line="  alb sg:        delete $alb_sg_id (cardinal-alb-sg)"
     cat <<EOF >&2
 This will tear down a Cardinal install in the following AWS account/region:
   region:        $region
@@ -135,6 +143,7 @@ This will tear down a Cardinal install in the following AWS account/region:
   data layer:    drain + delete S3 ingest, RDS, SQS, secrets, SSM
                  (only resources tagged Application=cardinal-lakerunner,
                   ManagedBy=cardinal-data-setup-script; others are skipped)
+$alb_sg_line
   cleanup stack: $cleanup_stack_name (created and self-deleted)
 
 Re-run with --yes to proceed.
@@ -176,6 +185,7 @@ aws --region "$region" cloudformation create-stack \
         ParameterKey=CleanupExecutionRoleArn,ParameterValue="$cleanup_execution_role_arn" \
         ParameterKey=ClusterName,ParameterValue="$cluster_name" \
         ParameterKey=DeployerRoleArn,ParameterValue="$deployer_role_arn" \
+        ParameterKey=AlbSecurityGroupId,ParameterValue="$alb_sg_id" \
     >/dev/null
 aws --region "$region" cloudformation wait stack-create-complete \
     --stack-name "$cleanup_stack_name" \

--- a/src/cardinal_cfn/cardinal_cleanup.py
+++ b/src/cardinal_cfn/cardinal_cleanup.py
@@ -77,6 +77,17 @@ def build() -> Template:
         Type="String",
         Description="ECS cluster the cleanup task is launched into.",
     ))
+    p_alb_sg = t.add_parameter(Parameter(
+        "AlbSecurityGroupId",
+        Type="String",
+        Default="",
+        Description=(
+            "Optional. The customer-supplied ALB security group "
+            "(cardinal-alb-sg) to delete during the step-4 sweep. Owned by "
+            "neither stack, so neither stack-delete reaches it. Leave empty "
+            "to skip."
+        ),
+    ))
     p_deployer = t.add_parameter(Parameter(
         "DeployerRoleArn",
         Type="String",
@@ -124,6 +135,7 @@ def build() -> Template:
                 Environment(Name="INFRA_STACK_NAME",      Value=Ref(p_infra)),
                 Environment(Name="CLEANUP_STACK_NAME",    Value=Ref("AWS::StackName")),
                 Environment(Name="DEPLOYER_ROLE_ARN",     Value=Ref(p_deployer)),
+                Environment(Name="ALB_SG_ID",             Value=Ref(p_alb_sg)),
             ],
             LogConfiguration=LogConfiguration(
                 LogDriver="awslogs",

--- a/src/cardinal_cfn/cleanup_script.py
+++ b/src/cardinal_cfn/cleanup_script.py
@@ -20,6 +20,8 @@ The script implements the four-step teardown ordered as:
      other data-layer resource has DeletionPolicy: Retain and survives)
   4. sweep the Retain'd resources (S3 bucket itself, secrets, SSM
      parameters, SQS queue, RDS subnet group, the RDS final snapshot)
+     plus, optionally, the customer-supplied ALB security group when
+     ALB_SG_ID is set
 
 Then self-deletes the cardinal-cleanup stack.
 """
@@ -42,6 +44,8 @@ fail() { log "FATAL: $*"; exit 2; }
 [ -n "${CLEANUP_STACK_NAME:-}" ]    || fail "CLEANUP_STACK_NAME is unset"
 [ -n "${DEPLOYER_ROLE_ARN:-}" ]     || fail "DEPLOYER_ROLE_ARN is unset"
 [ -n "${CLUSTER_NAME:-}" ]          || fail "CLUSTER_NAME is unset"
+# ALB_SG_ID is optional: when empty, the ALB-SG sweep (step 4h) is a no-op.
+: "${ALB_SG_ID:=}"
 
 ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
 [ -n "$ACCOUNT" ] && [ "$ACCOUNT" != "None" ] \
@@ -419,6 +423,23 @@ delete_rds_security_group() {
     aws ec2 delete-security-group --group-id "$RDS_SG_ID"
 }
 
+# 4h -- ALB security group (cardinal-alb-sg). Customer-supplied, owned by
+# neither the lakerunner nor the infra stack, so neither stack-delete reaches
+# it. Optional: only swept when ALB_SG_ID is set. The ALB itself lives in the
+# lakerunner stack and is gone by now (step 1), so this is safe to delete --
+# unless another surviving SG still references it as an ingress source (e.g.
+# the v1.39 ALB->query/control health-port rules), in which case AWS returns
+# DependencyViolation and the operator must clear those rules first.
+delete_alb_security_group() {
+    if [ -z "$ALB_SG_ID" ]; then return 0; fi
+    if ! aws ec2 describe-security-groups --group-ids "$ALB_SG_ID" >/dev/null 2>&1; then
+        log "ALB security group $ALB_SG_ID already absent"
+        return 0
+    fi
+    log "deleting ALB security group $ALB_SG_ID"
+    aws ec2 delete-security-group --group-id "$ALB_SG_ID"
+}
+
 # 4g -- RDS snapshots produced by step 3 (Snapshot DeletionPolicy)
 delete_rds_snapshots() {
     if [ -z "$DB_INSTANCE_ID" ]; then return 0; fi
@@ -439,6 +460,7 @@ delete_ssm
 delete_sqs
 delete_db_subnet_group
 delete_rds_security_group
+delete_alb_security_group
 delete_rds_snapshots
 
 # ===========================================================================

--- a/tests/templates/test_cardinal_cleanup.py
+++ b/tests/templates/test_cardinal_cleanup.py
@@ -102,6 +102,7 @@ def test_environment_pins_required_vars(td):
         "INFRA_STACK_NAME":      {"Ref": "InfraStackName"},
         "CLEANUP_STACK_NAME":    {"Ref": "AWS::StackName"},
         "DEPLOYER_ROLE_ARN":     {"Ref": "DeployerRoleArn"},
+        "ALB_SG_ID":             {"Ref": "AlbSecurityGroupId"},
     }
 
 


### PR DESCRIPTION
## What

Adds an optional `--alb-sg-id` to the cleanup tool so it can delete the customer-supplied ALB security group (`cardinal-alb-sg`) during the step-4 sweep.

`cardinal-alb-sg` is customer-supplied and owned by **neither** the `cardinal-lakerunner` nor the `cardinal-infrastructure` stack, so neither stack-delete reaches it — the cleanup task previously left it behind, blocking VPC teardown.

## Design

- No hardcoded SG ID — this is the published, cross-install tool. The specific ID is supplied at invocation.
- New `AlbSecurityGroupId` CFN parameter (default `""`) → `ALB_SG_ID` env var → new `delete_alb_security_group` step in the step-4 sweep. No-op when unset.
- Swept after step 1 (lakerunner stack, and therefore the ALB, already gone), so the delete is safe.
- The cleanup task role already holds `ec2:DeleteSecurityGroup` (for the RDS SG), so **no IAM change** is needed.

## Caveat (documented in the runbook)

If a surviving SG still references `cardinal-alb-sg` as an ingress source (e.g. the v1.39 ALB→query/control health-port-8090 rules), AWS returns `DependencyViolation`; clear those rules and re-run (every step is idempotent).

## Files

| File | Change |
|---|---|
| `src/cardinal_cfn/cleanup_script.py` | `delete_alb_security_group` (step 4h), keyed off `ALB_SG_ID` |
| `src/cardinal_cfn/cardinal_cleanup.py` | `AlbSecurityGroupId` param → `ALB_SG_ID` env var |
| `scripts/cleanup-lakerunner.sh` | `--alb-sg-id` flag, passed as stack param, shown in pre-`--yes` plan |
| `docs/operations/cleanup.md` | Runbook section + `DependencyViolation` caveat |
| `tests/templates/test_cardinal_cleanup.py` | Asserts the new env var |

## Verification

- `make test` → 471 passed, 1 skipped
- `make lint` → clean (no errors/warnings)
- Plan with flag: `alb sg:  delete sg-... (cardinal-alb-sg)`; without: `alb sg:  (none; --alb-sg-id not set)`

## Rollout note

The driver pulls `cardinal-cleanup.yaml` from S3 by `--version`, so this takes effect only once published as a new tag (or via a custom `--template-base-url` mirror). The currently-published template does not yet carry `AlbSecurityGroupId`.