### PR TITLE
satellite-infra-base: grant s3:PutObject on raw bucket (unblock self-telemetry traces)

### DIFF
--- a/src/cardinal_cfn/satellite_infra_base.py
+++ b/src/cardinal_cfn/satellite_infra_base.py
@@ -274,10 +274,19 @@ def build() -> Template:
                         "Version": "2012-10-17",
                         "Statement": [
                             {
-                                "Sid": "RawBucketReadDelete",
+                                # PutObject is required because the lakerunner
+                                # trace ingest worklane does not yet split read
+                                # vs write storage profiles (logs/metrics do),
+                                # so it writes cooked trace segments back to
+                                # this source bucket rather than redirecting to
+                                # the cooked bucket via writes_to_instance_num.
+                                # Remove once trace_ingest_worklane.go mirrors
+                                # the logs/metric read/write split.
+                                "Sid": "RawBucketReadWriteDelete",
                                 "Effect": "Allow",
                                 "Action": [
                                     "s3:GetObject",
+                                    "s3:PutObject",
                                     "s3:DeleteObject",
                                     "s3:ListBucket",
                                     "s3:GetBucketLocation",

--- a/tests/templates/test_satellite_infra_base.py
+++ b/tests/templates/test_satellite_infra_base.py
@@ -127,18 +127,22 @@ def test_role_external_id_is_conditional(td):
     }
 
 
-def test_role_can_read_and_delete_raw(td):
+def test_role_can_read_write_and_delete_raw(td):
+    # PutObject is present because the lakerunner trace ingest worklane writes
+    # cooked trace segments back to this source bucket (it does not yet split
+    # read vs write storage profiles the way logs/metrics do). See the role
+    # comment in satellite_infra_base.py.
     stmts = td["Resources"]["LakerunnerAccessRole"]["Properties"]["Policies"][
         0
     ]["PolicyDocument"]["Statement"]
-    s3 = next(s for s in stmts if s["Sid"] == "RawBucketReadDelete")
+    s3 = next(s for s in stmts if s["Sid"] == "RawBucketReadWriteDelete")
     assert set(s3["Action"]) == {
         "s3:GetObject",
+        "s3:PutObject",
         "s3:DeleteObject",
         "s3:ListBucket",
         "s3:GetBucketLocation",
     }
-    assert "s3:PutObject" not in s3["Action"]
 
 
 def test_role_can_consume_only_its_queue(td):


### PR DESCRIPTION
## Problem

Satellite self-telemetry **traces fail to process** while logs and metrics succeed:

```
s3:PutObject AccessDenied on cardinal-otel-raw-.../db/<org>/<collector>/<date>/traces/.../tbl_*.parquet
by arn:aws:sts::...:assumed-role/cardinal-satellite-access/lakerunner
```

## Root cause

`lakerunner/internal/metricsprocessing/trace_ingest_worklane.go` uses a single storage profile (`GetStorageProfileForOrganizationAndInstance`) for both read and write, so it writes cooked trace segments back to the **source (raw)** bucket with the read-only satellite role. The logs and metric worklanes call `ResolveWriteStorageProfile` and follow the `writes_to_instance_num` redirect to the cooked bucket — which is why logs/metrics work and traces don't. The trace worklane's own NOTE documents that the split is not yet implemented.

## Fix

Add `s3:PutObject` to the `cardinal-satellite-access` role's raw-bucket statement (Sid renamed `RawBucketReadDelete` -> `RawBucketReadWriteDelete`) so trace processing succeeds. Documented as removable once `trace_ingest_worklane.go` mirrors the logs/metric read/write split.

## Caveat

Until that lakerunner code change lands, cooked trace parquet lands in the raw bucket (subject to its lifecycle). The real fix is in the lakerunner repo; this unblocks the CFN-deployed self-telemetry path in the meantime.

## Testing

- `make build` (cfn-lint clean)
- `make test` — 474 passed, 1 skipped (updated `test_role_can_read_write_and_delete_raw`)