### PR TITLE
org: OrganizationId required, no default (operator-chosen UUID)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.122
+
+- **`OrganizationId` is now a required, operator-chosen parameter (no default).**
+  The canonical `12340000-...` default is removed from `lakerunner-infra-base`,
+  `lakerunner-services`, and the nested `maestro`/`migration` children; each now
+  requires a UUID (validated by `AllowedPattern`). This makes the bootstrap org
+  predictable by choice so it can match a satellite deployed before the central
+  install. (#188)
+  - The org-onboarding flow: pick a UUID up front; deploy the satellite with it
+    (`ORGANIZATION_ID` on `satellite-services`); install lakerunner with the
+    **same** UUID. More orgs can be added later via the DB / Maestro.
+  - **Upgrade action (required):** set `ORGANIZATION_ID` on the
+    `deploy-lakerunner-infra-base.sh` (Job 1) and `deploy-lakerunner-services.sh`
+    (Job 5) drivers — both now require it. Existing installs that used the
+    canonical org must pass `ORGANIZATION_ID=12340000-0000-4000-8000-000000000000`
+    explicitly to keep the same value (a different value would re-seed the
+    config-source storage profile for a different org).
+  - The org stays on **both** infra-base (seeds the authoritative config-source
+    `storage_profiles` + `api_keys` SSM) and services (migration sidecar +
+    Maestro). Use the same UUID in both.
+
 ## v0.0.121
 
 - **`PubsubAutoRegister` now defaults to `true`.** New `lakerunner-services`

--- a/docs/operations/jenkins-chained-deploy.md
+++ b/docs/operations/jenkins-chained-deploy.md
@@ -116,7 +116,7 @@ last.
 | `ALB_ALLOWED_CIDR1` | optional | template: `10.0.0.0/8` |
 | `ALB_ALLOWED_CIDR2` | optional | template: `172.16.0.0/12` |
 | `ALB_ALLOWED_CIDR3` | optional | template: `192.168.0.0/16` |
-| `ORGANIZATION_ID` | optional | template default |
+| `ORGANIZATION_ID` | required | org UUID for this install (no default); use the SAME value on Job 5 and every satellite |
 | `INITIAL_INGEST_API_KEY` | optional | template: empty |
 | `COOKED_BUCKET_NAME` | optional | template: generated |
 | `CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK` | optional | `true` sets the cooked bucket's S3 Block Public Access config; template default `false` (not set — relies on AWS account/bucket default BPA, avoids needing `s3:PutBucketPublicAccessBlock`) |
@@ -135,6 +135,7 @@ VERSION=v0.0.70 \
 VPC_ID=vpc-0abc \
 CLUSTER_ARN=arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
 LICENSE_DATA_FILE=./license.json \
+ORGANIZATION_ID=12340000-0000-4000-8000-000000000000 \
 ALB_ALLOWED_CIDR1=10.0.0.0/8 \
 ./scripts/deploy-lakerunner-infra-base.sh
 ```
@@ -268,6 +269,7 @@ exit. Set `CERTIFICATE_ARN` to use a real cert.
 | `CLUSTER_NAME` | required | ECS cluster name (no upstream output for it) |
 | `VPC_ID` | required | — |
 | `PRIVATE_SUBNETS` | required | comma-separated private subnet ids |
+| `ORGANIZATION_ID` | required | org UUID (no default); MUST match Job 1 (`lakerunner-infra-base`) and every satellite |
 | `CERTIFICATE_ARN` | optional | ACM/IAM cert ARN for the Maestro HTTPS listener. If unset, the wrapper auto-generates a self-signed internal cert **only on first create** (re-runs keep the existing cert — no churn). Set it to use a real cert. |
 | `CERTIFICATE_BODY` | optional | PEM cert body as a direct string (overrides auto-generation; body + private key together). Written to a temp file and passed via `FILE_PARAMS`. |
 | `CERTIFICATE_PRIVATE_KEY` | optional | PEM private key as a direct string |
@@ -301,6 +303,7 @@ CLUSTER_ARN=arn:aws:ecs:us-east-1:111122223333:cluster/cardinal \
 CLUSTER_NAME=cardinal \
 VPC_ID=vpc-0abc \
 PRIVATE_SUBNETS=subnet-1,subnet-2 \
+ORGANIZATION_ID=12340000-0000-4000-8000-000000000000 \
 DEX_ADMIN_PASSWORD_HASH='$2y$10$...' \
 ./scripts/deploy-lakerunner-services.sh
 ```

--- a/scripts-src/parts/deploy-lakerunner-infra-base.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-base.sh
@@ -30,6 +30,10 @@ Required:
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
   LICENSE_DATA         Cardinal license token (z64:...), seeds the license
                        secret. Or supply LICENSE_DATA_FILE instead.
+  ORGANIZATION_ID      Organization UUID for this install (operator-chosen, no
+                       default). Use the SAME value on lakerunner-services and on
+                       every satellite attributed to it. Seeded into the
+                       storage-profiles / api-keys SSM params.
 
 Optional (template defaults preserved when unset):
   LICENSE_DATA_FILE            Path to a file holding the license token
@@ -38,7 +42,6 @@ Optional (template defaults preserved when unset):
   ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
   ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
   ALB_ALLOWED_CIDR3            (template default 192.168.0.0/16).
-  ORGANIZATION_ID              Canonical org id seeded into config.
   INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
   COOKED_BUCKET_NAME           Explicit cooked bucket name.
   CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
@@ -67,6 +70,7 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
+[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 { [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
 if [ -n "$missing" ]; then
     usage >&2
@@ -94,7 +98,8 @@ TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 # optional ones added only when set so the template default applies otherwise.
 params="VpcId=$VPC_ID
 ClusterArn=$CLUSTER_ARN
-LicenseData=$license_data"
+LicenseData=$license_data
+OrganizationId=$ORGANIZATION_ID"
 [ -n "${ALB_SCHEME:-}" ] && params="$params
 AlbScheme=$ALB_SCHEME"
 [ -n "${ALB_ALLOWED_CIDR1:-}" ] && params="$params
@@ -103,8 +108,6 @@ AlbAllowedCidr1=$ALB_ALLOWED_CIDR1"
 AlbAllowedCidr2=$ALB_ALLOWED_CIDR2"
 [ -n "${ALB_ALLOWED_CIDR3:-}" ] && params="$params
 AlbAllowedCidr3=$ALB_ALLOWED_CIDR3"
-[ -n "${ORGANIZATION_ID:-}" ] && params="$params
-OrganizationId=$ORGANIZATION_ID"
 [ -n "${INITIAL_INGEST_API_KEY:-}" ] && params="$params
 InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
 [ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -41,6 +41,9 @@ Required:
   CLUSTER_NAME                ECS cluster name (no upstream output for it).
   VPC_ID                      VPC for the services.
   PRIVATE_SUBNETS             Comma-separated private subnet ids.
+  ORGANIZATION_ID             Organization UUID for this install (operator-chosen,
+                              no default). MUST match the value used on
+                              lakerunner-infra-base and on every satellite.
   DEX_ADMIN_PASSWORD_HASH     bcrypt hash for the Maestro/DEX admin login.
                               REQUIRED: DEX will not start without it ("no
                               password hash provided") and MaestroService rolls
@@ -118,6 +121,7 @@ missing=""
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${INFRA_RDS_STACK:-}" ] && missing="$missing INFRA_RDS_STACK"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
+[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
 [ -z "${CLUSTER_NAME:-}" ] && missing="$missing CLUSTER_NAME"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
@@ -185,6 +189,7 @@ MAPS=""
 # prefix.
 params="QueueUrl=$queue_url
 QueueRoleArn=$role_arn
+OrganizationId=$ORGANIZATION_ID
 TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
 ClusterArn=$CLUSTER_ARN
 ClusterName=$CLUSTER_NAME

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -31,6 +31,10 @@ Required:
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
   LICENSE_DATA         Cardinal license token (z64:...), seeds the license
                        secret. Or supply LICENSE_DATA_FILE instead.
+  ORGANIZATION_ID      Organization UUID for this install (operator-chosen, no
+                       default). Use the SAME value on lakerunner-services and on
+                       every satellite attributed to it. Seeded into the
+                       storage-profiles / api-keys SSM params.
 
 Optional (template defaults preserved when unset):
   LICENSE_DATA_FILE            Path to a file holding the license token
@@ -39,7 +43,6 @@ Optional (template defaults preserved when unset):
   ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
   ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
   ALB_ALLOWED_CIDR3            (template default 192.168.0.0/16).
-  ORGANIZATION_ID              Canonical org id seeded into config.
   INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
   COOKED_BUCKET_NAME           Explicit cooked bucket name.
   CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
@@ -68,6 +71,7 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
+[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 { [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
 if [ -n "$missing" ]; then
     usage >&2
@@ -95,7 +99,8 @@ TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 # optional ones added only when set so the template default applies otherwise.
 params="VpcId=$VPC_ID
 ClusterArn=$CLUSTER_ARN
-LicenseData=$license_data"
+LicenseData=$license_data
+OrganizationId=$ORGANIZATION_ID"
 [ -n "${ALB_SCHEME:-}" ] && params="$params
 AlbScheme=$ALB_SCHEME"
 [ -n "${ALB_ALLOWED_CIDR1:-}" ] && params="$params
@@ -104,8 +109,6 @@ AlbAllowedCidr1=$ALB_ALLOWED_CIDR1"
 AlbAllowedCidr2=$ALB_ALLOWED_CIDR2"
 [ -n "${ALB_ALLOWED_CIDR3:-}" ] && params="$params
 AlbAllowedCidr3=$ALB_ALLOWED_CIDR3"
-[ -n "${ORGANIZATION_ID:-}" ] && params="$params
-OrganizationId=$ORGANIZATION_ID"
 [ -n "${INITIAL_INGEST_API_KEY:-}" ] && params="$params
 InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
 [ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -42,6 +42,9 @@ Required:
   CLUSTER_NAME                ECS cluster name (no upstream output for it).
   VPC_ID                      VPC for the services.
   PRIVATE_SUBNETS             Comma-separated private subnet ids.
+  ORGANIZATION_ID             Organization UUID for this install (operator-chosen,
+                              no default). MUST match the value used on
+                              lakerunner-infra-base and on every satellite.
   DEX_ADMIN_PASSWORD_HASH     bcrypt hash for the Maestro/DEX admin login.
                               REQUIRED: DEX will not start without it ("no
                               password hash provided") and MaestroService rolls
@@ -119,6 +122,7 @@ missing=""
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${INFRA_RDS_STACK:-}" ] && missing="$missing INFRA_RDS_STACK"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
+[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
 [ -z "${CLUSTER_NAME:-}" ] && missing="$missing CLUSTER_NAME"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
@@ -186,6 +190,7 @@ MAPS=""
 # prefix.
 params="QueueUrl=$queue_url
 QueueRoleArn=$role_arn
+OrganizationId=$ORGANIZATION_ID
 TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
 ClusterArn=$CLUSTER_ARN
 ClusterName=$CLUSTER_NAME

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -277,11 +277,14 @@ def build() -> Template:
         Parameter(
             "OrganizationId",
             Type="String",
-            Default="12340000-0000-4000-8000-000000000000",
+            AllowedPattern=(
+                r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            ),
             Description=(
-                "Canonical single-install organization UUID. Seeded as the org "
-                "Maestro pre-populates; matches the lakerunner storage-profiles / "
-                "api-keys org so both sides own the same data feed."
+                "Organization UUID for this install (operator-chosen, no default). "
+                "Seeded as the org Maestro pre-populates; matches the lakerunner "
+                "storage-profiles / api-keys org so both sides own the same data feed."
             ),
         )
     )

--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -111,10 +111,13 @@ def build() -> Template:
         Parameter(
             "OrgId",
             Type="String",
-            Default="12340000-0000-4000-8000-000000000000",
+            AllowedPattern=(
+                r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+            ),
             Description=(
-                "Canonical single-install organization UUID. Must match the "
-                "infrastructure stack's storage-profiles/api-keys seed."
+                "Organization UUID for this install (operator-chosen, no default). "
+                "Must match the infrastructure stack's storage-profiles/api-keys seed."
             ),
         )
     )

--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -226,14 +226,15 @@ def build() -> Template:
     organization_id = t.add_parameter(Parameter(
         "OrganizationId",
         Type="String",
-        Default="12340000-0000-4000-8000-000000000000",
-        Description=(
-            "Canonical single-install organization UUID. Used in both the "
-            "storage-profiles and api-keys SSM seeds."
-        ),
         AllowedPattern=(
             r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
             r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        ),
+        Description=(
+            "Organization UUID for this install (operator-chosen, no default). "
+            "Must match the OrganizationId used on lakerunner-services and on "
+            "every satellite attributed to it. Used in both the "
+            "storage-profiles and api-keys SSM seeds."
         ),
     ))
     license_data = add_no_echo_parameter(

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -369,10 +369,14 @@ def build() -> Template:
     t.add_parameter(Parameter(
         "OrganizationId",
         Type="String",
-        Default="12340000-0000-4000-8000-000000000000",
+        AllowedPattern=(
+            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+            r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+        ),
         Description=(
-            "Canonical single-install organization UUID. Must match the value "
-            "the infrastructure stack seeded into storage-profiles / api-keys; "
+            "Organization UUID for this install (operator-chosen, no default). "
+            "Must match the value the infrastructure stack seeded into "
+            "storage-profiles / api-keys and every satellite's OrganizationId; "
             "Maestro pre-populates this org and wires it to the local lakerunner."
         ),
     ))

--- a/tests/templates/test_lakerunner_infra_base.py
+++ b/tests/templates/test_lakerunner_infra_base.py
@@ -37,6 +37,17 @@ def test_required_parameters(td):
         assert n in td["Parameters"], f"missing parameter: {n}"
 
 
+def test_organization_id_required_no_default(td):
+    """OrganizationId is operator-chosen: required (no default) and UUID-shaped,
+    so the bootstrap org is predictable and matches the satellites."""
+    p = td["Parameters"]["OrganizationId"]
+    assert "Default" not in p, "OrganizationId must have no default"
+    assert p["AllowedPattern"] == (
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
+
+
 def test_dropped_rds_param(td):
     """security.py's RdsSecurityGroupId param is gone (RDS ingress lives in rds)."""
     assert "RdsSecurityGroupId" not in td["Parameters"]

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -84,6 +84,17 @@ def test_data_plane_params(td):
     assert "QueueArn" not in params, "vestigial queue param present: QueueArn"
 
 
+def test_organization_id_required_no_default(td):
+    """OrganizationId is required (no default) on the services root, matching
+    infra-base so the bootstrap org is operator-chosen and consistent."""
+    p = td["Parameters"]["OrganizationId"]
+    assert "Default" not in p, "OrganizationId must have no default"
+    assert p["AllowedPattern"] == (
+        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
+        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    )
+
+
 def test_pubsub_sqs_queue_wired_to_process_child(td):
     """The group-0 SQS inputs (QueueUrl/QueueRoleArn) flow into the Process
     child, where the pubsub-sqs container sets them as plain SQS_* env vars."""

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -158,6 +158,19 @@ def test_satellite_drivers_never_pull_central_stack():
         assert "LicenseSecretArn" not in text, f"{name} still references LicenseSecretArn"
 
 
+def test_central_drivers_require_organization_id():
+    """ORGANIZATION_ID is operator-chosen with no template default, so both
+    central drivers must require it and pass it through as OrganizationId."""
+    for name in ("deploy-lakerunner-infra-base.sh", "deploy-lakerunner-services.sh"):
+        text = (SCRIPTS_DIR / name).read_text()
+        assert 'missing="$missing ORGANIZATION_ID"' in text, (
+            f"{name} must require ORGANIZATION_ID"
+        )
+        assert "OrganizationId=$ORGANIZATION_ID" in text, (
+            f"{name} must pass OrganizationId=$ORGANIZATION_ID"
+        )
+
+
 def test_lakerunner_services_passes_queue_params():
     """lakerunner-services must read the group-0 queue inputs from the satellite
     outputs and pass them as plain QueueUrl/QueueRoleArn params (no shell blob)."""


### PR DESCRIPTION
Makes the bootstrap org **operator-chosen** by removing the canonical `12340000-...` default, so the org id is predictable and can match a satellite deployed before the central install.

## Changes

- **No default** on `OrganizationId` (`lakerunner-infra-base`, `lakerunner-services`, `maestro`) and `OrgId` (`migration`). Each is now required and validated by the UUID `AllowedPattern`.
- **Drivers require `ORGANIZATION_ID`:** `deploy-lakerunner-infra-base.sh` (Job 1) and `deploy-lakerunner-services.sh` (Job 5). The services driver previously **never passed it**, so a custom org on infra-base would silently mismatch services/migration/maestro (which used the `12340000` default) -> storage-profile resolution failure. Now both pass the same value.

## Why the org stays on infra-base

It seeds the **authoritative config-source** `storage_profiles` SSM param that the binary reads (`storageProfiles.source: config`, "no other source supported" per the chart). That is **not** redundant with the migration sidecar's `organization_buckets` configdb seed (a different consumer). So infra-base genuinely needs the UUID; per the design discussion we keep it there rather than relocating the `Retain` SSM params between stacks.

## Onboarding flow this enables

1. Make up a UUID before installing lakerunner-services.
2. Deploy a satellite with it (`ORGANIZATION_ID` on `satellite-services`).
3. Install lakerunner with the **same** UUID (Job 1 + Job 5).

## Upgrade note (breaking)

`ORGANIZATION_ID` is now required on Jobs 1 and 5. Existing canonical-org installs must pass `ORGANIZATION_ID=12340000-0000-4000-8000-000000000000` explicitly to keep the same value.

## Verification

`make scripts` + `make build` (cfn-lint clean) + `make test` — 480 passed, 1 skipped. New tests: no-default/required on infra-base + services params; both drivers require + pass `ORGANIZATION_ID`. Docs + changelog `v0.0.122`.