### PR TITLE
defaults: drop dead per-service sizing from merged control tier

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -99,9 +99,6 @@ services:
   lakerunner-sweeper:
     signal_type: common
     command: ["/app/bin/lakerunner", "sweeper"]
-    cpu: 256
-    memory_mib: 512
-    replicas: 1
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
@@ -144,13 +141,6 @@ services:
   lakerunner-monitoring:
     signal_type: common
     command: ["/app/bin/lakerunner", "monitoring", "serve"]
-    cpu: 256
-    memory_mib: 512
-    replicas: 1
-    ingress:
-      port: 9090
-      container_port: 9090
-      attach_alb: false
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
@@ -159,9 +149,6 @@ services:
   lakerunner-admin-api:
     signal_type: common
     command: ["/app/bin/lakerunner", "admin-api", "serve"]
-    cpu: 256
-    memory_mib: 512
-    replicas: 1
     ingress:
       port: 9091
       container_port: 9091
@@ -176,9 +163,6 @@ services:
   lakerunner-alert-evaluator:
     signal_type: common
     command: ["/app/bin/lakerunner", "alert-evaluator"]
-    cpu: 256
-    memory_mib: 512
-    replicas: 1
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]


### PR DESCRIPTION
Follow-up cleanup after #162 (merged the four control-tier singletons into one ECS service/task).

The merged task in `services_control.py` hardcodes `CONTROL_TASK_CPU`/`CONTROL_TASK_MEMORY` (256/512) and `desired_count=1`, so for `lakerunner-sweeper`, `lakerunner-monitoring`, `lakerunner-admin-api`, and `lakerunner-alert-evaluator`:

- `cpu`, `memory_mib`, `replicas` were no longer read (and aren't in `_sizing_param_specs` either, so not even exposed as root params). The leftover `256`/`512` also misread as per-container when the whole task is 256/512.
- `monitoring.ingress` (port 9090, `attach_alb: false`) was dead; only `admin-api`'s `ingress` is consumed.

Removed those. Left `command`, `environment`, `admin-api.ingress`, and the `health_check`/`signal_type` blocks in place (the latter two are dead across all services but out of scope for this PR).

Verification: `make build` + `make test` pass, and the generated `services-control.yaml` is byte-identical to v0.0.117 — pure dead-config removal, no functional change.