### PR TITLE
satellite: decouple from central account (no license, no central-stack pull)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.120
+
+- **Satellite installs are fully decoupled from the central account.** A
+  satellite (`satellite-infra-base` + `satellite-services`, deployed as a
+  same-account/region pair) may now live in the **same or a different AWS
+  account** than the central lakerunner install — no satellite driver reads the
+  central `lakerunner-infra-base` stack (a cross-account `describe-stacks` that
+  could never have worked). (#185)
+  - **Collector no longer uses a license.** `satellite-services` drops the
+    `LicenseSecretArn` parameter, the collector exec-role
+    `secretsmanager:GetSecretValue`, and the `LICENSE_DATA` container secret —
+    the otel-collector image needs no license.
+  - **Central principal is supplied directly.** `deploy-satellite-infra-base.sh`
+    now takes `LAKERUNNER_PRINCIPAL` (the central `ProcessRoleArn`, read once out
+    of band) instead of mapping it from the `lakerunner-infra-base` stack, and no
+    longer requires `INFRA_BASE_STACK`.
+  - `deploy-satellite-services.sh` no longer requires `INFRA_BASE_STACK` (it only
+    needed it for the license); it still pulls `RawBucketName` from the
+    satellite's own paired `satellite-infra-base` in the same account.
+  - Upgrade action: when redeploying a satellite, set `LAKERUNNER_PRINCIPAL` on
+    the infra-base driver and drop `INFRA_BASE_STACK` from both satellite drivers.
+    The collector's own task/exec roles are unchanged (always self-contained). No
+    data-bearing resource is replaced.
+
 ## v0.0.119
 
 - **Satellite self-telemetry traces now process (IAM widening).** The

--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -166,15 +166,17 @@ PRIVATE_SUBNETS=subnet-1,subnet-2 \
 
 ## Job 3: satellite-infra-base (per ingest account/region)
 
-`scripts/deploy-satellite-infra-base.sh` — pulls infra-base Outputs and maps
-`LakerunnerPrincipal=ProcessRoleArn`.
+`scripts/deploy-satellite-infra-base.sh` — no upstream-stack pull. The central
+principal arrives directly as `LAKERUNNER_PRINCIPAL` (the lakerunner
+`ProcessRoleArn`, read once out of band), so a satellite works in the same or a
+different account.
 
 | Variable | Req/Opt | Default |
 |---|---|---|
 | `STACK_NAME` | required | — |
 | `REGION` | required | — |
 | `VERSION` | required | — |
-| `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base stack name |
+| `LAKERUNNER_PRINCIPAL` | required | ARN of the central lakerunner process role (its `ProcessRoleArn` output) allowed to assume the satellite access role |
 | `EXTERNAL_ID` | optional | template: empty |
 | `RAW_BUCKET_NAME` | optional | template: generated |
 | `RAW_BUCKET_LIFECYCLE_DAYS` | optional | template: `7` |
@@ -187,7 +189,7 @@ PRIVATE_SUBNETS=subnet-1,subnet-2 \
 STACK_NAME=cardinal-satellite-infra-base \
 REGION=us-east-1 \
 VERSION=v0.0.70 \
-INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
+LAKERUNNER_PRINCIPAL=arn:aws:iam::111122223333:role/cardinal-lakerunner-infra-base-ProcessRole-ABC123 \
 EXTERNAL_ID=myExternalId \
 ./scripts/deploy-satellite-infra-base.sh
 ```
@@ -202,8 +204,7 @@ collector config must change before scaling past one replica.
 | `STACK_NAME` | required | — |
 | `REGION` | required | — |
 | `VERSION` | required | — |
-| `SATELLITE_INFRA_BASE_STACK` | required | upstream satellite-infra-base (`RawBucketName`) |
-| `INFRA_BASE_STACK` | required | upstream lakerunner-infra-base (`LicenseSecretArn`) |
+| `SATELLITE_INFRA_BASE_STACK` | required | upstream satellite-infra-base (`RawBucketName`), same account/region |
 | `ORGANIZATION_ID` | required | org UUID this satellite's telemetry is attributed to |
 | `VPC_ID` | required | — |
 | `ALB_SUBNETS` | required | comma-separated subnets for the collector ALB |
@@ -221,7 +222,6 @@ STACK_NAME=cardinal-satellite-services \
 REGION=us-east-1 \
 VERSION=v0.0.70 \
 SATELLITE_INFRA_BASE_STACK=cardinal-satellite-infra-base \
-INFRA_BASE_STACK=cardinal-lakerunner-infra-base \
 ORGANIZATION_ID=12340000-0000-0000-0000-000000000000 \
 VPC_ID=vpc-0abc \
 ALB_SUBNETS=subnet-a,subnet-b \

--- a/scripts-src/parts/deploy-satellite-infra-base.sh
+++ b/scripts-src/parts/deploy-satellite-infra-base.sh
@@ -2,10 +2,12 @@
 # Jenkins job 3: deploy the cardinal-satellite-infra-base stack (one per
 # satellite ingest account/region).
 #
-# Upstream: the lakerunner-infra-base stack.  This stack's LakerunnerPrincipal
-# parameter does NOT match any infra-base output name, so it is wired via an
-# explicit MAPS LakerunnerPrincipal=ProcessRoleArn: the satellite trusts the
-# lakerunner process role to assume into the satellite ingest access role.
+# No upstream stack pull: a satellite may live in a DIFFERENT account than the
+# central lakerunner install, where describe-stacks cannot reach the
+# lakerunner-infra-base stack.  The central principal the satellite trusts is
+# supplied directly as LAKERUNNER_PRINCIPAL (the lakerunner process role ARN,
+# read once out of band) -> LakerunnerPrincipal param.  The satellite then
+# trusts that role to assume into the satellite ingest access role.
 #
 # Self-contained single-file driver: this front-half sets the engine env, then
 # falls through into the engine embedded below by scripts-src/build.sh (do not
@@ -23,11 +25,12 @@ deploy-satellite-infra-base.sh -- deploy the cardinal-satellite-infra-base stack
 All inputs come from environment variables (no flags).
 
 Required:
-  STACK_NAME         Stack to create/update.
-  REGION             AWS region (never defaulted; must be set explicitly).
-  VERSION            Published template tag.
-  INFRA_BASE_STACK   Upstream lakerunner-infra-base stack.  Its ProcessRoleArn
-                     output is mapped to this stack's LakerunnerPrincipal param.
+  STACK_NAME          Stack to create/update.
+  REGION              AWS region (never defaulted; must be set explicitly).
+  VERSION             Published template tag.
+  LAKERUNNER_PRINCIPAL  ARN of the central lakerunner process role (its
+                      ProcessRoleArn output) allowed to assume the satellite
+                      access role.  Read once out of band; works cross-account.
 
 Optional (template defaults preserved when unset):
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
@@ -52,7 +55,7 @@ missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
-[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+[ -z "${LAKERUNNER_PRINCIPAL:-}" ] && missing="$missing LAKERUNNER_PRINCIPAL"
 if [ -n "$missing" ]; then
     usage >&2
     echo "[deploy-satellite-infra-base] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
@@ -62,10 +65,13 @@ fi
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
 TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
-FROM_STACKS="$INFRA_BASE_STACK"
-MAPS="LakerunnerPrincipal=ProcessRoleArn"
+# No upstream-stack pull (cross-account safe): the central principal arrives
+# directly, never mapped from a stack output.
+FROM_STACKS=""
+MAPS=""
 
-params=""
+params="LakerunnerPrincipal=$LAKERUNNER_PRINCIPAL
+"
 [ -n "${EXTERNAL_ID:-}" ] && params="${params}ExternalId=$EXTERNAL_ID
 "
 [ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME

--- a/scripts-src/parts/deploy-satellite-services.sh
+++ b/scripts-src/parts/deploy-satellite-services.sh
@@ -2,12 +2,13 @@
 # Jenkins job 4: deploy the cardinal-satellite-services stack (the same-account
 # otel collector that performs ingest into the satellite raw bucket/queue).
 #
-# Upstream:
+# Upstream: only the satellite's OWN paired stack (same account/region):
 #   - satellite-infra-base : RawBucketName output -> RawBucketName param.
-#   - lakerunner-infra-base : LicenseSecretArn output -> LicenseSecretArn param.
-# Both output names match the parameter names, so plain FROM_STACKS pulls wire
-# them up.  OTEL_REPLICAS defaults to 1 here (the collector config must change
-# before scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
+# The output name matches the parameter name, so a plain FROM_STACKS pull wires
+# it up.  No pull from the central lakerunner-infra-base stack -- the collector
+# needs no license and a satellite may live in a different account.
+# OTEL_REPLICAS defaults to 1 here (the collector config must change before
+# scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
 #
 # Self-contained single-file driver: this front-half sets the engine env, then
 # falls through into the engine embedded below by scripts-src/build.sh (do not
@@ -29,7 +30,6 @@ Required:
   REGION                      AWS region (never defaulted; must be set explicitly).
   VERSION                     Published template tag.
   SATELLITE_INFRA_BASE_STACK  Upstream satellite-infra-base (RawBucketName).
-  INFRA_BASE_STACK            Upstream lakerunner-infra-base (LicenseSecretArn).
   ORGANIZATION_ID             Org UUID this satellite's telemetry is attributed to.
   VPC_ID                      VPC for the collector.
   ALB_SUBNETS                 Comma-separated subnets for the collector ALB.
@@ -58,7 +58,6 @@ missing=""
 [ -z "${REGION:-}" ] && missing="$missing REGION"
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
-[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${ALB_SUBNETS:-}" ] && missing="$missing ALB_SUBNETS"
@@ -78,7 +77,7 @@ template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 otel_replicas="${OTEL_REPLICAS:-1}"
 
 TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
-FROM_STACKS="$SATELLITE_INFRA_BASE_STACK $INFRA_BASE_STACK"
+FROM_STACKS="$SATELLITE_INFRA_BASE_STACK"
 MAPS=""
 
 params="OrganizationId=$ORGANIZATION_ID

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -3,10 +3,12 @@
 # Jenkins job 3: deploy the cardinal-satellite-infra-base stack (one per
 # satellite ingest account/region).
 #
-# Upstream: the lakerunner-infra-base stack.  This stack's LakerunnerPrincipal
-# parameter does NOT match any infra-base output name, so it is wired via an
-# explicit MAPS LakerunnerPrincipal=ProcessRoleArn: the satellite trusts the
-# lakerunner process role to assume into the satellite ingest access role.
+# No upstream stack pull: a satellite may live in a DIFFERENT account than the
+# central lakerunner install, where describe-stacks cannot reach the
+# lakerunner-infra-base stack.  The central principal the satellite trusts is
+# supplied directly as LAKERUNNER_PRINCIPAL (the lakerunner process role ARN,
+# read once out of band) -> LakerunnerPrincipal param.  The satellite then
+# trusts that role to assume into the satellite ingest access role.
 #
 # Self-contained single-file driver: this front-half sets the engine env, then
 # falls through into the engine embedded below by scripts-src/build.sh (do not
@@ -24,11 +26,12 @@ deploy-satellite-infra-base.sh -- deploy the cardinal-satellite-infra-base stack
 All inputs come from environment variables (no flags).
 
 Required:
-  STACK_NAME         Stack to create/update.
-  REGION             AWS region (never defaulted; must be set explicitly).
-  VERSION            Published template tag.
-  INFRA_BASE_STACK   Upstream lakerunner-infra-base stack.  Its ProcessRoleArn
-                     output is mapped to this stack's LakerunnerPrincipal param.
+  STACK_NAME          Stack to create/update.
+  REGION              AWS region (never defaulted; must be set explicitly).
+  VERSION             Published template tag.
+  LAKERUNNER_PRINCIPAL  ARN of the central lakerunner process role (its
+                      ProcessRoleArn output) allowed to assume the satellite
+                      access role.  Read once out of band; works cross-account.
 
 Optional (template defaults preserved when unset):
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
@@ -53,7 +56,7 @@ missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
-[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
+[ -z "${LAKERUNNER_PRINCIPAL:-}" ] && missing="$missing LAKERUNNER_PRINCIPAL"
 if [ -n "$missing" ]; then
     usage >&2
     echo "[deploy-satellite-infra-base] ERROR: missing required: $(echo "$missing" | sed 's/^ //; s/ /, /g')" >&2
@@ -63,10 +66,13 @@ fi
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
 TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
-FROM_STACKS="$INFRA_BASE_STACK"
-MAPS="LakerunnerPrincipal=ProcessRoleArn"
+# No upstream-stack pull (cross-account safe): the central principal arrives
+# directly, never mapped from a stack output.
+FROM_STACKS=""
+MAPS=""
 
-params=""
+params="LakerunnerPrincipal=$LAKERUNNER_PRINCIPAL
+"
 [ -n "${EXTERNAL_ID:-}" ] && params="${params}ExternalId=$EXTERNAL_ID
 "
 [ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -3,12 +3,13 @@
 # Jenkins job 4: deploy the cardinal-satellite-services stack (the same-account
 # otel collector that performs ingest into the satellite raw bucket/queue).
 #
-# Upstream:
+# Upstream: only the satellite's OWN paired stack (same account/region):
 #   - satellite-infra-base : RawBucketName output -> RawBucketName param.
-#   - lakerunner-infra-base : LicenseSecretArn output -> LicenseSecretArn param.
-# Both output names match the parameter names, so plain FROM_STACKS pulls wire
-# them up.  OTEL_REPLICAS defaults to 1 here (the collector config must change
-# before scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
+# The output name matches the parameter name, so a plain FROM_STACKS pull wires
+# it up.  No pull from the central lakerunner-infra-base stack -- the collector
+# needs no license and a satellite may live in a different account.
+# OTEL_REPLICAS defaults to 1 here (the collector config must change before
+# scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
 #
 # Self-contained single-file driver: this front-half sets the engine env, then
 # falls through into the engine embedded below by scripts-src/build.sh (do not
@@ -30,7 +31,6 @@ Required:
   REGION                      AWS region (never defaulted; must be set explicitly).
   VERSION                     Published template tag.
   SATELLITE_INFRA_BASE_STACK  Upstream satellite-infra-base (RawBucketName).
-  INFRA_BASE_STACK            Upstream lakerunner-infra-base (LicenseSecretArn).
   ORGANIZATION_ID             Org UUID this satellite's telemetry is attributed to.
   VPC_ID                      VPC for the collector.
   ALB_SUBNETS                 Comma-separated subnets for the collector ALB.
@@ -59,7 +59,6 @@ missing=""
 [ -z "${REGION:-}" ] && missing="$missing REGION"
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
-[ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${ALB_SUBNETS:-}" ] && missing="$missing ALB_SUBNETS"
@@ -79,7 +78,7 @@ template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 otel_replicas="${OTEL_REPLICAS:-1}"
 
 TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
-FROM_STACKS="$SATELLITE_INFRA_BASE_STACK $INFRA_BASE_STACK"
+FROM_STACKS="$SATELLITE_INFRA_BASE_STACK"
 MAPS=""
 
 params="OrganizationId=$ORGANIZATION_ID

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -12,7 +12,7 @@ from the queue cross-account. Nothing here pushes to the Lakerunner account.
 
 Resources created:
   - CollectorExecutionRole (IAM): managed AmazonECSTaskExecutionRolePolicy +
-    inline secretsmanager:GetSecretValue on LicenseSecretArn.
+    inline log-stream perms. The collector image needs no license.
   - CollectorTaskRole (IAM): inline s3:PutObject/GetObject/ListBucket/
     GetBucketLocation on RawBucketName. No DeleteObject (poller deletes).
   - AlbSecurityGroup (EC2): ingress tcp 4318 from IngestSourceCidr.
@@ -22,7 +22,7 @@ Resources created:
   - OtelGrpcTargetGroup: port 4318, health-check on 13133.
   - OtelGrpcListenerRule: path /v1/*, priority 300.
   - OtelGrpcLogGroup: /cardinal/otel-grpc.
-  - OtelGrpcTaskDef: ARM64 Fargate, env vars, LICENSE_DATA secret.
+  - OtelGrpcTaskDef: ARM64 Fargate, env vars. No license secret.
   - CollectorService: FARGATE on-demand, circuit breaker, no Cloud Map.
 """
 
@@ -52,7 +52,6 @@ from troposphere.ecs import (
     NetworkConfiguration,
     PortMapping,
     RuntimePlatform,
-    Secret,
     Service,
     TaskDefinition,
 )
@@ -130,16 +129,6 @@ def build() -> Template:
                 "cardinal-satellite-infra-base)."
             ),
             AllowedPattern=r"^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
-        )
-    )
-    t.add_parameter(
-        Parameter(
-            "LicenseSecretArn",
-            Type="String",
-            Description=(
-                "ARN of the Cardinal license secret in this account. "
-                "The collector validates it at startup."
-            ),
         )
     )
     t.add_parameter(
@@ -274,7 +263,6 @@ def build() -> Template:
                 "label": "Inputs",
                 "parameters": [
                     "RawBucketName",
-                    "LicenseSecretArn",
                     "OrganizationId",
                     "EcsClusterArn",
                 ],
@@ -321,14 +309,6 @@ def build() -> Template:
                     PolicyDocument={
                         "Version": "2012-10-17",
                         "Statement": [
-                            {
-                                "Sid": "LicenseSecretPull",
-                                "Effect": "Allow",
-                                "Action": [
-                                    "secretsmanager:GetSecretValue",
-                                ],
-                                "Resource": [Ref("LicenseSecretArn")],
-                            },
                             {
                                 "Sid": "CollectorLogStreams",
                                 "Effect": "Allow",
@@ -560,17 +540,12 @@ def build() -> Template:
     svc_env = otel_cfg.get("environment") or {}
     env += [Environment(Name=k, Value=str(v)) for k, v in svc_env.items()]
 
-    secrets = [
-        Secret(Name="LICENSE_DATA", ValueFrom=Ref("LicenseSecretArn")),
-    ]
-
     command = otel_cfg.get("command")
     container_kwargs = dict(
         Name=_SERVICE_KEY,
         Image=image_ref,
         Essential=True,
         Environment=env,
-        Secrets=secrets,
         PortMappings=[
             PortMapping(ContainerPort=_OTLP_HTTP_PORT, Protocol="tcp")
         ],

--- a/tests/templates/test_satellite_services.py
+++ b/tests/templates/test_satellite_services.py
@@ -20,7 +20,6 @@ def td():
 def test_required_parameters(td):
     for n in (
         "RawBucketName",
-        "LicenseSecretArn",
         "OrganizationId",
         "VpcId",
         "AlbSubnetsCsv",
@@ -72,19 +71,26 @@ def test_task_role_writes_only_raw_bucket(td):
     assert "s3:DeleteObject" not in all_actions
 
 
-def test_exec_role_reads_license_secret(td):
-    """Exec role allows secretsmanager:GetSecretValue on LicenseSecretArn."""
+def test_no_license_anywhere(td):
+    """The collector image needs no license: no LicenseSecretArn param, no
+    secretsmanager:GetSecretValue on the exec role, and no LICENSE_DATA secret
+    on the container. A satellite may live in a different account than the
+    central license secret, so nothing here may depend on it."""
+    assert "LicenseSecretArn" not in td["Parameters"]
+
     exec_role = td["Resources"]["CollectorExecutionRole"]
     stmts = exec_role["Properties"]["Policies"][0]["PolicyDocument"]["Statement"]
-    sm_stmt = next(
-        s for s in stmts
-        if "secretsmanager:GetSecretValue" in (
-            s["Action"] if isinstance(s["Action"], list) else [s["Action"]]
-        )
+    for s in stmts:
+        actions = s["Action"] if isinstance(s["Action"], list) else [s["Action"]]
+        assert "secretsmanager:GetSecretValue" not in actions
+
+    task_def = next(
+        r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
     )
-    resource = sm_stmt["Resource"]
-    resources = resource if isinstance(resource, list) else [resource]
-    assert {"Ref": "LicenseSecretArn"} in resources
+    container = task_def["Properties"]["ContainerDefinitions"][0]
+    secret_names = [s["Name"] for s in container.get("Secrets", [])]
+    assert "LICENSE_DATA" not in secret_names
+    assert "LicenseSecretArn" not in json.dumps(td)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -134,10 +134,28 @@ def test_cfntool_wrapper_only_wraps_role_capable_subcommands():
     )
 
 
-def test_satellite_infra_base_maps_lakerunner_principal():
-    """The one non-automatic --map: LakerunnerPrincipal <- ProcessRoleArn."""
+def test_satellite_infra_base_takes_principal_directly():
+    """The satellite trust principal arrives as a direct LAKERUNNER_PRINCIPAL env
+    var, never mapped from the central lakerunner-infra-base stack -- a satellite
+    may live in a different account where describe-stacks cannot reach it."""
     text = (SCRIPTS_DIR / "deploy-satellite-infra-base.sh").read_text()
-    assert "LakerunnerPrincipal=ProcessRoleArn" in text
+    assert "LakerunnerPrincipal=$LAKERUNNER_PRINCIPAL" in text
+    assert "LakerunnerPrincipal=ProcessRoleArn" not in text
+    assert "INFRA_BASE_STACK" not in text
+
+
+def test_satellite_drivers_never_pull_central_stack():
+    """Neither satellite driver may pull from the central lakerunner-infra-base
+    stack (cross-account safe): no central INFRA_BASE_STACK, no LicenseSecretArn.
+    The satellite's OWN SATELLITE_INFRA_BASE_STACK (same account) stays."""
+    for name in ("deploy-satellite-infra-base.sh", "deploy-satellite-services.sh"):
+        text = (SCRIPTS_DIR / name).read_text()
+        # Strip the allowed same-account token before checking for the central one.
+        without_satellite = text.replace("SATELLITE_INFRA_BASE_STACK", "")
+        assert "INFRA_BASE_STACK" not in without_satellite, (
+            f"{name} still references the central INFRA_BASE_STACK"
+        )
+        assert "LicenseSecretArn" not in text, f"{name} still references LicenseSecretArn"
 
 
 def test_lakerunner_services_passes_queue_params():


### PR DESCRIPTION
A satellite (`satellite-infra-base` + `satellite-services`, deployed as a same-account/region pair) may live in the **same or a different AWS account** than the central lakerunner install. `describe-stacks` is account+region scoped, so the satellite drivers can no longer read the central `lakerunner-infra-base` stack.

## Changes

- **`satellite-services` template** — drop `LicenseSecretArn` param, the collector exec-role `secretsmanager:GetSecretValue` statement, and the `LICENSE_DATA` container secret. The otel-collector image needs no license (only `lakerunner`/`maestro` binaries get `LICENSE_DATA`).
- **`deploy-satellite-infra-base.sh`** — take `LAKERUNNER_PRINCIPAL` directly (the central `ProcessRoleArn`, read once out of band) instead of `MAPS=LakerunnerPrincipal=ProcessRoleArn` off the central stack; drop the `INFRA_BASE_STACK` requirement.
- **`deploy-satellite-services.sh`** — drop `INFRA_BASE_STACK` (only needed for the license). Still pulls `RawBucketName` from its own paired `satellite-infra-base` (same account, "the set").
- The collector's own `CollectorTaskRole` / `CollectorExecutionRole` were already self-contained — never reused from `lakerunner-infra-base`; unchanged.

## Result

Neither satellite driver references the central stack. The operator passes the central principal ARN as a plain env var, so a satellite deploys identically whether co-located with the central install or in a separate account.

## Verification

- `make scripts` + `make build` (cfn-lint clean), `make test` — 475 passed, 1 skipped.
- Tests updated: `test_satellite_services.py` now asserts no license anywhere; `test_deploy_stack_lint.py` asserts the drivers take the principal directly and never pull the central stack.
- `docs/operations/jenkins-chained-deploy.md` updated; changelog entry `v0.0.120`.

## Related (not in this PR)

The inverse coupling still exists: the central `deploy-lakerunner-services.sh` (Job 5) pulls `RawQueueUrl`/`LakerunnerAccessRoleArn` from `SATELLITE_INFRA_BASE_STACK`, which is the same cross-account-`describe-stacks` problem in reverse for different-account satellites. Out of scope here; flagging for a follow-up.