### PR TITLE
drivers: accept license + cert PEMs as direct string env vars (files optional)

### DIFF
--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -105,7 +105,8 @@ last.
 | `VERSION` | required | — |
 | `VPC_ID` | required | — |
 | `CLUSTER_ARN` | required | — |
-| `LICENSE_DATA_FILE` | required | path to license JSON, read into the license secret |
+| `LICENSE_DATA` | required* | Cardinal license token (`z64:...`) as a direct string, seeds the license secret |
+| `LICENSE_DATA_FILE` | required* | path fallback for `LICENSE_DATA` (one of the two is required) |
 | `ALB_SCHEME` | optional | template: `internal` |
 | `ALB_ALLOWED_CIDR1` | optional | template: `10.0.0.0/8` |
 | `ALB_ALLOWED_CIDR2` | optional | template: `172.16.0.0/12` |
@@ -260,9 +261,12 @@ exit. Set `CERTIFICATE_ARN` to use a real cert.
 | `VPC_ID` | required | — |
 | `PRIVATE_SUBNETS` | required | comma-separated private subnet ids |
 | `CERTIFICATE_ARN` | optional | ACM/IAM cert ARN for the Maestro HTTPS listener. If unset, the wrapper auto-generates a self-signed internal cert **only on first create** (re-runs keep the existing cert — no churn). Set it to use a real cert. |
-| `CERTIFICATE_BODY_FILE` | optional | PEM cert body path (overrides auto-generation; passed via `FILE_PARAMS`) |
-| `CERTIFICATE_PRIVATE_KEY_FILE` | optional | PEM private key path (overrides auto-generation; passed via `FILE_PARAMS`) |
-| `CERTIFICATE_CHAIN_FILE` | optional | PEM chain path (passed via `FILE_PARAMS`) |
+| `CERTIFICATE_BODY` | optional | PEM cert body as a direct string (overrides auto-generation; body + private key together). Written to a temp file and passed via `FILE_PARAMS`. |
+| `CERTIFICATE_PRIVATE_KEY` | optional | PEM private key as a direct string |
+| `CERTIFICATE_CHAIN` | optional | PEM chain as a direct string |
+| `CERTIFICATE_BODY_FILE` | optional | path fallback for `CERTIFICATE_BODY` |
+| `CERTIFICATE_PRIVATE_KEY_FILE` | optional | path fallback for `CERTIFICATE_PRIVATE_KEY` |
+| `CERTIFICATE_CHAIN_FILE` | optional | path fallback for `CERTIFICATE_CHAIN` |
 | `DEX_ADMIN_EMAIL` | optional | template: `admin@cardinal.local` |
 | `DEX_ADMIN_PASSWORD_HASH` | optional | template: empty — **needed for Maestro UI login** |
 | `DEX_CLIENT_ID` | optional | template: `maestro-ui` |

--- a/scripts-src/parts/deploy-lakerunner-infra-base.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-base.sh
@@ -28,9 +28,12 @@ Required:
   VERSION              Published template tag, e.g. v0.0.70.
   VPC_ID               VPC for the security groups.
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
-  LICENSE_DATA_FILE    Path to license JSON (seeds the license secret).
+  LICENSE_DATA         Cardinal license token (z64:...), seeds the license
+                       secret. Or supply LICENSE_DATA_FILE instead.
 
 Optional (template defaults preserved when unset):
+  LICENSE_DATA_FILE            Path to a file holding the license token
+                               (fallback for LICENSE_DATA).
   ALB_SCHEME                   internet-facing | internal (template default: internal).
   ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
   ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
@@ -61,18 +64,23 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
-[ -z "${LICENSE_DATA_FILE:-}" ] && missing="$missing LICENSE_DATA_FILE"
+{ [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
 if [ -n "$missing" ]; then
     usage >&2
     echo "[deploy-lakerunner-infra-base] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
-if [ ! -r "$LICENSE_DATA_FILE" ]; then
-    echo "[deploy-lakerunner-infra-base] ERROR: cannot read LICENSE_DATA_FILE: $LICENSE_DATA_FILE" >&2
-    exit 2
+# LICENSE_DATA (direct token) wins; LICENSE_DATA_FILE is the file fallback.
+if [ -n "${LICENSE_DATA:-}" ]; then
+    license_data="$LICENSE_DATA"
+else
+    if [ ! -r "$LICENSE_DATA_FILE" ]; then
+        echo "[deploy-lakerunner-infra-base] ERROR: cannot read LICENSE_DATA_FILE: $LICENSE_DATA_FILE" >&2
+        exit 2
+    fi
+    license_data=$(cat "$LICENSE_DATA_FILE")
 fi
-license_data=$(cat "$LICENSE_DATA_FILE")
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -53,9 +53,13 @@ Optional (template defaults preserved when unset):
                               warn; fine for internal/test).  Re-runs (UPDATE)
                               keep the existing cert untouched -- no churn.  Set
                               CERTIFICATE_ARN to use a real cert.
-  CERTIFICATE_BODY_FILE       PEM cert body (path).  Overrides auto-generation.
-  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path).  Overrides auto-generation.
-  CERTIFICATE_CHAIN_FILE      PEM chain (path).
+  CERTIFICATE_BODY            PEM cert body (string).  Overrides auto-generation
+                              (body + private key must be supplied together).
+  CERTIFICATE_PRIVATE_KEY     PEM private key (string).
+  CERTIFICATE_CHAIN           PEM chain (string, optional).
+  CERTIFICATE_BODY_FILE       PEM cert body (path) -- fallback for CERTIFICATE_BODY.
+  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path) -- fallback for CERTIFICATE_PRIVATE_KEY.
+  CERTIFICATE_CHAIN_FILE      PEM chain (path) -- fallback for CERTIFICATE_CHAIN.
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
   DEX_CLIENT_ID               (template default maestro-ui).
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
@@ -205,55 +209,90 @@ DexInitImage=$DEX_INIT_IMAGE"
 DbInitImage=$DB_INIT_IMAGE"
 
 # --- Certificate handling. ---------------------------------------------------
-# Cert PEM material is passed via FILE_PARAMS (multi-line safe), never inlined
-# into the newline-delimited PARAMS string.
+# Cert PEM material reaches the template via FILE_PARAMS (multi-line safe), never
+# inlined into the newline-delimited PARAMS string.  Operators supply each PEM as
+# a direct string env var (CERTIFICATE_BODY / CERTIFICATE_PRIVATE_KEY /
+# CERTIFICATE_CHAIN) -- written into a temp dir here -- or as a *_FILE path
+# fallback.  The string form wins when both are set.
 #
 # Create-only auto-generation: the cert.yaml child builds an AWS::IAM::Server-
 # Certificate from CertificateBody/CertificatePrivateKey when CertificateArn is
 # empty.  A fresh self-signed PEM on every re-run would replace that cert and
 # churn the ALB listener, so we generate it ONLY on first create:
 #   - CERTIFICATE_ARN set            -> pass it (stable ARN, no churn).
-#   - empty + PEM files supplied     -> pass the supplied PEMs.
+#   - empty + PEM supplied           -> pass the supplied PEMs.
 #   - empty + stack absent (CREATE)  -> generate a self-signed cert, pass it.
-#   - empty + stack present (UPDATE) -> pass nothing; deploy-stack.sh resolves
+#   - empty + stack present (UPDATE) -> pass nothing; the engine resolves
 #     CertificateBody/CertificatePrivateKey to UsePreviousValue, keeping the
 #     existing IAM ServerCertificate untouched.
 file_params=""
 cert_dir=""
+cert_body_path=""
+cert_key_path=""
+cert_chain_path=""
 
 if [ -n "${CERTIFICATE_ARN:-}" ]; then
     params="$params
 CertificateArn=$CERTIFICATE_ARN"
-elif [ -n "${CERTIFICATE_BODY_FILE:-}" ] || [ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ]; then
-    [ -r "${CERTIFICATE_BODY_FILE:-}" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_BODY_FILE: ${CERTIFICATE_BODY_FILE:-}" >&2; exit 2; }
-    [ -r "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_PRIVATE_KEY_FILE: ${CERTIFICATE_PRIVATE_KEY_FILE:-}" >&2; exit 2; }
-    file_params="CertificateBody=$CERTIFICATE_BODY_FILE
-CertificatePrivateKey=$CERTIFICATE_PRIVATE_KEY_FILE"
-    if [ -n "${CERTIFICATE_CHAIN_FILE:-}" ]; then
-        [ -r "$CERTIFICATE_CHAIN_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_CHAIN_FILE: $CERTIFICATE_CHAIN_FILE" >&2; exit 2; }
-        file_params="$file_params
-CertificateChain=$CERTIFICATE_CHAIN_FILE"
-    fi
 else
-    # No ARN, no PEM files.  Generate only on first create (stack absent).
-    if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
-        echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
+    # Resolve each PEM to a file path: the direct string env var (written into a
+    # temp dir) wins; the matching *_FILE path is the fallback.
+    if [ -n "${CERTIFICATE_BODY:-}" ]; then
+        [ -n "$cert_dir" ] || cert_dir=$(mktemp -d)
+        printf '%s\n' "$CERTIFICATE_BODY" > "$cert_dir/cert.pem"
+        cert_body_path="$cert_dir/cert.pem"
+    elif [ -n "${CERTIFICATE_BODY_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_BODY_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_BODY_FILE: $CERTIFICATE_BODY_FILE" >&2; exit 2; }
+        cert_body_path="$CERTIFICATE_BODY_FILE"
+    fi
+    if [ -n "${CERTIFICATE_PRIVATE_KEY:-}" ]; then
+        [ -n "$cert_dir" ] || cert_dir=$(mktemp -d)
+        printf '%s\n' "$CERTIFICATE_PRIVATE_KEY" > "$cert_dir/key.pem"
+        cert_key_path="$cert_dir/key.pem"
+    elif [ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_PRIVATE_KEY_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_PRIVATE_KEY_FILE: $CERTIFICATE_PRIVATE_KEY_FILE" >&2; exit 2; }
+        cert_key_path="$CERTIFICATE_PRIVATE_KEY_FILE"
+    fi
+    if [ -n "${CERTIFICATE_CHAIN:-}" ]; then
+        [ -n "$cert_dir" ] || cert_dir=$(mktemp -d)
+        printf '%s\n' "$CERTIFICATE_CHAIN" > "$cert_dir/chain.pem"
+        cert_chain_path="$cert_dir/chain.pem"
+    elif [ -n "${CERTIFICATE_CHAIN_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_CHAIN_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_CHAIN_FILE: $CERTIFICATE_CHAIN_FILE" >&2; exit 2; }
+        cert_chain_path="$CERTIFICATE_CHAIN_FILE"
+    fi
+
+    if [ -n "$cert_body_path" ] || [ -n "$cert_key_path" ]; then
+        # Supplied PEM: body and key must come together.
+        [ -n "$cert_body_path" ] || { echo "[deploy-lakerunner-services] ERROR: private key supplied without a certificate body (set CERTIFICATE_BODY or CERTIFICATE_BODY_FILE)" >&2; exit 2; }
+        [ -n "$cert_key_path" ] || { echo "[deploy-lakerunner-services] ERROR: certificate body supplied without a private key (set CERTIFICATE_PRIVATE_KEY or CERTIFICATE_PRIVATE_KEY_FILE)" >&2; exit 2; }
+        file_params="CertificateBody=$cert_body_path
+CertificatePrivateKey=$cert_key_path"
+        if [ -n "$cert_chain_path" ]; then
+            file_params="$file_params
+CertificateChain=$cert_chain_path"
+        fi
     else
-        if ! command -v openssl >/dev/null 2>&1; then
-            echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_*_FILE" >&2
-            exit 2
-        fi
-        echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
-        cert_dir=$(mktemp -d)
-        if ! openssl req -x509 -newkey rsa:2048 -nodes \
-                -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
-                -days 825 -subj "/CN=cardinal.test" \
-                -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
-            echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
-            exit 1
-        fi
-        file_params="CertificateBody=$cert_dir/cert.pem
+        # No ARN, no PEM.  Generate only on first create (stack absent).
+        if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
+            echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
+        else
+            if ! command -v openssl >/dev/null 2>&1; then
+                echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_BODY+CERTIFICATE_PRIVATE_KEY (or their *_FILE variants)" >&2
+                exit 2
+            fi
+            echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
+            cert_dir=$(mktemp -d)
+            if ! openssl req -x509 -newkey rsa:2048 -nodes \
+                    -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
+                    -days 825 -subj "/CN=cardinal.test" \
+                    -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
+                echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
+                exit 1
+            fi
+            file_params="CertificateBody=$cert_dir/cert.pem
 CertificatePrivateKey=$cert_dir/key.pem"
+        fi
     fi
 fi
 

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -29,9 +29,12 @@ Required:
   VERSION              Published template tag, e.g. v0.0.70.
   VPC_ID               VPC for the security groups.
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
-  LICENSE_DATA_FILE    Path to license JSON (seeds the license secret).
+  LICENSE_DATA         Cardinal license token (z64:...), seeds the license
+                       secret. Or supply LICENSE_DATA_FILE instead.
 
 Optional (template defaults preserved when unset):
+  LICENSE_DATA_FILE            Path to a file holding the license token
+                               (fallback for LICENSE_DATA).
   ALB_SCHEME                   internet-facing | internal (template default: internal).
   ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
   ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
@@ -62,18 +65,23 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
-[ -z "${LICENSE_DATA_FILE:-}" ] && missing="$missing LICENSE_DATA_FILE"
+{ [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
 if [ -n "$missing" ]; then
     usage >&2
     echo "[deploy-lakerunner-infra-base] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
     exit 2
 fi
 
-if [ ! -r "$LICENSE_DATA_FILE" ]; then
-    echo "[deploy-lakerunner-infra-base] ERROR: cannot read LICENSE_DATA_FILE: $LICENSE_DATA_FILE" >&2
-    exit 2
+# LICENSE_DATA (direct token) wins; LICENSE_DATA_FILE is the file fallback.
+if [ -n "${LICENSE_DATA:-}" ]; then
+    license_data="$LICENSE_DATA"
+else
+    if [ ! -r "$LICENSE_DATA_FILE" ]; then
+        echo "[deploy-lakerunner-infra-base] ERROR: cannot read LICENSE_DATA_FILE: $LICENSE_DATA_FILE" >&2
+        exit 2
+    fi
+    license_data=$(cat "$LICENSE_DATA_FILE")
 fi
-license_data=$(cat "$LICENSE_DATA_FILE")
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -54,9 +54,13 @@ Optional (template defaults preserved when unset):
                               warn; fine for internal/test).  Re-runs (UPDATE)
                               keep the existing cert untouched -- no churn.  Set
                               CERTIFICATE_ARN to use a real cert.
-  CERTIFICATE_BODY_FILE       PEM cert body (path).  Overrides auto-generation.
-  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path).  Overrides auto-generation.
-  CERTIFICATE_CHAIN_FILE      PEM chain (path).
+  CERTIFICATE_BODY            PEM cert body (string).  Overrides auto-generation
+                              (body + private key must be supplied together).
+  CERTIFICATE_PRIVATE_KEY     PEM private key (string).
+  CERTIFICATE_CHAIN           PEM chain (string, optional).
+  CERTIFICATE_BODY_FILE       PEM cert body (path) -- fallback for CERTIFICATE_BODY.
+  CERTIFICATE_PRIVATE_KEY_FILE PEM private key (path) -- fallback for CERTIFICATE_PRIVATE_KEY.
+  CERTIFICATE_CHAIN_FILE      PEM chain (path) -- fallback for CERTIFICATE_CHAIN.
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
   DEX_CLIENT_ID               (template default maestro-ui).
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
@@ -206,55 +210,90 @@ DexInitImage=$DEX_INIT_IMAGE"
 DbInitImage=$DB_INIT_IMAGE"
 
 # --- Certificate handling. ---------------------------------------------------
-# Cert PEM material is passed via FILE_PARAMS (multi-line safe), never inlined
-# into the newline-delimited PARAMS string.
+# Cert PEM material reaches the template via FILE_PARAMS (multi-line safe), never
+# inlined into the newline-delimited PARAMS string.  Operators supply each PEM as
+# a direct string env var (CERTIFICATE_BODY / CERTIFICATE_PRIVATE_KEY /
+# CERTIFICATE_CHAIN) -- written into a temp dir here -- or as a *_FILE path
+# fallback.  The string form wins when both are set.
 #
 # Create-only auto-generation: the cert.yaml child builds an AWS::IAM::Server-
 # Certificate from CertificateBody/CertificatePrivateKey when CertificateArn is
 # empty.  A fresh self-signed PEM on every re-run would replace that cert and
 # churn the ALB listener, so we generate it ONLY on first create:
 #   - CERTIFICATE_ARN set            -> pass it (stable ARN, no churn).
-#   - empty + PEM files supplied     -> pass the supplied PEMs.
+#   - empty + PEM supplied           -> pass the supplied PEMs.
 #   - empty + stack absent (CREATE)  -> generate a self-signed cert, pass it.
-#   - empty + stack present (UPDATE) -> pass nothing; deploy-stack.sh resolves
+#   - empty + stack present (UPDATE) -> pass nothing; the engine resolves
 #     CertificateBody/CertificatePrivateKey to UsePreviousValue, keeping the
 #     existing IAM ServerCertificate untouched.
 file_params=""
 cert_dir=""
+cert_body_path=""
+cert_key_path=""
+cert_chain_path=""
 
 if [ -n "${CERTIFICATE_ARN:-}" ]; then
     params="$params
 CertificateArn=$CERTIFICATE_ARN"
-elif [ -n "${CERTIFICATE_BODY_FILE:-}" ] || [ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ]; then
-    [ -r "${CERTIFICATE_BODY_FILE:-}" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_BODY_FILE: ${CERTIFICATE_BODY_FILE:-}" >&2; exit 2; }
-    [ -r "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_PRIVATE_KEY_FILE: ${CERTIFICATE_PRIVATE_KEY_FILE:-}" >&2; exit 2; }
-    file_params="CertificateBody=$CERTIFICATE_BODY_FILE
-CertificatePrivateKey=$CERTIFICATE_PRIVATE_KEY_FILE"
-    if [ -n "${CERTIFICATE_CHAIN_FILE:-}" ]; then
-        [ -r "$CERTIFICATE_CHAIN_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_CHAIN_FILE: $CERTIFICATE_CHAIN_FILE" >&2; exit 2; }
-        file_params="$file_params
-CertificateChain=$CERTIFICATE_CHAIN_FILE"
-    fi
 else
-    # No ARN, no PEM files.  Generate only on first create (stack absent).
-    if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
-        echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
+    # Resolve each PEM to a file path: the direct string env var (written into a
+    # temp dir) wins; the matching *_FILE path is the fallback.
+    if [ -n "${CERTIFICATE_BODY:-}" ]; then
+        [ -n "$cert_dir" ] || cert_dir=$(mktemp -d)
+        printf '%s\n' "$CERTIFICATE_BODY" > "$cert_dir/cert.pem"
+        cert_body_path="$cert_dir/cert.pem"
+    elif [ -n "${CERTIFICATE_BODY_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_BODY_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_BODY_FILE: $CERTIFICATE_BODY_FILE" >&2; exit 2; }
+        cert_body_path="$CERTIFICATE_BODY_FILE"
+    fi
+    if [ -n "${CERTIFICATE_PRIVATE_KEY:-}" ]; then
+        [ -n "$cert_dir" ] || cert_dir=$(mktemp -d)
+        printf '%s\n' "$CERTIFICATE_PRIVATE_KEY" > "$cert_dir/key.pem"
+        cert_key_path="$cert_dir/key.pem"
+    elif [ -n "${CERTIFICATE_PRIVATE_KEY_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_PRIVATE_KEY_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_PRIVATE_KEY_FILE: $CERTIFICATE_PRIVATE_KEY_FILE" >&2; exit 2; }
+        cert_key_path="$CERTIFICATE_PRIVATE_KEY_FILE"
+    fi
+    if [ -n "${CERTIFICATE_CHAIN:-}" ]; then
+        [ -n "$cert_dir" ] || cert_dir=$(mktemp -d)
+        printf '%s\n' "$CERTIFICATE_CHAIN" > "$cert_dir/chain.pem"
+        cert_chain_path="$cert_dir/chain.pem"
+    elif [ -n "${CERTIFICATE_CHAIN_FILE:-}" ]; then
+        [ -r "$CERTIFICATE_CHAIN_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read CERTIFICATE_CHAIN_FILE: $CERTIFICATE_CHAIN_FILE" >&2; exit 2; }
+        cert_chain_path="$CERTIFICATE_CHAIN_FILE"
+    fi
+
+    if [ -n "$cert_body_path" ] || [ -n "$cert_key_path" ]; then
+        # Supplied PEM: body and key must come together.
+        [ -n "$cert_body_path" ] || { echo "[deploy-lakerunner-services] ERROR: private key supplied without a certificate body (set CERTIFICATE_BODY or CERTIFICATE_BODY_FILE)" >&2; exit 2; }
+        [ -n "$cert_key_path" ] || { echo "[deploy-lakerunner-services] ERROR: certificate body supplied without a private key (set CERTIFICATE_PRIVATE_KEY or CERTIFICATE_PRIVATE_KEY_FILE)" >&2; exit 2; }
+        file_params="CertificateBody=$cert_body_path
+CertificatePrivateKey=$cert_key_path"
+        if [ -n "$cert_chain_path" ]; then
+            file_params="$file_params
+CertificateChain=$cert_chain_path"
+        fi
     else
-        if ! command -v openssl >/dev/null 2>&1; then
-            echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_*_FILE" >&2
-            exit 2
-        fi
-        echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
-        cert_dir=$(mktemp -d)
-        if ! openssl req -x509 -newkey rsa:2048 -nodes \
-                -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
-                -days 825 -subj "/CN=cardinal.test" \
-                -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
-            echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
-            exit 1
-        fi
-        file_params="CertificateBody=$cert_dir/cert.pem
+        # No ARN, no PEM.  Generate only on first create (stack absent).
+        if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
+            echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
+        else
+            if ! command -v openssl >/dev/null 2>&1; then
+                echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_BODY+CERTIFICATE_PRIVATE_KEY (or their *_FILE variants)" >&2
+                exit 2
+            fi
+            echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
+            cert_dir=$(mktemp -d)
+            if ! openssl req -x509 -newkey rsa:2048 -nodes \
+                    -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
+                    -days 825 -subj "/CN=cardinal.test" \
+                    -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
+                echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
+                exit 1
+            fi
+            file_params="CertificateBody=$cert_dir/cert.pem
 CertificatePrivateKey=$cert_dir/key.pem"
+        fi
     fi
 fi
 

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -166,6 +166,50 @@ def test_lakerunner_services_supports_alb_scheme():
     assert "AlbScheme=$ALB_SCHEME" in text
 
 
+def test_infra_base_license_accepts_string_or_file():
+    """LICENSE_DATA (direct token string) is the primary input; LICENSE_DATA_FILE
+    is kept as a file fallback. One of the two is required."""
+    script = SCRIPTS_DIR / "deploy-lakerunner-infra-base.sh"
+    text = script.read_text()
+    assert 'license_data="$LICENSE_DATA"' in text, "no direct-string license path"
+    assert 'cat "$LICENSE_DATA_FILE"' in text, "LICENSE_DATA_FILE fallback dropped"
+
+    # Behavioral: LICENSE_DATA alone satisfies the license requirement.
+    with_str = subprocess.run(
+        ["sh", str(script)],
+        capture_output=True,
+        text=True,
+        env={"PATH": TEST_PATH, "LICENSE_DATA": "z64:test"},
+    )
+    miss = [ln for ln in (with_str.stdout + with_str.stderr).splitlines()
+            if "missing required" in ln]
+    assert miss and "LICENSE_DATA" not in miss[0], (
+        f"LICENSE_DATA should satisfy the requirement: {miss}"
+    )
+
+    # And with neither var, LICENSE_DATA is reported missing.
+    without = subprocess.run(
+        ["sh", str(script)], capture_output=True, text=True, env={"PATH": TEST_PATH}
+    )
+    miss2 = [ln for ln in (without.stdout + without.stderr).splitlines()
+             if "missing required" in ln]
+    assert miss2 and "LICENSE_DATA" in miss2[0], (
+        f"LICENSE_DATA should be required when unset: {miss2}"
+    )
+
+
+def test_services_cert_accepts_string_or_file():
+    """Cert PEMs accept a direct string env var (written to a temp dir) with the
+    *_FILE path kept as a fallback."""
+    text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
+    # String PEM -> temp file (then FILE_PARAMS reads it, multi-line safe).
+    assert 'cert_body_path="$cert_dir/cert.pem"' in text
+    assert '"$CERTIFICATE_BODY"' in text
+    # *_FILE fallbacks kept.
+    assert 'cert_body_path="$CERTIFICATE_BODY_FILE"' in text
+    assert 'cert_key_path="$CERTIFICATE_PRIVATE_KEY_FILE"' in text
+
+
 def test_lakerunner_services_drops_otel_replicas():
     """The lakerunner-services template no longer has an OtelReplicas param;
     the wrapper must not pass it (dead plumbing)."""


### PR DESCRIPTION
Files are friction for operators, so the chained deploy drivers now accept the license token and cert PEMs as plain string env vars. The `_FILE` variants stay as fallbacks (additive, non-breaking).

## infra-base
- `LICENSE_DATA` — the `z64:...` token as a direct string (primary).
- `LICENSE_DATA_FILE` — path fallback. One of the two is required.

## services (cert)
- `CERTIFICATE_BODY` / `CERTIFICATE_PRIVATE_KEY` / `CERTIFICATE_CHAIN` — PEM strings. The driver writes them into its existing cert temp dir and feeds them via `FILE_PARAMS` (multi-line safe; the engine's single trap already cleans the temp dir).
- `CERTIFICATE_*_FILE` — path fallbacks. String wins when both are set.
- The create-only self-signed fallback is unchanged.

## Notes
- Regenerated `scripts/` via `make scripts` (drift test enforces).
- Added driver tests; updated `jenkins-chained-deploy.md`.
- The monolith `deploy-lakerunner.sh` is untouched (pending removal).
- Independent of #175 (Aurora revert) and #176 (dev-scripts reorg) — disjoint files.

Verification: shellcheck clean; multi-line PEM verified to round-trip; 477 passed, 1 skipped.