### PR TITLE
sg: omit inline all-allow SecurityGroupEgress to avoid RevokeSecurityGroupEgress deny

### DIFF
--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -47,7 +47,7 @@ from troposphere import (
     Tags,
     Template,
 )
-from troposphere.ec2 import SecurityGroup, SecurityGroupIngress, SecurityGroupRule
+from troposphere.ec2 import SecurityGroup, SecurityGroupIngress
 from troposphere.iam import Policy, Role
 from troposphere.s3 import (
     Bucket,
@@ -338,11 +338,10 @@ def build() -> Template:
             "Cardinal ALB. Inbound 443 / 9443 / 4318 from AlbAllowedCidrs."
         ),
         VpcId=Ref(vpc_id),
-        SecurityGroupEgress=[SecurityGroupRule(
-            IpProtocol="-1",
-            CidrIp="0.0.0.0/0",
-            Description="All egress",
-        )],
+        # No inline SecurityGroupEgress: AWS auto-creates an all-allow egress
+        # rule on the SG, which is exactly what we want. Specifying it would
+        # force CloudFormation to RevokeSecurityGroupEgress the default first,
+        # an action some customer SCPs explicitly deny (VPC-destructive guard).
         Tags=_tags(component="alb-sg"),
     ))
 
@@ -393,11 +392,7 @@ def build() -> Template:
             title,
             GroupDescription=description,
             VpcId=Ref(vpc_id),
-            SecurityGroupEgress=[SecurityGroupRule(
-                IpProtocol="-1",
-                CidrIp="0.0.0.0/0",
-                Description="All egress",
-            )],
+            # No inline SecurityGroupEgress: see AlbSecurityGroup above.
             Tags=_tags(component=component),
         ))
 

--- a/src/cardinal_cfn/lakerunner_infra_rds.py
+++ b/src/cardinal_cfn/lakerunner_infra_rds.py
@@ -183,16 +183,11 @@ def build() -> Template:
                     "Cardinal lakerunner RDS; ingress added per DB-client tier"
                 ),
                 VpcId=Ref("VpcId"),
-                SecurityGroupEgress=[
-                    {
-                        "IpProtocol": "-1",
-                        "CidrIp": "0.0.0.0/0",
-                        "Description": (
-                            "All egress (RDS does not initiate connections; "
-                            "default kept for AWS::EC2::SecurityGroup parity)."
-                        ),
-                    }
-                ],
+                # No inline SecurityGroupEgress: AWS auto-creates an all-allow
+                # egress rule, which suffices (RDS does not initiate outbound
+                # connections). Specifying it would force CloudFormation to
+                # RevokeSecurityGroupEgress the default first, an action some
+                # customer SCPs explicitly deny (VPC-destructive guard).
                 Tags=_tags(component="rds-sg"),
             )
         )

--- a/src/cardinal_cfn/lrdev_vpc.py
+++ b/src/cardinal_cfn/lrdev_vpc.py
@@ -315,13 +315,10 @@ def build() -> Template:
                     Description="HTTPS from VPC",
                 )
             ],
-            SecurityGroupEgress=[
-                SecurityGroupRule(
-                    IpProtocol="-1",
-                    CidrIp="0.0.0.0/0",
-                    Description="All outbound traffic",
-                )
-            ],
+            # No inline SecurityGroupEgress: AWS auto-creates an all-allow
+            # egress rule. Specifying it would force CloudFormation to
+            # RevokeSecurityGroupEgress the default first, an action some
+            # customer SCPs explicitly deny (VPC-destructive guard).
             Tags=_vpc_tags(role="vpce-sg"),
         )
     )

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -405,13 +405,10 @@ def build() -> Template:
                     Description="OTLP/HTTP from IngestSourceCidr",
                 )
             ],
-            SecurityGroupEgress=[
-                SecurityGroupRule(
-                    IpProtocol="-1",
-                    CidrIp="0.0.0.0/0",
-                    Description="All egress",
-                )
-            ],
+            # No inline SecurityGroupEgress: AWS auto-creates an all-allow
+            # egress rule. Specifying it would force CloudFormation to
+            # RevokeSecurityGroupEgress the default first, an action some
+            # customer SCPs explicitly deny (VPC-destructive guard).
             Tags=_tags(component="satellite-alb-sg"),
         )
     )
@@ -440,13 +437,7 @@ def build() -> Template:
                     Description="Health probe from ALB SG",
                 ),
             ],
-            SecurityGroupEgress=[
-                SecurityGroupRule(
-                    IpProtocol="-1",
-                    CidrIp="0.0.0.0/0",
-                    Description="All egress",
-                )
-            ],
+            # No inline SecurityGroupEgress: see AlbSecurityGroup above.
             Tags=_tags(component="satellite-task-sg"),
         )
     )


### PR DESCRIPTION
## Problem

The `cardinal-lakerunner-infra-base` stack hit `CREATE_FAILED` in customer account 167872550306:

> not authorized to perform: ec2:RevokeSecurityGroupEgress ... with an explicit deny in an identity-based policy: CFCT-Clearpool-Deny-VPC-Destructive

The error fires during SG **create**, but the denied action is a *revoke*. When a template specifies an inline `SecurityGroupEgress`, CloudFormation creates the SG (AWS auto-attaches a default all-allow egress rule), then calls `ec2:RevokeSecurityGroupEgress` to strip that default before re-authorizing from the template — even when the specified rule is byte-for-byte the all-allow default. The customer SCP explicitly denies that revoke.

## Fix

Every egress rule across these templates was the all-allow default (`-1` / `0.0.0.0/0`) — so the inline property bought nothing but the revoke call. Drop it and let AWS keep its auto-created default rule. Behavior is identical; no revoke is issued.

Affected SGs:
- `lakerunner_infra_base.py` — ALB SG + all task SGs (dropped now-unused `SecurityGroupRule` import)
- `lakerunner_infra_rds.py` — RDS SG
- `satellite_services.py` — satellite ALB + task SGs
- `lrdev_vpc.py` — VPC-endpoint SG

## Verification

- `make build` — cfn-lint clean; `grep SecurityGroupEgress generated-templates/` returns none
- `make test` — 474 passed, 1 skipped