### PR TITLE
s3: make bucket PublicAccessBlock opt-in (default off)

### DIFF
--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -114,6 +114,7 @@ last.
 | `ORGANIZATION_ID` | optional | template default |
 | `INITIAL_INGEST_API_KEY` | optional | template: empty |
 | `COOKED_BUCKET_NAME` | optional | template: generated |
+| `CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK` | optional | `true` sets the cooked bucket's S3 Block Public Access config; template default `false` (not set — relies on AWS account/bucket default BPA, avoids needing `s3:PutBucketPublicAccessBlock`) |
 | `LICENSE_SECRET_NAME` | optional | template: `cardinal-license` |
 | `ADMIN_KEY_SECRET_NAME` | optional | template: `cardinal-admin-key` |
 | `API_KEYS_PARAM_NAME` | optional | template: `/cardinal/api-keys` |
@@ -177,6 +178,7 @@ PRIVATE_SUBNETS=subnet-1,subnet-2 \
 | `EXTERNAL_ID` | optional | template: empty |
 | `RAW_BUCKET_NAME` | optional | template: generated |
 | `RAW_BUCKET_LIFECYCLE_DAYS` | optional | template: `7` |
+| `CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK` | optional | `true` sets the raw bucket's S3 Block Public Access config; template default `false` (not set) |
 | `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` |
 | `DEPLOYER_ROLE_ARN` | optional | unset |
 | `NO_EXECUTE` | optional | unset |

--- a/scripts-src/parts/deploy-lakerunner-infra-base.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-base.sh
@@ -41,6 +41,9 @@ Optional (template defaults preserved when unset):
   ORGANIZATION_ID              Canonical org id seeded into config.
   INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
   COOKED_BUCKET_NAME           Explicit cooked bucket name.
+  CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
+                               'true' to set the cooked bucket's S3 Block Public
+                               Access config (template default 'false': not set).
   LICENSE_SECRET_NAME          (template default cardinal-license).
   ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
   API_KEYS_PARAM_NAME          (template default /cardinal/api-keys).
@@ -106,6 +109,8 @@ OrganizationId=$ORGANIZATION_ID"
 InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
 [ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params
 CookedBucketName=$COOKED_BUCKET_NAME"
+[ -n "${CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK:-}" ] && params="$params
+ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK"
 [ -n "${LICENSE_SECRET_NAME:-}" ] && params="$params
 LicenseSecretName=$LICENSE_SECRET_NAME"
 [ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params

--- a/scripts-src/parts/deploy-satellite-infra-base.sh
+++ b/scripts-src/parts/deploy-satellite-infra-base.sh
@@ -33,6 +33,9 @@ Optional (template defaults preserved when unset):
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
   RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
   RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
+  CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
+                             'true' to set the raw bucket's S3 Block Public
+                             Access config (template default 'false': not set).
   TEMPLATE_BASE_URL          Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN          Passed to create-change-set.
   NO_EXECUTE                 Non-empty: change-set only, do not execute.
@@ -68,6 +71,8 @@ params=""
 [ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME
 "
 [ -n "${RAW_BUCKET_LIFECYCLE_DAYS:-}" ] && params="${params}RawBucketLifecycleDays=$RAW_BUCKET_LIFECYCLE_DAYS
+"
+[ -n "${CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK:-}" ] && params="${params}ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
 "
 
 PARAMS="$params"

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -42,6 +42,9 @@ Optional (template defaults preserved when unset):
   ORGANIZATION_ID              Canonical org id seeded into config.
   INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
   COOKED_BUCKET_NAME           Explicit cooked bucket name.
+  CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
+                               'true' to set the cooked bucket's S3 Block Public
+                               Access config (template default 'false': not set).
   LICENSE_SECRET_NAME          (template default cardinal-license).
   ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
   API_KEYS_PARAM_NAME          (template default /cardinal/api-keys).
@@ -107,6 +110,8 @@ OrganizationId=$ORGANIZATION_ID"
 InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
 [ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params
 CookedBucketName=$COOKED_BUCKET_NAME"
+[ -n "${CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK:-}" ] && params="$params
+ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK"
 [ -n "${LICENSE_SECRET_NAME:-}" ] && params="$params
 LicenseSecretName=$LICENSE_SECRET_NAME"
 [ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -34,6 +34,9 @@ Optional (template defaults preserved when unset):
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
   RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
   RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
+  CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
+                             'true' to set the raw bucket's S3 Block Public
+                             Access config (template default 'false': not set).
   TEMPLATE_BASE_URL          Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN          Passed to create-change-set.
   NO_EXECUTE                 Non-empty: change-set only, do not execute.
@@ -69,6 +72,8 @@ params=""
 [ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME
 "
 [ -n "${RAW_BUCKET_LIFECYCLE_DAYS:-}" ] && params="${params}RawBucketLifecycleDays=$RAW_BUCKET_LIFECYCLE_DAYS
+"
+[ -n "${CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK:-}" ] && params="${params}ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
 "
 
 PARAMS="$params"

--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -171,6 +171,18 @@ def build() -> Template:
         ),
         AllowedPattern=r"^$|^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
     ))
+    t.add_parameter(Parameter(
+        "ConfigureBucketPublicAccessBlock",
+        Type="String",
+        Default="false",
+        AllowedValues=["false", "true"],
+        Description=(
+            "When 'true', set the cooked bucket's PublicAccessBlockConfiguration "
+            "(all four flags). Default 'false' leaves it unset: new buckets are "
+            "already covered by AWS account/bucket default Block Public Access, "
+            "and setting it explicitly requires s3:PutBucketPublicAccessBlock."
+        ),
+    ))
     license_secret_name = t.add_parameter(Parameter(
         "LicenseSecretName",
         Type="String",
@@ -301,6 +313,10 @@ def build() -> Template:
     t.add_condition(
         "UseDefaultCookedBucketName",
         Equals(Ref(cooked_bucket_name), ""),
+    )
+    t.add_condition(
+        "AddCookedBucketPublicAccessBlock",
+        Equals(Ref("ConfigureBucketPublicAccessBlock"), "true"),
     )
     t.add_condition(
         "HasInitialIngestApiKey",
@@ -769,11 +785,15 @@ def build() -> Template:
             Bucket(
                 "CookedBucket",
                 BucketName=cooked_bucket_name_value,
-                PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
-                    BlockPublicAcls=True,
-                    BlockPublicPolicy=True,
-                    IgnorePublicAcls=True,
-                    RestrictPublicBuckets=True,
+                PublicAccessBlockConfiguration=If(
+                    "AddCookedBucketPublicAccessBlock",
+                    PublicAccessBlockConfiguration(
+                        BlockPublicAcls=True,
+                        BlockPublicPolicy=True,
+                        IgnorePublicAcls=True,
+                        RestrictPublicBuckets=True,
+                    ),
+                    Ref("AWS::NoValue"),
                 ),
                 BucketEncryption=BucketEncryption(
                     ServerSideEncryptionConfiguration=[

--- a/src/cardinal_cfn/satellite_infra_base.py
+++ b/src/cardinal_cfn/satellite_infra_base.py
@@ -117,8 +117,28 @@ def build() -> Template:
         )
     )
 
+    t.add_parameter(
+        Parameter(
+            "ConfigureBucketPublicAccessBlock",
+            Type="String",
+            Default="false",
+            AllowedValues=["false", "true"],
+            Description=(
+                "When 'true', set the raw bucket's PublicAccessBlockConfiguration "
+                "(all four flags). Default 'false' leaves it unset: new buckets "
+                "are already covered by AWS account/bucket default Block Public "
+                "Access, and setting it explicitly requires "
+                "s3:PutBucketPublicAccessBlock."
+            ),
+        )
+    )
+
     t.add_condition("UseDefaultBucketName", Equals(Ref("RawBucketName"), ""))
     t.add_condition("HasExternalId", Not(Equals(Ref("ExternalId"), "")))
+    t.add_condition(
+        "AddRawBucketPublicAccessBlock",
+        Equals(Ref("ConfigureBucketPublicAccessBlock"), "true"),
+    )
 
     bucket_name_value = If(
         "UseDefaultBucketName",
@@ -172,11 +192,15 @@ def build() -> Template:
                 # is not yet in place, so the bucket is created after it.
                 DependsOn="RawIngestQueuePolicy",
                 BucketName=bucket_name_value,
-                PublicAccessBlockConfiguration=PublicAccessBlockConfiguration(
-                    BlockPublicAcls=True,
-                    BlockPublicPolicy=True,
-                    IgnorePublicAcls=True,
-                    RestrictPublicBuckets=True,
+                PublicAccessBlockConfiguration=If(
+                    "AddRawBucketPublicAccessBlock",
+                    PublicAccessBlockConfiguration(
+                        BlockPublicAcls=True,
+                        BlockPublicPolicy=True,
+                        IgnorePublicAcls=True,
+                        RestrictPublicBuckets=True,
+                    ),
+                    Ref("AWS::NoValue"),
                 ),
                 BucketEncryption=BucketEncryption(
                     ServerSideEncryptionConfiguration=[

--- a/tests/templates/test_lakerunner_infra_base.py
+++ b/tests/templates/test_lakerunner_infra_base.py
@@ -252,12 +252,23 @@ def test_cooked_bucket_encrypted_and_pab(td):
     props = td["Resources"]["CookedBucket"]["Properties"]
     enc = props["BucketEncryption"]["ServerSideEncryptionConfiguration"][0]
     assert enc["ServerSideEncryptionByDefault"]["SSEAlgorithm"] == "AES256"
-    assert props["PublicAccessBlockConfiguration"] == {
+    # PublicAccessBlock is opt-in (default off): the property is wrapped in an
+    # Fn::If keyed on AddCookedBucketPublicAccessBlock, falling back to NoValue.
+    pab = props["PublicAccessBlockConfiguration"]["Fn::If"]
+    assert pab[0] == "AddCookedBucketPublicAccessBlock"
+    assert pab[1] == {
         "BlockPublicAcls": True,
         "BlockPublicPolicy": True,
         "IgnorePublicAcls": True,
         "RestrictPublicBuckets": True,
     }
+    assert pab[2] == {"Ref": "AWS::NoValue"}
+
+
+def test_public_access_block_param_defaults_off(td):
+    p = td["Parameters"]["ConfigureBucketPublicAccessBlock"]
+    assert p["Default"] == "false"
+    assert set(p["AllowedValues"]) == {"false", "true"}
 
 
 def test_no_sqs_resources(td):

--- a/tests/templates/test_satellite_infra_base.py
+++ b/tests/templates/test_satellite_infra_base.py
@@ -52,16 +52,23 @@ def test_bucket_is_delete_policy(td):
     assert b["UpdateReplacePolicy"] == "Delete"
 
 
-def test_bucket_blocks_public_access(td):
+def test_bucket_public_access_block_opt_in(td):
+    # PublicAccessBlock is opt-in (default off): wrapped in an Fn::If keyed on
+    # AddRawBucketPublicAccessBlock, falling back to NoValue.
     pab = td["Resources"]["RawIngestBucket"]["Properties"][
         "PublicAccessBlockConfiguration"
-    ]
-    assert pab == {
+    ]["Fn::If"]
+    assert pab[0] == "AddRawBucketPublicAccessBlock"
+    assert pab[1] == {
         "BlockPublicAcls": True,
         "BlockPublicPolicy": True,
         "IgnorePublicAcls": True,
         "RestrictPublicBuckets": True,
     }
+    assert pab[2] == {"Ref": "AWS::NoValue"}
+    p = td["Parameters"]["ConfigureBucketPublicAccessBlock"]
+    assert p["Default"] == "false"
+    assert set(p["AllowedValues"]) == {"false", "true"}
 
 
 def test_bucket_is_encrypted(td):


### PR DESCRIPTION
Setting a bucket's `PublicAccessBlockConfiguration` requires `s3:PutBucketPublicAccessBlock`, which some deployer roles lack. AWS already applies account/bucket **default** Block Public Access to new buckets, so the explicit config is redundant for safety.

- New parameter `ConfigureBucketPublicAccessBlock` (`false`/`true`, **default `false`**) on `lakerunner-infra-base` (cooked bucket) and `satellite-infra-base` (raw bucket).
- The bucket `PublicAccessBlockConfiguration` is wrapped in `Fn::If[<cond>, {…}, AWS::NoValue]` — by default the property is **omitted entirely**. Opt back in with the param set to `true`.
- Drivers: optional `CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK` passthrough (regenerated via `make scripts`).
- Tests assert the opt-in `Fn::If` + default-off param; `jenkins-chained-deploy.md` updated.

Safety: with the block omitted, new buckets are still non-public via AWS default BPA, and neither bucket has any public policy/ACL.

Verification: cfn-lint clean; shellcheck clean; 474 passed, 1 skipped.