### PR TITLE
deploy-satellite-services: echo visible inputs before validating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.122
+
+- **`deploy-satellite-services.sh` now echoes the inputs it can see.** Before
+  validating, the driver prints every required and optional input visible to the
+  process (value, or `<unset>`) to stderr, so a `missing required: ...` failure
+  is easy to diagnose. The usual cause is a value set as a plain shell variable
+  but not exported, so the driver — a separate process — never receives it and
+  it shows as `<unset>`. No behavior or parameter change.
+  - Upgrade action: none.
+
 ## v0.0.121
 
 - **`PubsubAutoRegister` now defaults to `true`.** New `lakerunner-services`

--- a/scripts-src/parts/deploy-satellite-services.sh
+++ b/scripts-src/parts/deploy-satellite-services.sh
@@ -53,6 +53,19 @@ case "${1:-}" in
     *) echo "[deploy-satellite-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
 esac
 
+# Echo the inputs this script can actually see before validating, so a
+# "missing required" failure is easy to diagnose.  The usual cause is a value
+# set as a plain shell variable but not exported -- this child process then
+# never receives it, and it shows as <unset> below.
+echo "[deploy-satellite-services] inputs visible to this process:" >&2
+for _v in STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK ORGANIZATION_ID \
+          VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS TEMPLATE_BASE_URL \
+          DEPLOYER_ROLE_ARN NO_EXECUTE; do
+    eval "_val=\${$_v:-}"
+    printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
+done
+
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -54,6 +54,19 @@ case "${1:-}" in
     *) echo "[deploy-satellite-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
 esac
 
+# Echo the inputs this script can actually see before validating, so a
+# "missing required" failure is easy to diagnose.  The usual cause is a value
+# set as a plain shell variable but not exported -- this child process then
+# never receives it, and it shows as <unset> below.
+echo "[deploy-satellite-services] inputs visible to this process:" >&2
+for _v in STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK ORGANIZATION_ID \
+          VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS TEMPLATE_BASE_URL \
+          DEPLOYER_ROLE_ARN NO_EXECUTE; do
+    eval "_val=\${$_v:-}"
+    printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
+done
+
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"


### PR DESCRIPTION
## What

`deploy-satellite-services.sh` now prints every required and optional input the process can actually see (value, or `<unset>`) to stderr, immediately before the missing-required check.

## Why

A `missing required: ALB_SUBNETS, TASK_SUBNETS, ECS_CLUSTER_ARN` failure is almost always caused by setting those values as **plain shell variables that aren't exported** — the driver runs as a separate process and never receives them:

```sh
TASK_SUBNETS=subnet-1            # shell var, NOT exported
./deploy-satellite-services.sh   # child process can't see it -> "missing required"
```

The new echo makes this obvious: the un-exported vars show as `<unset>` in the output. Use the same-line prefix form, or `export`, to fix it.

## Notes

- Edited the source part (`scripts-src/parts/deploy-satellite-services.sh`) and regenerated the committed copy via `make scripts`.
- No behavior or parameter change; the validation logic is unchanged.
- CHANGELOG entry added under `v0.0.122`.
- `tests/unit/test_deploy_stack_lint.py` (drift check) passes.