### PR TITLE
defaults: bump lakerunner v1.40.0, maestro v1.50.0

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.33.0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.46.4"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.0"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"


### PR DESCRIPTION
Bump the two Cardinal product images in `cardinal-defaults.yaml` to their latest public-ECR releases.

| Image | From | To |
|---|---|---|
| lakerunner | v1.33.0 | v1.40.0 |
| maestro | v1.46.4 | v1.50.0 |

`otel` (v1.8.0) and `dex` (v0.1.0) are already at their latest releases; utility images (`db_init` `:latest`, `dex_init` busybox `1.37`) untouched.

These are the `Default` values for the `LakerunnerImage` / `MaestroImage` root-stack parameters; deploys can still override. lakerunner is the single image for both the service tasks and the DB migrator, so the bump retriggers migrations before the service tier updates.

`make build` regenerates clean and cfn-lint passes.