### PR TITLE
pubsub-sqs: default autoregister on + multiple satellite SQS queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.121
+
+- **`PubsubAutoRegister` now defaults to `true`.** New `lakerunner-services`
+  deploys auto-register unseen satellite raw-bucket orgs and route their cooked
+  output to `PubsubAutoRegisterWritesToInstance` (default `1`) without an extra
+  flag. (#186)
+  - Upgrade action: none to keep it on. To preserve the old off-by-default
+    behavior, pass `PUBSUB_AUTOREGISTER=false` (driver) / set
+    `PubsubAutoRegister=false`. Existing stacks keep whatever value they were
+    deployed with until you re-apply.
+- **pubsub-sqs can now consume multiple satellite SQS queues.** Beyond the
+  primary (group-0) `QueueUrl`/`QueueRoleArn`, `lakerunner-services` adds
+  numbered queue groups 1..10: `QueueUrl<n>` / `QueueRegion<n>` / `QueueRoleArn<n>`
+  params, emitted as `SQS_QUEUE_URL_<n>` / `SQS_REGION_<n>` / `SQS_ROLE_ARN_<n>`
+  on the pubsub-sqs container only when set. Each group carries its own region
+  and assume-role, so the central poller reaches satellite queues in other
+  accounts/regions. Driver env: `QUEUE_URL_<n>` / `QUEUE_REGION_<n>` /
+  `QUEUE_ROLE_ARN_<n>` (`QUEUE_REGION_<n>` defaults to `REGION`).
+  - Upgrade action: none. Set the numbered env vars to add satellites; the
+    ceiling is 10 (bump `MAX_ADDITIONAL_QUEUES` to raise it).
+
 ## v0.0.120
 
 - **Satellite installs are fully decoupled from the central account.** A

--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -88,11 +88,16 @@ last.
   `lakerunner-infra-base` Output `ProcessRoleArn` (the satellite trusts the
   lakerunner process role to assume into the satellite access role). The
   wrapper sets `MAPS="LakerunnerPrincipal=ProcessRoleArn"`.
-- `lakerunner-services` parameters `QueueUrl` and `QueueRoleArn` are read from
-  the `satellite-infra-base` stack Outputs `RawQueueUrl` and
-  `LakerunnerAccessRoleArn`, then passed as `PARAMS` lines. The pubsub-sqs
-  container sets them as plain `SQS_QUEUE_URL` / `SQS_ROLE_ARN` env vars
-  (`SQS_REGION` comes from the stack's own `AWS::Region`).
+- `lakerunner-services` parameters `QueueUrl` and `QueueRoleArn` (the primary,
+  group-0 queue) are read from the `satellite-infra-base` stack Outputs
+  `RawQueueUrl` and `LakerunnerAccessRoleArn`, then passed as `PARAMS` lines. The
+  pubsub-sqs container sets them as plain `SQS_QUEUE_URL` / `SQS_ROLE_ARN` env
+  vars (`SQS_REGION` comes from the stack's own `AWS::Region`).
+- Additional satellite queues (a satellite per account/region) are added via
+  `QUEUE_URL_<n>` / `QUEUE_REGION_<n>` / `QUEUE_ROLE_ARN_<n>` (n=1..10), which
+  become `SQS_QUEUE_URL_<n>` / `SQS_REGION_<n>` / `SQS_ROLE_ARN_<n>` on pubsub-sqs.
+  Each carries its own region and assume-role, so the poller reaches queues in
+  other accounts/regions. `QUEUE_REGION_<n>` defaults to `REGION` when unset.
 
 ## Job 1: lakerunner-infra-base
 
@@ -277,6 +282,9 @@ exit. Set `CERTIFICATE_ARN` to use a real cert.
 | `SERVICE_NAMESPACE_NAME` | optional | template: `cardinal.local` |
 | `PUBLIC_SUBNETS` | optional | template: empty |
 | `OTEL_REPLICAS` | optional | `0` |
+| `PUBSUB_AUTOREGISTER` | optional | template default `true` (set `false` to disable) |
+| `PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE` | optional | `1` |
+| `QUEUE_URL_<n>` `QUEUE_REGION_<n>` `QUEUE_ROLE_ARN_<n>` (n=1..10) | optional | additional satellite queues for pubsub-sqs; `QUEUE_REGION_<n>` defaults to `REGION` |
 | `LAKERUNNER_IMAGE` `MAESTRO_IMAGE` `OTEL_IMAGE` `DEX_IMAGE` `DEX_INIT_IMAGE` `DB_INIT_IMAGE` | optional | template defaults |
 | `TEMPLATE_BASE_URL` | optional | `https://cardinal-cfn.s3.us-east-2.amazonaws.com/lakerunner` (also forwarded as `TemplateBaseUrl`) |
 | `DEPLOYER_ROLE_ARN` | optional | unset |

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -83,8 +83,8 @@ Optional (template defaults preserved when unset):
                               ALB_ALLOWED_CIDR* settings).
   LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
   DB_INIT_IMAGE               Image overrides (template defaults otherwise).
-  PUBSUB_AUTOREGISTER         Set to "true" to enable pubsub-sqs auto-
-                              registration of satellite buckets (default false).
+  PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
+                              (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are
                               registered and cooked output is routed to the
                               central instance.
@@ -92,6 +92,11 @@ Optional (template defaults preserved when unset):
                               Central cooked-bucket instance_num that auto-
                               registered orgs write to (default 1). Required
                               when PUBSUB_AUTOREGISTER=true.
+  QUEUE_URL_<n>, QUEUE_REGION_<n>, QUEUE_ROLE_ARN_<n>
+                              Additional satellite queues for pubsub-sqs, n=1..10.
+                              Set QUEUE_URL_<n> (and optionally the matching
+                              region / assume-role ARN) to add a queue beyond the
+                              primary one.  QUEUE_REGION_<n> defaults to REGION.
   TEMPLATE_BASE_URL           Default: $DEFAULT_TEMPLATE_BASE_URL.  Also
                               forwarded as the TemplateBaseUrl param (nested
                               children load from the matching prefix).
@@ -207,6 +212,26 @@ DexImage=$DEX_IMAGE"
 DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params
 DbInitImage=$DB_INIT_IMAGE"
+
+# --- Additional satellite queues (groups 1..10). -----------------------------
+# pubsub-sqs consumes extra satellite queues from numbered env groups.  For each
+# n, set QUEUE_URL_<n> (and optionally QUEUE_REGION_<n> / QUEUE_ROLE_ARN_<n>) to
+# add one.  The ceiling mirrors MAX_ADDITIONAL_QUEUES in services_process.py.
+n=1
+while [ "$n" -le 10 ]; do
+    eval "q_url=\${QUEUE_URL_$n:-}"
+    if [ -n "$q_url" ]; then
+        eval "q_region=\${QUEUE_REGION_$n:-}"
+        eval "q_role=\${QUEUE_ROLE_ARN_$n:-}"
+        params="$params
+QueueUrl$n=$q_url"
+        [ -n "$q_region" ] && params="$params
+QueueRegion$n=$q_region"
+        [ -n "$q_role" ] && params="$params
+QueueRoleArn$n=$q_role"
+    fi
+    n=$((n + 1))
+done
 
 # --- Certificate handling. ---------------------------------------------------
 # Cert PEM material reaches the template via FILE_PARAMS (multi-line safe), never

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -84,8 +84,8 @@ Optional (template defaults preserved when unset):
                               ALB_ALLOWED_CIDR* settings).
   LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
   DB_INIT_IMAGE               Image overrides (template defaults otherwise).
-  PUBSUB_AUTOREGISTER         Set to "true" to enable pubsub-sqs auto-
-                              registration of satellite buckets (default false).
+  PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
+                              (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are
                               registered and cooked output is routed to the
                               central instance.
@@ -93,6 +93,11 @@ Optional (template defaults preserved when unset):
                               Central cooked-bucket instance_num that auto-
                               registered orgs write to (default 1). Required
                               when PUBSUB_AUTOREGISTER=true.
+  QUEUE_URL_<n>, QUEUE_REGION_<n>, QUEUE_ROLE_ARN_<n>
+                              Additional satellite queues for pubsub-sqs, n=1..10.
+                              Set QUEUE_URL_<n> (and optionally the matching
+                              region / assume-role ARN) to add a queue beyond the
+                              primary one.  QUEUE_REGION_<n> defaults to REGION.
   TEMPLATE_BASE_URL           Default: $DEFAULT_TEMPLATE_BASE_URL.  Also
                               forwarded as the TemplateBaseUrl param (nested
                               children load from the matching prefix).
@@ -208,6 +213,26 @@ DexImage=$DEX_IMAGE"
 DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params
 DbInitImage=$DB_INIT_IMAGE"
+
+# --- Additional satellite queues (groups 1..10). -----------------------------
+# pubsub-sqs consumes extra satellite queues from numbered env groups.  For each
+# n, set QUEUE_URL_<n> (and optionally QUEUE_REGION_<n> / QUEUE_ROLE_ARN_<n>) to
+# add one.  The ceiling mirrors MAX_ADDITIONAL_QUEUES in services_process.py.
+n=1
+while [ "$n" -le 10 ]; do
+    eval "q_url=\${QUEUE_URL_$n:-}"
+    if [ -n "$q_url" ]; then
+        eval "q_region=\${QUEUE_REGION_$n:-}"
+        eval "q_role=\${QUEUE_ROLE_ARN_$n:-}"
+        params="$params
+QueueUrl$n=$q_url"
+        [ -n "$q_region" ] && params="$params
+QueueRegion$n=$q_region"
+        [ -n "$q_role" ] && params="$params
+QueueRoleArn$n=$q_role"
+    fi
+    n=$((n + 1))
+done
 
 # --- Certificate handling. ---------------------------------------------------
 # Cert PEM material reaches the template via FILE_PARAMS (multi-line safe), never

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -15,7 +15,10 @@ CPU values come from cardinal-defaults.yaml directly.
 """
 
 from troposphere import (
+    Equals,
     GetAtt,
+    If,
+    Not,
     Output,
     Parameter,
     Ref,
@@ -31,6 +34,12 @@ from cardinal_cfn.parameters import (
     add_install_id_parameters,
     add_parameter_group_metadata,
 )
+
+# pubsub-sqs reads additional satellite queues from numbered env-var groups
+# (SQS_QUEUE_URL_<n> / SQS_REGION_<n> / SQS_ROLE_ARN_<n>). The binary itself has
+# no cap; the stack exposes a fixed set of optional numbered queue parameters.
+# Bump this to raise the ceiling (each adds three parameters + two conditions).
+MAX_ADDITIONAL_QUEUES = 10
 
 
 def build() -> Template:
@@ -108,6 +117,41 @@ def build() -> Template:
             ),
         )
     )
+    # Additional satellite queues (groups 1..MAX_ADDITIONAL_QUEUES). Each set,
+    # when QueueUrl<n> is non-empty, is emitted as SQS_QUEUE_URL_<n> /
+    # SQS_REGION_<n> / SQS_ROLE_ARN_<n> on the pubsub-sqs container so the poller
+    # consumes that satellite's queue (cross-account/region) via its own role.
+    # QueueRegion<n> defaults to the stack region when left empty.
+    for n in range(1, MAX_ADDITIONAL_QUEUES + 1):
+        t.add_parameter(
+            Parameter(
+                f"QueueUrl{n}",
+                Type="String",
+                Default="",
+                Description=f"SQS queue URL for additional satellite queue group {n}. "
+                "Empty skips this group.",
+            )
+        )
+        t.add_parameter(
+            Parameter(
+                f"QueueRegion{n}",
+                Type="String",
+                Default="",
+                Description=f"AWS region for additional satellite queue group {n}. "
+                "Empty uses the stack region.",
+            )
+        )
+        t.add_parameter(
+            Parameter(
+                f"QueueRoleArn{n}",
+                Type="String",
+                Default="",
+                Description=f"IAM role ARN the pubsub-sqs service STS-assumes for "
+                f"additional satellite queue group {n}.",
+            )
+        )
+        t.add_condition(f"HasQueue{n}", Not(Equals(Ref(f"QueueUrl{n}"), "")))
+        t.add_condition(f"HasQueueRegion{n}", Not(Equals(Ref(f"QueueRegion{n}"), "")))
     t.add_parameter(
         Parameter(
             "LicenseSecretArn",
@@ -246,7 +290,7 @@ def build() -> Template:
         Parameter(
             "PubsubAutoRegister",
             Type="String",
-            Default="false",
+            Default="true",
             AllowedValues=["true", "false"],
             Description=(
                 "Enable pubsub-sqs auto-registration of unseen satellite raw "
@@ -406,6 +450,7 @@ def build() -> Template:
                     Name="LAKERUNNER_PUBSUB_AUTOREGISTER_WRITES_TO_INSTANCE",
                     Value=Ref("PubsubAutoRegisterWritesToInstance"),
                 ),
+                *_additional_queue_env(),
             ],
         },
     ]
@@ -514,6 +559,49 @@ def _service_specific_env(service_cfg: dict) -> list:
     """Convert the YAML environment dict into a list of ECS Environment objects."""
     env = service_cfg.get("environment") or {}
     return [Environment(Name=k, Value=str(v)) for k, v in env.items()]
+
+
+def _additional_queue_env() -> list:
+    """Numbered SQS env groups for additional satellite queues.
+
+    For each group n in 1..MAX_ADDITIONAL_QUEUES emit SQS_QUEUE_URL_<n> /
+    SQS_REGION_<n> / SQS_ROLE_ARN_<n>, but only when QueueUrl<n> is set --
+    Fn::If with AWS::NoValue drops the entry from the Environment list
+    otherwise. SQS_REGION_<n> falls back to the stack region when QueueRegion<n>
+    is left empty.
+    """
+    no_value = Ref("AWS::NoValue")
+    entries: list = []
+    for n in range(1, MAX_ADDITIONAL_QUEUES + 1):
+        entries.append(
+            If(
+                f"HasQueue{n}",
+                Environment(Name=f"SQS_QUEUE_URL_{n}", Value=Ref(f"QueueUrl{n}")),
+                no_value,
+            )
+        )
+        entries.append(
+            If(
+                f"HasQueue{n}",
+                Environment(
+                    Name=f"SQS_REGION_{n}",
+                    Value=If(
+                        f"HasQueueRegion{n}",
+                        Ref(f"QueueRegion{n}"),
+                        Ref("AWS::Region"),
+                    ),
+                ),
+                no_value,
+            )
+        )
+        entries.append(
+            If(
+                f"HasQueue{n}",
+                Environment(Name=f"SQS_ROLE_ARN_{n}", Value=Ref(f"QueueRoleArn{n}")),
+                no_value,
+            )
+        )
+    return entries
 
 
 if __name__ == "__main__":

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -41,6 +41,7 @@ from troposphere import (
 from troposphere.cloudformation import Stack
 from troposphere.servicediscovery import PrivateDnsNamespace
 
+from cardinal_cfn.children.services_process import MAX_ADDITIONAL_QUEUES
 from cardinal_cfn.install_id import install_id_short, install_id_long
 from cardinal_cfn.parameters import add_parameter_group_metadata, add_no_echo_parameter
 from cardinal_cfn.images import add_image_override
@@ -110,7 +111,7 @@ def _sizing_param_specs(defaults: dict) -> list[dict]:
          "description": "Fargate memory (MiB) for lakerunner-process-traces."},
         {"name": "PubsubSqsReplicas", "type": "Number", "default": int(pubsub["replicas"]),
          "min": 1, "description": "Desired replicas for lakerunner-pubsub-sqs."},
-        {"name": "PubsubAutoRegister", "type": "String", "default": "false",
+        {"name": "PubsubAutoRegister", "type": "String", "default": "true",
          "allowed_values": ["true", "false"],
          "description": "Enable pubsub-sqs auto-registration of unseen satellite raw buckets."},
         {"name": "PubsubAutoRegisterWritesToInstance", "type": "String", "default": "1",
@@ -294,6 +295,22 @@ def build() -> Template:
     # Infra-stack outputs threaded in as parameters
     # ---------------------------------------------------------------------
     _add_string_params(t, _INFRA_SETUP_PARAMS)
+
+    # Additional satellite queue groups (1..MAX_ADDITIONAL_QUEUES), forwarded to
+    # the process child where they become SQS_QUEUE_URL_<n>/_REGION_<n>/_ROLE_ARN_<n>
+    # on the pubsub-sqs container.
+    for n in range(1, MAX_ADDITIONAL_QUEUES + 1):
+        _add_string_params(t, [
+            (f"QueueUrl{n}", "String", "",
+             f"SQS queue URL for additional satellite queue group {n} "
+             "(empty skips it)."),
+            (f"QueueRegion{n}", "String", "",
+             f"AWS region for additional satellite queue group {n} "
+             "(empty uses the stack region)."),
+            (f"QueueRoleArn{n}", "String", "",
+             f"IAM role ARN pubsub-sqs STS-assumes for additional satellite "
+             f"queue group {n}."),
+        ])
 
     # ---------------------------------------------------------------------
     # Security-tier inputs (SG ids + role ARNs); replace the Security child.
@@ -633,6 +650,10 @@ def build() -> Template:
         "PubsubAutoRegister": Ref("PubsubAutoRegister"),
         "PubsubAutoRegisterWritesToInstance": Ref("PubsubAutoRegisterWritesToInstance"),
     })
+    for n in range(1, MAX_ADDITIONAL_QUEUES + 1):
+        services_process_params[f"QueueUrl{n}"] = Ref(f"QueueUrl{n}")
+        services_process_params[f"QueueRegion{n}"] = Ref(f"QueueRegion{n}")
+        services_process_params[f"QueueRoleArn{n}"] = Ref(f"QueueRoleArn{n}")
     services_process_stack = _add_child(
         t, "Process", "services-process.yaml",
         services_process_params, depends_on=["Migration"])

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -159,10 +159,23 @@ def test_pubsub_autoregister_params_present_with_defaults(td):
     root with the correct defaults."""
     params = td["Parameters"]
     assert "PubsubAutoRegister" in params
-    assert params["PubsubAutoRegister"]["Default"] == "false"
+    assert params["PubsubAutoRegister"]["Default"] == "true"
     assert params["PubsubAutoRegister"]["AllowedValues"] == ["true", "false"]
     assert "PubsubAutoRegisterWritesToInstance" in params
     assert params["PubsubAutoRegisterWritesToInstance"]["Default"] == "1"
+
+
+def test_additional_queue_groups_forwarded_to_process_child(td):
+    """The root declares numbered queue params and forwards them to the process
+    child so pubsub-sqs can consume multiple satellite queues."""
+    params = td["Parameters"]
+    for n in (1, 10):
+        for p in (f"QueueUrl{n}", f"QueueRegion{n}", f"QueueRoleArn{n}"):
+            assert p in params, f"root missing {p}"
+            assert params[p]["Default"] == ""
+    process = td["Resources"]["Process"]["Properties"]["Parameters"]
+    assert process["QueueUrl1"] == {"Ref": "QueueUrl1"}
+    assert process["QueueRoleArn10"] == {"Ref": "QueueRoleArn10"}
 
 
 def test_pubsub_autoregister_wired_to_process_child(td):

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -274,7 +274,11 @@ def test_all_task_definitions_set_ssl_required(td):
     task_defs = [r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"]
     for tdef in task_defs:
         for container in tdef["Properties"]["ContainerDefinitions"]:
-            env = {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+            env = {
+                e["Name"]: e["Value"]
+                for e in container.get("Environment", [])
+                if isinstance(e, dict) and "Name" in e
+            }
             assert env.get("LRDB_SSLMODE") == "require", (
                 f"{container.get('Name')} LRDB_SSLMODE must be 'require'; got {env.get('LRDB_SSLMODE')!r}"
             )
@@ -292,7 +296,13 @@ def _container(td, task_def_id):
 
 def _env(td, task_def_id):
     container = _container(td, task_def_id)
-    return {e["Name"]: e["Value"] for e in container.get("Environment", [])}
+    # Skip conditional entries (Fn::If with AWS::NoValue) -- only plain
+    # Name/Value env vars have a "Name" key.
+    return {
+        e["Name"]: e["Value"]
+        for e in container.get("Environment", [])
+        if isinstance(e, dict) and "Name" in e
+    }
 
 
 def test_pubsub_sqs_has_plain_group0_env(td):
@@ -338,10 +348,31 @@ def test_pubsub_autoregister_params_exist_with_defaults(td):
     with the expected defaults."""
     params = td["Parameters"]
     assert "PubsubAutoRegister" in params
-    assert params["PubsubAutoRegister"]["Default"] == "false"
+    assert params["PubsubAutoRegister"]["Default"] == "true"
     assert params["PubsubAutoRegister"]["AllowedValues"] == ["true", "false"]
     assert "PubsubAutoRegisterWritesToInstance" in params
     assert params["PubsubAutoRegisterWritesToInstance"]["Default"] == "1"
+
+
+def test_additional_queue_groups_are_conditional(td):
+    """Each additional queue group N declares QueueUrl/Region/RoleArn params, a
+    HasQueue<N> condition, and emits SQS_*_<N> on pubsub-sqs only when set."""
+    params = td["Parameters"]
+    conditions = td.get("Conditions", {})
+    for n in (1, 2, 10):
+        for p in (f"QueueUrl{n}", f"QueueRegion{n}", f"QueueRoleArn{n}"):
+            assert p in params, f"missing param {p}"
+            assert params[p]["Default"] == "", f"{p} must default empty"
+        assert f"HasQueue{n}" in conditions
+        assert f"HasQueueRegion{n}" in conditions
+
+    # The SQS_*_N entries are Fn::If-gated on HasQueue<N> (dropped via NoValue).
+    env_raw = _container(td, "PubsubSqsTaskDef")["Environment"]
+    conds_used = {
+        e["Fn::If"][0] for e in env_raw if isinstance(e, dict) and "Fn::If" in e
+    }
+    assert "HasQueue1" in conds_used
+    assert "HasQueue10" in conds_used
 
 
 def test_pubsub_sqs_has_autoregister_env_vars(td):


### PR DESCRIPTION
Two related changes to `lakerunner-services` / the `services-process` child for multi-account satellite ingest.

## 1. `PubsubAutoRegister` defaults to `true`

Flipped the default (root `lakerunner_services.py` + child `services_process.py`). New deploys auto-register unseen satellite raw-bucket orgs and route cooked output to `PubsubAutoRegisterWritesToInstance` (default `1`) with no extra flag. Pass `PUBSUB_AUTOREGISTER=false` to opt out.

## 2. Multiple SQS queues

The binary consumes numbered queue groups (`SQS_QUEUE_URL_<n>` / `SQS_REGION_<n>` / `SQS_ROLE_ARN_<n>`); the stack only wired the primary (group 0). Added optional numbered params `QueueUrl<n>` / `QueueRegion<n>` / `QueueRoleArn<n>` for n=1..`MAX_ADDITIONAL_QUEUES` (10), forwarded root -> process child, emitted on the pubsub-sqs container **only when `QueueUrl<n>` is set** (`Fn::If` + `AWS::NoValue` drops empty slots). Each group carries its own region (falls back to the stack region) and assume-role, so the poller reaches satellite queues in other accounts/regions.

Driver: `QUEUE_URL_<n>` / `QUEUE_REGION_<n>` / `QUEUE_ROLE_ARN_<n>` env loop (n=1..10).

## Verification

- `make scripts` + `make build` (cfn-lint clean) + `make test` — 477 passed, 1 skipped (incl. shellcheck on the generated driver).
- New tests: conditional numbered env on the child, root->child forwarding, autoregister default flipped. Fixed the env-extraction test helpers to skip `Fn::If` entries.
- `docs/operations/jenkins-chained-deploy.md` updated; changelog `v0.0.121`.

The ceiling is a fixed `MAX_ADDITIONAL_QUEUES = 10` (numbered-params approach, per design choice); bump the constant to raise it.