### PR TITLE
Maestro as sole owner of Lakerunner org provisioning (admin-key-only install)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,37 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.124
+
+- **Lakerunner now installs admin-key-only; Maestro is the sole owner of org
+  content.** CloudFormation no longer seeds the organization, its storage line,
+  or its ingest key into `configdb`. Three writers were removed: the
+  `lakerunner-infra-base` `StorageProfilesParam` / `ApiKeysParam` SSM parameters
+  (and the migrator import that consumed them), and the `migration` child's
+  `ensure-storage-profile` sidecar. The org, its storage line (the central
+  bucket, `otel-raw/`), and its ingest key are now provisioned at runtime by
+  Maestro through Lakerunner's `/api/v1/provision` admin API. Admin-api auth is
+  unchanged — it already seeds its first key from `cardinal-admin-key` via
+  `ADMIN_INITIAL_API_KEY`.
+  - **Parameters removed:** `lakerunner-infra-base` drops `OrganizationId`,
+    `InitialIngestApiKey`, `StorageProfilesParamName`, `ApiKeysParamName` (and
+    its `StorageProfilesParamName` / `ApiKeysParamName` outputs). The
+    `migration` child drops `StorageProfilesParamName`, `ApiKeysParamName`,
+    `OrgId`, `IngestBucketName`. `lakerunner-services` no longer threads the
+    `*ParamName` outputs. `OrganizationId` now lives **only** on
+    `lakerunner-services` (it feeds Maestro's `MAESTRO_BOOTSTRAP_ORG_ID`).
+  - **Driver change:** `deploy-lakerunner-infra-base.sh` no longer requires
+    `ORGANIZATION_ID` and no longer accepts `INITIAL_INGEST_API_KEY`,
+    `API_KEYS_PARAM_NAME`, or `STORAGE_PROFILES_PARAM_NAME`.
+    `deploy-lakerunner-services.sh` still requires `ORGANIZATION_ID`.
+  - **Upgrade action:** none for existing installs — `configdb` is already
+    populated and the migrator only seeds empty tables, so this is
+    non-destructive to running stacks (it changes the fresh-install contract).
+    On the infra-base driver, stop passing `ORGANIZATION_ID` /
+    `INITIAL_INGEST_API_KEY` / `*_PARAM_NAME`. Operators who relied on a
+    deterministic ingest key now create it in the Maestro UI rather than via
+    `InitialIngestApiKey`.
+
 ## v0.0.123
 
 - **`OrganizationId` is now a required, operator-chosen parameter (no default).**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ Two customer-facing CloudFormation root templates:
 
 Plus a single shell driver:
 
-- `scripts/data-setup.sh` — raw-AWS-CLI data provisioner. Creates RDS, S3 ingest, SQS, the three `cardinal-*` Secrets Manager secrets (`-db-master`, `-license`, `-admin-key`), and the two SSM parameters. Idempotent; emits a JSON document on stdout whose keys map 1:1 to the lakerunner stack's infra-setup parameters. The customer supplies all IAM roles, security groups, the ECS cluster, and the Cloud Map private DNS namespace out-of-band; they are inputs to the script, which forwards their identifiers into the JSON output.
+- `scripts/data-setup.sh` — raw-AWS-CLI data provisioner. Creates RDS, S3 ingest, SQS, and the three `cardinal-*` Secrets Manager secrets (`-db-master`, `-license`, `-admin-key`). It seeds **no** org content: Lakerunner installs admin-key-only (admin-api seeds its first key from `cardinal-admin-key` via `ADMIN_INITIAL_API_KEY`), and Maestro is the sole owner of the org, its storage line, and its ingest key — provisioned at runtime through Lakerunner's `/api/v1/provision` admin API. Idempotent; emits a JSON document on stdout whose keys map 1:1 to the lakerunner stack's infra-setup parameters. The customer supplies all IAM roles, security groups, the ECS cluster, and the Cloud Map private DNS namespace out-of-band; they are inputs to the script, which forwards their identifiers into the JSON output.
 
 The lakerunner root nests these children — application-tier resources only:
 
@@ -95,12 +95,12 @@ generated-templates/
 
 - Default to **CloudFormation-generated physical names** with a `Name` tag.
 - Prefix is `cardinal-`. Use `chq-` only when an AWS resource name length cap forces it.
-- Explicit physical names *only* where externally referenced — SSM Parameter names (AWS-required), the S3 ingest bucket name (predictability), license/admin secrets (referenced from outside the stack).
+- Explicit physical names *only* where externally referenced — the S3 ingest bucket name (predictability), license/admin secrets (referenced from outside the stack).
 - Never name RDS, ECS clusters/services, listener rules, log groups, target groups — explicit names block in-place updates.
 
 ### Single-install assumption
 
-The fixed `cardinal-*` resource names the script creates (RDS instance, S3 bucket, SQS queue, secrets, SSM params) imply one Cardinal install per AWS account/region. The ECS cluster + Cloud Map namespace names are customer-chosen but should be picked with the same constraint in mind. Customers running multiple installs should use separate accounts (or separate regions).
+The fixed `cardinal-*` resource names the script creates (RDS instance, S3 bucket, SQS queue, secrets) imply one Cardinal install per AWS account/region. The ECS cluster + Cloud Map namespace names are customer-chosen but should be picked with the same constraint in mind. Customers running multiple installs should use separate accounts (or separate regions).
 
 ### Multi-install isolation (lakerunner-internal)
 

--- a/docs/superpowers/plans/2026-06-03-maestro-owns-org-provisioning.md
+++ b/docs/superpowers/plans/2026-06-03-maestro-owns-org-provisioning.md
@@ -1,0 +1,260 @@
+# Maestro Sole Owner of Org Provisioning — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Lakerunner install in "just the admin key exists" mode by removing CloudFormation's three org-content writers, leaving Maestro (via `/api/v1/provision`) as the sole owner of the org, its storage line, and its ingest key.
+
+**Architecture:** Pure removal on the CFN generators. Today three things seed org content into `configdb`: (1) infra-base SSM `StorageProfilesParam`/`ApiKeysParam` imported by the migrator, (2) the migration child's `ensure-storage-profile` sidecar that upserts the org bucket row, (3) Maestro's provisioning worker. We delete (1) and (2). `ADMIN_INITIAL_API_KEY` (admin-key-only auth) is already wired in `services_control.py:350` — unchanged. `OrganizationId` stays only on the services root (feeds `MAESTRO_BOOTSTRAP_ORG_ID`); it is removed from infra-base and the migration child.
+
+**Tech Stack:** Python + troposphere generators; cloud-radar template tests; cfn-lint; bash deploy drivers assembled from `scripts-src/` by `build.sh`.
+
+**Verification gate for every task:** `make build` (generate + cfn-lint) and the relevant `pytest` must pass before commit.
+
+---
+
+### Task 1: Drop org-content seeding from `lakerunner-infra-base`
+
+**Files:**
+- Modify: `src/cardinal_cfn/lakerunner_infra_base.py`
+- Test: `tests/templates/test_lakerunner_infra_base.py`
+
+- [ ] **Step 1: Update the test to the new contract (failing first).**
+
+In `tests/templates/test_lakerunner_infra_base.py`:
+- Remove `StorageProfilesParamName`, `ApiKeysParamName`, `OrganizationId`, `InitialIngestApiKey` from the expected-parameters set (around lines 31-35) and from the outputs set (around lines 337-338).
+- Remove `test`-the-org-default body that reads `td["Parameters"]["OrganizationId"]` (lines ~41-65) and the `StorageProfilesParam` / `ApiKeysParam` resource assertions (lines ~305-311).
+- Add a negative test:
+
+```python
+def test_no_org_content_params_or_resources(template_dict):
+    """infra-base seeds NO org content; Maestro owns it via /api/v1/provision."""
+    params = template_dict["Parameters"]
+    for gone in ("OrganizationId", "InitialIngestApiKey",
+                 "StorageProfilesParamName", "ApiKeysParamName"):
+        assert gone not in params, f"{gone} should be removed from infra-base"
+    resources = template_dict["Resources"]
+    assert "StorageProfilesParam" not in resources
+    assert "ApiKeysParam" not in resources
+    outputs = template_dict.get("Outputs", {})
+    assert "StorageProfilesParamName" not in outputs
+    assert "ApiKeysParamName" not in outputs
+```
+
+- [ ] **Step 2: Run the test, expect failure.**
+
+Run: `.venv/bin/python -m pytest tests/templates/test_lakerunner_infra_base.py -q`
+Expected: FAIL (params/resources still present).
+
+- [ ] **Step 3: Edit `lakerunner_infra_base.py` — remove the parameters.**
+
+Delete the `Parameter` blocks for `StorageProfilesParamName` (lines ~206-215), `ApiKeysParamName` (~216-225), `OrganizationId` (~226-239), and `InitialIngestApiKey` (~250-258). Keep `license_secret_name`, `admin_key_secret_name`, `license_data`.
+
+- [ ] **Step 4: Edit parameter-group metadata.**
+
+In `add_parameter_group_metadata` (lines ~260-309): delete the `"Organization"` group entry (`["OrganizationId", "InitialIngestApiKey"]`), drop `StorageProfilesParamName`/`ApiKeysParamName` from the `"Names (advanced)"` group, and remove the `OrganizationId`/`InitialIngestApiKey` entries from the `labels=` dict.
+
+- [ ] **Step 5: Remove the `HasInitialIngestApiKey` condition** (lines ~322-325).
+
+- [ ] **Step 6: Remove the SSM `_stmt_ssm_read([...])` calls** from all five tier roles (migration ~600-603, query ~622-625, process ~658-661, control ~707-710, maestro ~762-765). Also remove the exec role's `ResolveCardinalSsm` statement (lines ~568-579) and the now-unused `_stmt_ssm_read` helper (lines ~991-1007). No SSM parameters remain to read.
+
+- [ ] **Step 7: Remove the SSM resources** `StorageProfilesParam` (lines ~853-881) and `ApiKeysParam` (~883-910), plus the `SSMParameter` import (line 60) and the two `_emit(...ParamName...)` outputs (~944-947).
+
+- [ ] **Step 8: Update the module docstring** (lines 17, 31-33) to drop the storage-profiles/api-keys SSM mentions; note the stack creates the admin-key + license secrets only.
+
+- [ ] **Step 9: Run tests + build.**
+
+Run: `.venv/bin/python -m pytest tests/templates/test_lakerunner_infra_base.py -q && make build`
+Expected: PASS; cfn-lint clean.
+
+- [ ] **Step 10: Commit.**
+
+```bash
+git add src/cardinal_cfn/lakerunner_infra_base.py tests/templates/test_lakerunner_infra_base.py
+git commit -m "infra-base: stop seeding org content (no OrganizationId/SSM); Maestro owns it"
+```
+
+---
+
+### Task 2: Strip the migrator's SSM import and the `ensure-storage-profile` sidecar
+
+**Files:**
+- Modify: `src/cardinal_cfn/children/migration.py`
+- Test: `tests/templates/test_migration.py`
+
+- [ ] **Step 1: Update tests to new contract (failing first).**
+
+In `tests/templates/test_migration.py`:
+- Remove `StorageProfilesParamName`, `ApiKeysParamName`, `OrgId`, `IngestBucketName` from the expected-params tuple (lines ~43-44).
+- Delete `test_migrator_seeds_configdb_from_ssm` (~48-65).
+- Change the container-name expectation (line ~104) to `["configdb-init", "migrator", "keepalive"]`.
+- Delete `test_ensure_storage_profile_*` tests (~131-162) and the `ensure-storage-profile` entries in the dependsOn test; set keepalive's expected `DependsOn` to `[{"ContainerName": "migrator", "Condition": "SUCCESS"}]` (~126-127).
+- Add:
+
+```python
+def test_migrator_does_not_import_ssm(template_dict):
+    """Org content is Maestro-owned; the migrator seeds nothing from SSM."""
+    migrator = _containers(template_dict)["migrator"]
+    env = {e["Name"]: e["Value"] for e in migrator["Environment"]}
+    assert "STORAGE_PROFILE_FILE" not in env
+    assert "API_KEYS_FILE" not in env
+    secrets = {s["Name"] for s in migrator.get("Secrets", [])}
+    assert "STORAGE_PROFILES_YAML" not in secrets
+    assert "API_KEYS_YAML" not in secrets
+
+
+def test_no_ensure_storage_profile_container(template_dict):
+    assert "ensure-storage-profile" not in _containers(template_dict)
+```
+
+- [ ] **Step 2: Run tests, expect failure.**
+
+Run: `.venv/bin/python -m pytest tests/templates/test_migration.py -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Remove the four parameters** `StorageProfilesParamName`, `ApiKeysParamName` (lines ~91-104), `OrgId` (~110-123), `IngestBucketName` (~124-130) and update the SSM-seed comment block (~83-90).
+
+- [ ] **Step 4: Strip the migrator container's SSM wiring.** In `migrator_container`, delete the `STORAGE_PROFILE_FILE` and `API_KEYS_FILE` `Environment` entries (~219-220) and the `STORAGE_PROFILES_YAML` / `API_KEYS_YAML` `Secret` entries (~229-240).
+
+- [ ] **Step 5: Delete the `ensure_sp_container` definition** entirely (~245-322).
+
+- [ ] **Step 6: Rewire keepalive.** Change `keepalive_container`'s `DependsOn` to `ContainerName="migrator", Condition="SUCCESS"` (~332), and update its comment (~328-331). In `TaskDefinition.ContainerDefinitions` (~352-357) remove `ensure_sp_container`, leaving `[configdb_init_container, migrator_container, keepalive_container]`.
+
+- [ ] **Step 7: Update the module docstring** (lines 4-30) to describe three containers (configdb-init → migrator → keepalive) and drop the ensure-storage-profile narrative.
+
+- [ ] **Step 8: Run tests + build.**
+
+Run: `.venv/bin/python -m pytest tests/templates/test_migration.py -q && make build`
+Expected: PASS; cfn-lint clean.
+
+- [ ] **Step 9: Commit.**
+
+```bash
+git add src/cardinal_cfn/children/migration.py tests/templates/test_migration.py
+git commit -m "migration: drop SSM import + ensure-storage-profile sidecar (Maestro owns org content)"
+```
+
+---
+
+### Task 3: Unwire the removed params from the services root
+
+**Files:**
+- Modify: `src/cardinal_cfn/lakerunner_services.py`
+- Test: `tests/templates/test_lakerunner_services.py`
+
+- [ ] **Step 1: Update tests (failing first).**
+
+In `tests/templates/test_lakerunner_services.py`:
+- Remove `StorageProfilesParamName`, `ApiKeysParamName` from the expected param/forwarding sets (~76-77).
+- Change the `IngestBucketName`/migration assertions (~81, ~144) so the Migration child is passed NEITHER `IngestBucketName`, `OrgId`, `StorageProfilesParamName`, nor `ApiKeysParamName`:
+
+```python
+def test_migration_child_gets_no_org_content_params(template_dict):
+    migration = _migration_child_params(template_dict)  # existing helper or inline
+    for gone in ("StorageProfilesParamName", "ApiKeysParamName",
+                 "OrgId", "IngestBucketName"):
+        assert gone not in migration
+```
+
+- Keep the `OrganizationId` test (it still exists on the services root and feeds Maestro) but update any assertion text that says it is "seeded into storage-profiles / api-keys."
+
+- [ ] **Step 2: Run tests, expect failure.**
+
+Run: `.venv/bin/python -m pytest tests/templates/test_lakerunner_services.py -q`
+Expected: FAIL.
+
+- [ ] **Step 3: Remove the two infra-setup params.** In `_INFRA_SETUP_PARAMS` (lines ~178-181) delete the `StorageProfilesParamName` and `ApiKeysParamName` tuples.
+
+- [ ] **Step 4: Trim the Migration child params.** In the `migration_stack = _add_child(...)` call (lines ~590-593) delete `"StorageProfilesParamName"`, `"ApiKeysParamName"`, `"OrgId"`, `"IngestBucketName"`.
+
+- [ ] **Step 5: Update `OrganizationId` parameter description** (lines ~376-381) to drop "seeded into storage-profiles / api-keys" — it now reads only: the org Maestro pre-populates and provisions into Lakerunner; must match every satellite's `OrganizationId`.
+
+- [ ] **Step 6: Run tests + build.**
+
+Run: `.venv/bin/python -m pytest tests/templates/test_lakerunner_services.py -q && make build`
+Expected: PASS; cfn-lint clean.
+
+- [ ] **Step 7: Commit.**
+
+```bash
+git add src/cardinal_cfn/lakerunner_services.py tests/templates/test_lakerunner_services.py
+git commit -m "services-root: stop threading SSM-param + OrgId/IngestBucket into migration child"
+```
+
+---
+
+### Task 4: Update the infra-base deploy driver
+
+**Files:**
+- Modify: `scripts-src/parts/deploy-lakerunner-infra-base.sh`
+- Generated: `scripts/deploy-lakerunner-infra-base.sh` (regenerated by `build.sh`)
+- Test: `tests/unit/test_deploy_stack_lint.py`
+
+- [ ] **Step 1: Edit the driver part.** In `scripts-src/parts/deploy-lakerunner-infra-base.sh`:
+  - Remove the `ORGANIZATION_ID` required-input doc + validation (lines ~33-36, ~73) and the `OrganizationId=$ORGANIZATION_ID` param line (~102).
+  - Remove `INITIAL_INGEST_API_KEY` doc + the `InitialIngestApiKey=...` block (~45, ~111-112).
+  - Remove `API_KEYS_PARAM_NAME` / `STORAGE_PROFILES_PARAM_NAME` docs + the `ApiKeysParamName=` / `StorageProfilesParamName=` param lines (~52-53, ~122-124).
+
+  Note: `ORGANIZATION_ID` REMAINS a required input on the **services** driver (`deploy-lakerunner-services.sh`) — do not touch that one.
+
+- [ ] **Step 2: Regenerate the scripts.**
+
+Run: `./build.sh` (or `make build` if it assembles scripts; verify which regenerates `scripts/`).
+Expected: `scripts/deploy-lakerunner-infra-base.sh` updated, no `OrganizationId`/SSM-param references.
+
+- [ ] **Step 3: Verify.**
+
+Run: `grep -n "ORGANIZATION_ID\|StorageProfilesParamName\|ApiKeysParamName\|InitialIngestApiKey" scripts/deploy-lakerunner-infra-base.sh`
+Expected: no matches.
+Run: `.venv/bin/python -m pytest tests/unit/test_deploy_stack_lint.py -q`
+Expected: PASS.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add scripts-src/parts/deploy-lakerunner-infra-base.sh scripts/deploy-lakerunner-infra-base.sh
+git commit -m "deploy-infra-base: drop ORGANIZATION_ID + org-content SSM inputs"
+```
+
+---
+
+### Task 5: Docs — CHANGELOG, CLAUDE.md, full test sweep
+
+**Files:**
+- Modify: `CHANGELOG.md`, `CLAUDE.md`
+- Test: full suite
+
+- [ ] **Step 1: Add a CHANGELOG entry** (newest first; bump from the current top version). Operator-facing content:
+  - infra-base no longer takes `OrganizationId` / `InitialIngestApiKey` and no longer creates the `/cardinal/storage-profiles` + `/cardinal/api-keys` SSM params; the migrator no longer imports them and the `ensure-storage-profile` sidecar is removed. Lakerunner installs admin-key-only.
+  - `OrganizationId` is now only on `lakerunner-services` (drives Maestro's `MAESTRO_BOOTSTRAP_ORG_ID`); Maestro provisions the org + storage line + ingest key via `/api/v1/provision`.
+  - **Upgrade action:** none for existing installs (configdb already populated; the migrator only seeds empty tables). For the infra-base driver, stop passing `ORGANIZATION_ID` / `INITIAL_INGEST_API_KEY` / `*_PARAM_NAME`. Operators who relied on a deterministic ingest key now create it in the Maestro UI.
+
+- [ ] **Step 2: Fix CLAUDE.md.** The "Repository overview" / data-setup section says `data-setup.sh` creates "the two SSM parameters." Update it: there are no longer org-content SSM parameters; Lakerunner is provisioned admin-key-only and Maestro owns org content. Remove the `storage-profiles`/`api-keys` SSM bullet wherever it appears.
+
+- [ ] **Step 3: Full build + test.**
+
+Run: `make build && make test`
+Expected: all PASS; cfn-lint clean.
+
+- [ ] **Step 4: Commit.**
+
+```bash
+git add CHANGELOG.md CLAUDE.md
+git commit -m "docs: changelog + CLAUDE.md for admin-key-only install / Maestro-owned org content"
+```
+
+---
+
+### Task 6 (verification, no code): confirm Maestro provisions post-boot
+
+Not a CFN change — a runtime check the design flagged. After a fresh deploy (or against the existing test account), confirm Maestro's provisioning worker calls `/api/v1/provision` shortly after boot WITHOUT waiting on collector activity, so the org's storage line exists for `otel-raw/` ingestion. If it only fires on activity, open a conductor follow-up to run the shared-install reconcile on a short timer at startup.
+
+- [ ] Capture maestro logs showing `Bootstrap complete` then a `provision_org` job success; confirm `configdb.lrconfig_organization_buckets` has the central bucket row. Record findings in the PR description. (If unreachable in this environment, note it as the one manual post-merge check.)
+
+---
+
+## Self-Review
+
+- **Spec coverage:** retire SSM seeds (Task 1), migrator import (Task 2), `ensure-storage-profile` third writer (Task 2), `OrganizationId` off infra-base (Tasks 1/4) but kept on services→maestro (Task 3), admin-key-only already wired (no task needed — noted), driver reconcile (Task 4), data-setup/CLAUDE.md SSM-ownership reconciliation (Task 5), CHANGELOG (Task 5), post-boot provision verification (Task 6). All covered.
+- **Placeholder scan:** none — every step names exact files/lines and the assertions/edits.
+- **Type consistency:** parameter/output/container names match across tasks (`StorageProfilesParamName`, `ApiKeysParamName`, `OrgId`, `IngestBucketName`, `ensure-storage-profile`, `OrganizationId`, `ADMIN_INITIAL_API_KEY`).
+- Note: line numbers are from the current files and will drift as edits land; locate by symbol, not line.

--- a/docs/superpowers/specs/2026-06-03-maestro-owns-org-provisioning-design.md
+++ b/docs/superpowers/specs/2026-06-03-maestro-owns-org-provisioning-design.md
@@ -1,0 +1,184 @@
+# Maestro as Sole Owner of Lakerunner Org Provisioning — Design
+
+Date: 2026-06-03
+Status: Approved
+
+## Goal
+
+A fresh install where the **only** Lakerunner-specific setup step is "an admin
+key exists." Everything else — the bootstrap organization, its storage line (the
+central ingest bucket, `otel-raw/` prefix), and the org's ingest API key — is
+provisioned by Maestro through Lakerunner's admin API
+(`POST /api/v1/provision`), the same "normal provisioning" path Maestro uses for
+every other org.
+
+This collapses the configuration surface to a single place. Instead of two
+writers seeding org content into Lakerunner's `configdb` (CloudFormation via an
+SSM → migrator import, *and* Maestro via the admin API), Maestro becomes the
+**sole owner** of org/table content. CloudFormation (and `data-setup.sh`) create
+only schema-bearing and identity-bearing prerequisites: the database, the
+buckets, the queues, and the admin-key secret.
+
+A direct benefit: self-registering collectors "just work." Pubsub
+auto-registration refuses to create orgs (it only adopts buckets for an
+*existing* org); because Maestro now guarantees the org exists, satellite
+collectors that self-register against the bucket succeed.
+
+## Background: why this is doable today
+
+Verified against the live code in `../lakerunner` (Go services) and
+`../conductor` (Maestro). The architecture already supports admin-key-only
+operation; the work is to stop CloudFormation from also seeding org content.
+
+Lakerunner runtime (`../lakerunner`):
+
+- `POST /api/v1/provision` atomically writes the org row
+  (`lrconfig_organizations`), the storage line
+  (`lrconfig_bucket_configurations` + `lrconfig_organization_buckets`), and org
+  API keys (`lrconfig_organization_api_keys` +
+  `lrconfig_organization_api_key_mappings`) in one transaction. Idempotent
+  (409 = already provisioned = success).
+- Storage profiles and API keys are read from `configdb` **at runtime — never
+  from SSM**. The SSM path is a one-time install seed only.
+- The admin key validates against `lrconfig_admin_api_keys` **or** an
+  `ADMIN_INITIAL_API_KEY` env fallback (constant-time compare). The env fallback
+  needs no DB seeding.
+- Services (`admin-api`, `query-api`, `process-*`, `pubsub-sqs`, migrator) boot
+  healthy with an empty `configdb`. There is no startup validation requiring an
+  org or a storage profile to exist. Failures only occur at request time when a
+  specific missing profile is queried.
+- The migrator seeds `configdb` only when the tables are empty
+  (`initializeIfNeededFunc`), and gracefully skips when no config file is
+  supplied. An empty seed is a no-op.
+- Pubsub auto-registration validates that the org **already exists** before
+  adopting a bucket; it does not create orgs.
+
+Conductor / Maestro (`../conductor/packages/maestro`):
+
+- `services/bootstrap.ts` (issue #784) is env-gated on `MAESTRO_BOOTSTRAP_*`.
+  On every boot it find-or-creates: the owner user, the org (PK ==
+  `MAESTRO_BOOTSTRAP_ORG_ID`), the owner membership, and a `shared_cardinal`
+  managed Lakerunner instance with `auto_add_to_all_orgs=true` carrying the
+  bucket columns from `MAESTRO_BOOTSTRAP_BUCKET_*`. It is idempotent and adds
+  **no** startup dependency on the admin-api being reachable.
+- The shared-install reconciler maps each org onto the shared instance and
+  enqueues a provision job; `services/lakerunner-provisioning.ts` builds the
+  `DesiredBucket[]` from the instance's bucket columns, calls
+  `provisionOrganization` (→ `/api/v1/provision`), and `importApiKey` to create
+  the org's ingest key. The async worker retries, so admin-api need not be up at
+  Maestro boot.
+
+CloudFormation maestro child (`src/cardinal_cfn/children/maestro.py`):
+
+- Already wires the complete `MAESTRO_BOOTSTRAP_*` env: `ORG_ID`
+  (`OrganizationId`), `ORG_NAME`, `OWNER_EMAIL` (`DexAdminEmail`),
+  `LAKERUNNER_QUERY_API_URL`, `LAKERUNNER_ADMIN_API_URL`,
+  `LAKERUNNER_ADMIN_API_KEY` (from the `cardinal-admin-key` secret), and the
+  bucket group (`BUCKET_NAME` = central ingest bucket, `BUCKET_REGION`,
+  `BUCKET_CLOUD_PROVIDER=aws`, `BUCKET_COLLECTOR_NAME=lakerunner`).
+
+The only reason the desired world does not already hold is that CloudFormation
+**also** seeds org content into `configdb` at install time (via
+`OrganizationId` + `InitialIngestApiKey` → SSM `StorageProfilesParam` /
+`ApiKeysParam` → migrator import). That second writer is what this design
+removes.
+
+## Decisions
+
+- **Ownership:** Maestro is the *sole* owner of org content. CloudFormation
+  seeds no org, no storage profiles, no org API keys.
+- **Admin key:** `admin-api` receives the key via an `ADMIN_INITIAL_API_KEY`
+  env, sourced from the existing `cardinal-admin-key` Secrets Manager secret.
+  The key is validated via the env fallback and is never persisted to
+  `configdb`. Maestro uses the same secret value to authenticate `/provision`.
+- **Org-content SSM seeds:** *retired entirely* (removed, not emptied) — the
+  `StorageProfilesParam` / `ApiKeysParam` SSM parameters, their seeding inputs,
+  IAM read grants, and the migrator import.
+- **Provision trigger:** Maestro's existing boot-time `MAESTRO_BOOTSTRAP_*`
+  path. No new one-shot job or "set this up" command.
+- **`OrganizationId` location:** lives only on the services / maestro side
+  (feeding `MAESTRO_BOOTSTRAP_ORG_ID`). Removed from `lakerunner-infra-base`.
+
+## Scope of change (CloudFormation, mostly deletion)
+
+1. **`src/cardinal_cfn/lakerunner_infra_base.py`**
+   - Remove the `OrganizationId` and `InitialIngestApiKey` parameters.
+   - Remove the `StorageProfilesParam` / `ApiKeysParam` SSM resources, their
+     seeding logic (`HasInitialIngestApiKey` condition, the YAML bodies), the
+     `*ParamName` parameters, and the `StorageProfilesParamName` /
+     `ApiKeysParamName` outputs.
+   - Remove the `ssm:GetParameter*` IAM grants tied to those params.
+   - Keep the `cardinal-admin-key` secret and continue exporting its ARN.
+
+2. **`src/cardinal_cfn/children/migration.py`**
+   - Drop the `STORAGE_PROFILE_FILE` / `API_KEYS_FILE` env, the
+     `STORAGE_PROFILES_YAML` / `API_KEYS_YAML` SSM-backed secrets, the
+     `*ParamName` parameters, and the `ssm:GetParameter` grant. The migrator
+     runs schema-only and seeds nothing (graceful empty-config skip).
+
+3. **`src/cardinal_cfn/children/services_control.py` (admin-api)**
+   - Add `ADMIN_INITIAL_API_KEY` as a Secrets-Manager-backed env from the
+     `cardinal-admin-key` secret ARN.
+
+4. **Dead-env cleanup (service children)**
+   - Remove `StorageProfilesParamName` / `ApiKeysParamName` env from every
+     service container that still carries them. Runtime is DB-driven; these are
+     inert.
+
+5. **`src/cardinal_cfn/root.py` and `src/cardinal_cfn/lakerunner_services.py`**
+   - Stop threading `OrganizationId` and the `*ParamName` outputs from
+     `lakerunner-infra-base`. `OrganizationId` remains a services-side parameter
+     feeding the maestro child.
+
+6. **`scripts/data-setup.sh`**
+   - Stop creating/seeding the org-content SSM parameters. Continue creating the
+     `cardinal-admin-key` secret. (Audit for any other org-content seeding it
+     performs and remove it.)
+   - **Reconcile SSM ownership first:** `CLAUDE.md` describes `data-setup.sh` as
+     the creator of the two SSM parameters, while `lakerunner_infra_base.py`
+     creates `StorageProfilesParam` / `ApiKeysParam` as CFN resources. The plan
+     must determine which path actually creates them in the current deploy (or
+     both) and remove the org-content seeding wherever it lives, then update
+     `CLAUDE.md` to match.
+
+7. **`CHANGELOG.md` + parameter docs**
+   - Operator-facing entry: this changes the **fresh-install** contract.
+     Lakerunner installs admin-key-only; Maestro provisions the org. Note no
+     upgrade action for existing installs (their `configdb` already holds
+     content; the migrator's empty seed is a no-op there).
+
+8. **Conductor / Maestro:** no code changes anticipated. A verification task
+   confirms the deployed maestro image carries `bootstrap.ts` (#784) and the
+   provisioning worker, and that a fresh deploy provisions the org + central
+   bucket so `otel-raw/` ingestion works end to end.
+
+## Resulting flow (the staged sequence)
+
+1. Lakerunner installs with only `ADMIN_INITIAL_API_KEY` set; `configdb` empty.
+2. Maestro boots with no orgs.
+3. Bootstrap creates the `shared_cardinal` instance (admin key + central
+   bucket), then the org, maps the bucket onto it, and the async worker calls
+   `/api/v1/provision` → writes the org row + storage line + org ingest key into
+   `configdb`.
+4. `otel-raw/` ingestion works; self-registering collectors find the org
+   present; satellite buckets continue to be adopted via pubsub
+   auto-registration (which required the org to exist — now guaranteed).
+
+## Edge cases and non-goals
+
+- **Eventual consistency:** if collector data lands before Maestro's first
+  successful provision, pubsub auto-registration rejects and retries until the
+  org exists. Acceptable; no ordering guarantee is added.
+- **Admin key not in DB:** validated purely via the env fallback. Consistent
+  with the single-install posture. Both `admin-api` and Maestro reference the
+  same `cardinal-admin-key` secret.
+- **The "write bucket":** the central org reads and writes to the same instance
+  (default `instance_num`); no `writes_to` redirect is needed for it. Satellite
+  raw buckets continue to redirect cooked output via pubsub auto-registration's
+  `PubsubAutoRegisterWritesToInstance` — unchanged by this design, and now
+  reliable because the org exists.
+- **Existing installs:** non-destructive. The migrator only seeds empty tables,
+  so a live `configdb` with content is untouched. This design changes the
+  fresh-install contract, not running installs.
+- **Non-goal:** a separate one-shot provision command/container. Rejected in
+  favor of the existing, tested boot-time bootstrap.

--- a/scripts-src/parts/deploy-lakerunner-infra-base.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-base.sh
@@ -2,8 +2,10 @@
 # Jenkins job 1: deploy the cardinal-lakerunner-infra-base stack.
 #
 # This is the head of the chain -- it has no upstream stacks.  It owns the IAM
-# roles, security groups, cooked bucket, license/admin secrets, and SSM params
-# that every downstream stack consumes.
+# roles, security groups, cooked bucket, and license/admin secrets that every
+# downstream stack consumes.  It seeds NO org content: Lakerunner installs
+# admin-key-only and Maestro provisions the org via /api/v1/provision, so
+# ORGANIZATION_ID lives on the services driver, not here.
 #
 # Self-contained single-file driver: this front-half composes the published
 # template URL from TEMPLATE_BASE_URL + VERSION and builds the PARAMS block, then
@@ -30,10 +32,6 @@ Required:
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
   LICENSE_DATA         Cardinal license token (z64:...), seeds the license
                        secret. Or supply LICENSE_DATA_FILE instead.
-  ORGANIZATION_ID      Organization UUID for this install (operator-chosen, no
-                       default). Use the SAME value on lakerunner-services and on
-                       every satellite attributed to it. Seeded into the
-                       storage-profiles / api-keys SSM params.
 
 Optional (template defaults preserved when unset):
   LICENSE_DATA_FILE            Path to a file holding the license token
@@ -42,15 +40,12 @@ Optional (template defaults preserved when unset):
   ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
   ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
   ALB_ALLOWED_CIDR3            (template default 192.168.0.0/16).
-  INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
   COOKED_BUCKET_NAME           Explicit cooked bucket name.
   CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
                                'true' to set the cooked bucket's S3 Block Public
                                Access config (template default 'false': not set).
   LICENSE_SECRET_NAME          (template default cardinal-license).
   ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
-  API_KEYS_PARAM_NAME          (template default /cardinal/api-keys).
-  STORAGE_PROFILES_PARAM_NAME  (template default /cardinal/storage-profiles).
   TEMPLATE_BASE_URL            Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN            Passed to create-change-set.
   NO_EXECUTE                   Non-empty: change-set only, do not execute.
@@ -70,7 +65,6 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
-[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 { [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
 if [ -n "$missing" ]; then
     usage >&2
@@ -98,8 +92,7 @@ TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 # optional ones added only when set so the template default applies otherwise.
 params="VpcId=$VPC_ID
 ClusterArn=$CLUSTER_ARN
-LicenseData=$license_data
-OrganizationId=$ORGANIZATION_ID"
+LicenseData=$license_data"
 [ -n "${ALB_SCHEME:-}" ] && params="$params
 AlbScheme=$ALB_SCHEME"
 [ -n "${ALB_ALLOWED_CIDR1:-}" ] && params="$params
@@ -108,8 +101,6 @@ AlbAllowedCidr1=$ALB_ALLOWED_CIDR1"
 AlbAllowedCidr2=$ALB_ALLOWED_CIDR2"
 [ -n "${ALB_ALLOWED_CIDR3:-}" ] && params="$params
 AlbAllowedCidr3=$ALB_ALLOWED_CIDR3"
-[ -n "${INITIAL_INGEST_API_KEY:-}" ] && params="$params
-InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
 [ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params
 CookedBucketName=$COOKED_BUCKET_NAME"
 [ -n "${CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK:-}" ] && params="$params
@@ -118,10 +109,6 @@ ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK"
 LicenseSecretName=$LICENSE_SECRET_NAME"
 [ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params
 AdminKeySecretName=$ADMIN_KEY_SECRET_NAME"
-[ -n "${API_KEYS_PARAM_NAME:-}" ] && params="$params
-ApiKeysParamName=$API_KEYS_PARAM_NAME"
-[ -n "${STORAGE_PROFILES_PARAM_NAME:-}" ] && params="$params
-StorageProfilesParamName=$STORAGE_PROFILES_PARAM_NAME"
 
 PARAMS="$params"
 FROM_STACKS=""

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -3,8 +3,10 @@
 # Jenkins job 1: deploy the cardinal-lakerunner-infra-base stack.
 #
 # This is the head of the chain -- it has no upstream stacks.  It owns the IAM
-# roles, security groups, cooked bucket, license/admin secrets, and SSM params
-# that every downstream stack consumes.
+# roles, security groups, cooked bucket, and license/admin secrets that every
+# downstream stack consumes.  It seeds NO org content: Lakerunner installs
+# admin-key-only and Maestro provisions the org via /api/v1/provision, so
+# ORGANIZATION_ID lives on the services driver, not here.
 #
 # Self-contained single-file driver: this front-half composes the published
 # template URL from TEMPLATE_BASE_URL + VERSION and builds the PARAMS block, then
@@ -31,10 +33,6 @@ Required:
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
   LICENSE_DATA         Cardinal license token (z64:...), seeds the license
                        secret. Or supply LICENSE_DATA_FILE instead.
-  ORGANIZATION_ID      Organization UUID for this install (operator-chosen, no
-                       default). Use the SAME value on lakerunner-services and on
-                       every satellite attributed to it. Seeded into the
-                       storage-profiles / api-keys SSM params.
 
 Optional (template defaults preserved when unset):
   LICENSE_DATA_FILE            Path to a file holding the license token
@@ -43,15 +41,12 @@ Optional (template defaults preserved when unset):
   ALB_ALLOWED_CIDR1            ALB ingress CIDR allowlist (template default 10.0.0.0/8).
   ALB_ALLOWED_CIDR2            (template default 172.16.0.0/12).
   ALB_ALLOWED_CIDR3            (template default 192.168.0.0/16).
-  INITIAL_INGEST_API_KEY       Bootstrap ingest API key.
   COOKED_BUCKET_NAME           Explicit cooked bucket name.
   CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
                                'true' to set the cooked bucket's S3 Block Public
                                Access config (template default 'false': not set).
   LICENSE_SECRET_NAME          (template default cardinal-license).
   ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
-  API_KEYS_PARAM_NAME          (template default /cardinal/api-keys).
-  STORAGE_PROFILES_PARAM_NAME  (template default /cardinal/storage-profiles).
   TEMPLATE_BASE_URL            Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN            Passed to create-change-set.
   NO_EXECUTE                   Non-empty: change-set only, do not execute.
@@ -71,7 +66,6 @@ missing=""
 [ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
-[ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 { [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
 if [ -n "$missing" ]; then
     usage >&2
@@ -99,8 +93,7 @@ TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
 # optional ones added only when set so the template default applies otherwise.
 params="VpcId=$VPC_ID
 ClusterArn=$CLUSTER_ARN
-LicenseData=$license_data
-OrganizationId=$ORGANIZATION_ID"
+LicenseData=$license_data"
 [ -n "${ALB_SCHEME:-}" ] && params="$params
 AlbScheme=$ALB_SCHEME"
 [ -n "${ALB_ALLOWED_CIDR1:-}" ] && params="$params
@@ -109,8 +102,6 @@ AlbAllowedCidr1=$ALB_ALLOWED_CIDR1"
 AlbAllowedCidr2=$ALB_ALLOWED_CIDR2"
 [ -n "${ALB_ALLOWED_CIDR3:-}" ] && params="$params
 AlbAllowedCidr3=$ALB_ALLOWED_CIDR3"
-[ -n "${INITIAL_INGEST_API_KEY:-}" ] && params="$params
-InitialIngestApiKey=$INITIAL_INGEST_API_KEY"
 [ -n "${COOKED_BUCKET_NAME:-}" ] && params="$params
 CookedBucketName=$COOKED_BUCKET_NAME"
 [ -n "${CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK:-}" ] && params="$params
@@ -119,10 +110,6 @@ ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK"
 LicenseSecretName=$LICENSE_SECRET_NAME"
 [ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params
 AdminKeySecretName=$ADMIN_KEY_SECRET_NAME"
-[ -n "${API_KEYS_PARAM_NAME:-}" ] && params="$params
-ApiKeysParamName=$API_KEYS_PARAM_NAME"
-[ -n "${STORAGE_PROFILES_PARAM_NAME:-}" ] && params="$params
-StorageProfilesParamName=$STORAGE_PROFILES_PARAM_NAME"
 
 PARAMS="$params"
 FROM_STACKS=""

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -143,13 +143,13 @@ def build() -> Template:
         "BucketName",
         Type="String",
         Description=(
-            "Ingest S3 bucket name (the cardinal-infrastructure stack's "
-            "IngestBucketName output). Maestro consumes this only to seed "
-            "the MAESTRO_BOOTSTRAP_BUCKET_* env vars so its in-process "
-            "Lakerunner provisioning worker can recreate the "
-            "organization_buckets join row that it currently wipes on "
-            "every provision_org cycle. No S3 IAM is granted to the "
-            "maestro task role -- the bucket name is metadata only."
+            "Central S3 bucket name (the infra stack's cooked/ingest bucket "
+            "output). Maestro consumes this only to seed the "
+            "MAESTRO_BOOTSTRAP_BUCKET_* env vars so its in-process Lakerunner "
+            "provisioning worker writes the organization_buckets storage line "
+            "via /api/v1/provision -- the sole writer of that row, since CFN "
+            "seeds no org content. No S3 IAM is granted to the maestro task "
+            "role -- the bucket name is metadata only."
         ),
     ))
     t.add_parameter(Parameter("DbEndpoint", Type="String", Description="RDS endpoint hostname."))
@@ -542,11 +542,10 @@ def build() -> Template:
             Environment(Name="MAESTRO_BOOTSTRAP_ORG_ID", Value=Ref("OrganizationId")),
             Environment(Name="MAESTRO_BOOTSTRAP_ORG_NAME", Value=Ref("OrgName")),
             Environment(Name="MAESTRO_BOOTSTRAP_OWNER_EMAIL", Value=Ref("DexAdminEmail")),
-            # Bucket coordinates so a maestro version newer than the broken
-            # v1.45.9 can re-populate organization_buckets after
-            # provision_org instead of leaving the join row absent (which
-            # broke every Explore query until the migration task force-ran
-            # ensure-storage-profile).
+            # Bucket coordinates so maestro's provision_org writes the
+            # organization_buckets join row (the central bucket's storage line).
+            # This is now the ONLY writer of that row -- CFN seeds no org
+            # content -- so it must always be populated here.
             Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_NAME", Value=Ref("BucketName")),
             Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_REGION", Value=Ref("AWS::Region")),
             Environment(Name="MAESTRO_BOOTSTRAP_BUCKET_CLOUD_PROVIDER", Value="aws"),

--- a/src/cardinal_cfn/children/migration.py
+++ b/src/cardinal_cfn/children/migration.py
@@ -1,33 +1,25 @@
 """migration.yaml nested stack: DB migrator task definition + a long-running
 ECS service that runs the migrator once and then sleeps.
 
-No Lambda. The migrator task definition has four containers:
+No Lambda. The migrator task definition has three containers:
 
   1. configdb-init (non-essential): psql CREATE DATABASE configdb if absent.
   2. migrator (non-essential): `lakerunner migrate --databases=lrdb,configdb`,
-     dependsOn configdb-init=COMPLETE.
-  3. ensure-storage-profile (non-essential): idempotent psql upsert that
-     guarantees the canonical single-install storage_profile row exists in
-     configdb.bucket_configurations + configdb.organization_buckets. The
-     lakerunner image's initializeIfNeededFunc only seeds configdb when those
-     tables are empty, so installs whose first migration landed before
-     #117 (the storage-profiles {} bug) or which got partially seeded under
-     a different org/collector never get the canonical row -- ingest still
-     works via the otel-collector path, but maestro UI queries (post-#121)
-     run as the canonical 12340000 org and fail with "storage profile not
-     found." This sidecar self-heals that on every image bump.
-  4. keepalive (essential): sleeps forever, dependsOn ensure-storage-profile=
-     SUCCESS. A failed upsert blocks keepalive -> the ECS deployment circuit
-     breaker fails the service -> the root stack rolls back. Loud, not silent.
+     dependsOn configdb-init=COMPLETE. It seeds NO org content -- with empty
+     configdb tables the binary's initializeIfNeededFunc is a no-op. The org,
+     its storage line, and its ingest key are owned by Maestro, which
+     provisions them at runtime via Lakerunner's /api/v1/provision admin API.
+  3. keepalive (essential): sleeps forever, dependsOn migrator=SUCCESS. A
+     failed migration blocks keepalive -> the ECS deployment circuit breaker
+     fails the service -> the root stack rolls back. Loud, not silent.
 
 Because keepalive is the only essential container and ECS will not start it
-until its dependencies exit 0, the task is not RUNNING -- and therefore the
+until the migrator exits 0, the task is not RUNNING -- and therefore the
 ECS service is not at steady state, and therefore the MigrationStack nested
-stack is not CREATE_COMPLETE -- until migrations and the canonical-profile
-upsert both succeed. The service-tier stacks already DependsOn MigrationStack,
-so they only deploy after that gate clears. An image change redeploys the
-service (new migrator run + new upsert) before those stacks update, exactly
-as the old custom-resource trigger did.
+stack is not CREATE_COMPLETE -- until migrations succeed. The service-tier
+stacks already DependsOn MigrationStack, so they only deploy after that gate
+clears. An image change redeploys the service (new migrator run) before those
+stacks update, exactly as the old custom-resource trigger did.
 """
 
 from troposphere import (
@@ -79,55 +71,6 @@ def build() -> Template:
     t.add_parameter(Parameter("DbPort", Type="String", Default="5432", Description="RDS port."))
     t.add_parameter(Parameter("DbName", Type="String", Default="lakerunner", Description="Database name."))
     t.add_parameter(Parameter("DbSecretArn", Type="String", Description="ARN of the DB master secret."))
-
-    # SSM-backed seeds for configdb (storage profiles, API keys). The migrator
-    # reads these via STORAGE_PROFILE_FILE/API_KEYS_FILE = env:VAR indirection
-    # (see lakerunner cmd/initialize/loader.go). They are injected as env vars
-    # by ECS Secrets resolution against the SSM parameter ARN -- which is why
-    # the execution role needs ssm:GetParameter* on /cardinal/* (already
-    # documented in docs/operations/permissions-lakerunner.md). The migrator's
-    # initializeIfNeededFunc seeds configdb only when the tables are empty, so
-    # operator edits via the maestro UI are not clobbered on image bumps.
-    t.add_parameter(
-        Parameter(
-            "StorageProfilesParamName",
-            Type="String",
-            Description="Name of the SSM parameter holding the storage_profiles YAML.",
-        )
-    )
-    t.add_parameter(
-        Parameter(
-            "ApiKeysParamName",
-            Type="String",
-            Description="Name of the SSM parameter holding the api_keys YAML.",
-        )
-    )
-
-    # Inputs for the ensure-storage-profile sidecar. The canonical
-    # single-install org id and the ingest bucket name are exactly the values
-    # the SSM-driven seed would have written, so the sidecar's row is
-    # indistinguishable from a clean first-install seed.
-    t.add_parameter(
-        Parameter(
-            "OrgId",
-            Type="String",
-            AllowedPattern=(
-                r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
-                r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-            ),
-            Description=(
-                "Organization UUID for this install (operator-chosen, no default). "
-                "Must match the infrastructure stack's storage-profiles/api-keys seed."
-            ),
-        )
-    )
-    t.add_parameter(
-        Parameter(
-            "IngestBucketName",
-            Type="String",
-            Description="Name of the S3 ingest bucket (infra-setup output).",
-        )
-    )
 
     # Image parameters. The migrator runs from the same image as the lakerunner
     # service tasks (LakerunnerImage), so the two cannot drift; an image change
@@ -213,123 +156,29 @@ def build() -> Template:
             Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
             Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
             Environment(Name="CONFIGDB_SSLMODE", Value="require"),
-            # The env: prefix tells the binary's initializeIfNeededFunc to
-            # read the YAML body from the named env var, which ECS Secrets
-            # populates from SSM below.
-            Environment(Name="STORAGE_PROFILE_FILE", Value="env:STORAGE_PROFILES_YAML"),
-            Environment(Name="API_KEYS_FILE", Value="env:API_KEYS_YAML"),
+            # No STORAGE_PROFILE_FILE / API_KEYS_FILE: org content is owned by
+            # Maestro (provisioned via /api/v1/provision), not seeded here. With
+            # empty configdb tables the binary's initializeIfNeededFunc is a
+            # no-op.
         ],
         Secrets=[
             Secret(Name="LRDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
             Secret(Name="LRDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
             Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
             Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
-            # ECS resolves these at task launch by calling SSM with the
-            # execution role and injects the parameter value as the env var.
-            Secret(
-                Name="STORAGE_PROFILES_YAML",
-                ValueFrom=Sub(
-                    "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${StorageProfilesParamName}"
-                ),
-            ),
-            Secret(
-                Name="API_KEYS_YAML",
-                ValueFrom=Sub(
-                    "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${ApiKeysParamName}"
-                ),
-            ),
         ],
         LogConfiguration=_logs("migrator"),
-    )
-
-    # ensure-storage-profile: idempotent upsert that guarantees the canonical
-    # org's storage_profile row exists in configdb. Schema verified against
-    # the live lakerunner repo migrations (1755582182, 1755706737, 1755713265,
-    # 1755727712, 1755747368, 1755747422, 1755753938, 1779112554). ON CONFLICT
-    # uses bucket_configurations.bucket_name UNIQUE and the
-    # organization_buckets (organization_id, bucket_id, instance_num,
-    # collector_name) UNIQUE constraint -- both present on every live install.
-    # The legacy organization_id UNIQUE on organization_buckets was dropped in
-    # 1755727712 (allow_multiple_buckets_per_org), so this never collides with
-    # operator-added second buckets for the same org. DO NOTHING preserves
-    # operator edits made via the maestro UI.
-    #
-    # SQL goes in via stdin (not -c) so psql performs \set + :'var' client-side
-    # quoting -- psql's -c mode does not interpret :'var', and shell-substituting
-    # values into the SQL string would lean on parameter pattern hygiene the
-    # migration child does not own. The heredoc is UNQUOTED so $VARS expand via
-    # the shell before psql sees them; \set then re-quotes them properly for
-    # SQL via :'name' substitution inside the INSERT statements.
-    ensure_sp_container = ContainerDefinition(
-        Name="ensure-storage-profile",
-        Image=Ref("DbInitImage"),
-        Essential=False,
-        DependsOn=[ContainerDependency(ContainerName="migrator", Condition="SUCCESS")],
-        EntryPoint=["sh", "-c"],
-        Command=[
-            "set -e\n"
-            "export PGSSLMODE=require PGPASSWORD=\"$CONFIGDB_PASSWORD\"\n"
-            "psql -v ON_ERROR_STOP=1 -e \\\n"
-            "  -h \"$CONFIGDB_HOST\" -p \"$CONFIGDB_PORT\" \\\n"
-            "  -U \"$CONFIGDB_USER\" -d \"$CONFIGDB_DBNAME\" <<SQL\n"
-            "\\set bucket '$BUCKET_NAME'\n"
-            "\\set region '$AWS_REGION_NAME'\n"
-            "\\set org    '$ORG_ID'\n"
-            "\\echo === ensure-storage-profile inputs ===\n"
-            "\\echo  bucket = :'bucket'\n"
-            "\\echo  region = :'region'\n"
-            "\\echo  org    = :'org'\n"
-            "\\echo === state BEFORE upsert ===\n"
-            "SELECT id, bucket_name, cloud_provider, region FROM bucket_configurations\n"
-            "  WHERE bucket_name = :'bucket';\n"
-            "SELECT id, organization_id, bucket_id, instance_num, collector_name\n"
-            "  FROM organization_buckets;\n"
-            "\\echo === upsert bucket_configurations ===\n"
-            "INSERT INTO bucket_configurations\n"
-            "  (bucket_name, cloud_provider, region, use_path_style)\n"
-            "VALUES (:'bucket', 'aws', :'region', TRUE)\n"
-            "ON CONFLICT (bucket_name) DO NOTHING\n"
-            "RETURNING id, bucket_name;\n"
-            "\\echo === upsert organization_buckets ===\n"
-            "INSERT INTO organization_buckets\n"
-            "  (organization_id, bucket_id, instance_num, collector_name)\n"
-            "SELECT (:'org')::uuid, id, 1, 'lakerunner'\n"
-            "FROM bucket_configurations WHERE bucket_name = :'bucket'\n"
-            "ON CONFLICT (organization_id, bucket_id, instance_num, collector_name)\n"
-            "DO NOTHING\n"
-            "RETURNING id, organization_id, bucket_id, instance_num, collector_name;\n"
-            "\\echo === state AFTER upsert ===\n"
-            "SELECT id, bucket_name, cloud_provider, region FROM bucket_configurations\n"
-            "  WHERE bucket_name = :'bucket';\n"
-            "SELECT id, organization_id, bucket_id, instance_num, collector_name\n"
-            "  FROM organization_buckets;\n"
-            "\\echo === done ===\n"
-            "SQL\n"
-        ],
-        Environment=[
-            Environment(Name="CONFIGDB_HOST", Value=Ref("DbEndpoint")),
-            Environment(Name="CONFIGDB_PORT", Value=Ref("DbPort")),
-            Environment(Name="CONFIGDB_DBNAME", Value="configdb"),
-            Environment(Name="BUCKET_NAME", Value=Ref("IngestBucketName")),
-            Environment(Name="AWS_REGION_NAME", Value=Ref("AWS::Region")),
-            Environment(Name="ORG_ID", Value=Ref("OrgId")),
-        ],
-        Secrets=[
-            Secret(Name="CONFIGDB_USER", ValueFrom=Sub("${DbSecretArn}:username::")),
-            Secret(Name="CONFIGDB_PASSWORD", ValueFrom=Sub("${DbSecretArn}:password::")),
-        ],
-        LogConfiguration=_logs("ensure-storage-profile"),
     )
 
     keepalive_container = ContainerDefinition(
         Name="keepalive",
         Image=Ref("DbInitImage"),
         # The single essential container. ECS will not start it until the
-        # canonical-profile upsert has exited 0, so the task -- and thus the
-        # service, and thus this nested stack -- only reaches a stable RUNNING
-        # state after both the migrator and the upsert succeed.
+        # migrator has exited 0, so the task -- and thus the service, and thus
+        # this nested stack -- only reaches a stable RUNNING state after
+        # migrations succeed.
         Essential=True,
-        DependsOn=[ContainerDependency(ContainerName="ensure-storage-profile", Condition="SUCCESS")],
+        DependsOn=[ContainerDependency(ContainerName="migrator", Condition="SUCCESS")],
         EntryPoint=["sh", "-c"],
         Command=["echo 'migrations complete; idling'; exec sleep 2147483647"],
         LogConfiguration=_logs("keepalive"),
@@ -352,7 +201,6 @@ def build() -> Template:
             ContainerDefinitions=[
                 configdb_init_container,
                 migrator_container,
-                ensure_sp_container,
                 keepalive_container,
             ],
             Tags=cardinal_tags(component="migration", role="migrator-task"),

--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -14,7 +14,12 @@ Resources created:
 - 1 shared ECS task execution role + 5 per-tier task roles.
 - 1 cooked bucket (durable; cooked-only output; Retain).
 - license + admin-key secrets (Retain, named cardinal-*).
-- storage-profiles + api-keys SSM params (operator-managed).
+
+No org-content SSM params: Lakerunner installs admin-key-only (the admin-api
+binary seeds its first key from the cardinal-admin-key secret via
+ADMIN_INITIAL_API_KEY), and Maestro is the sole owner of the org, its storage
+line, and its ingest key -- provisioned at runtime through Lakerunner's
+/api/v1/provision admin API.
 
 Because base deploys before rds/services, its roles CANNOT reference
 RDS/service ARNs. Instead they scope by NAME PATTERN:
@@ -22,15 +27,13 @@ RDS/service ARNs. Instead they scope by NAME PATTERN:
 - secrets -> arn:...:secret:cardinal-* (requires the rds master secret to
   be named cardinal-db-master and base's secrets cardinal-license /
   cardinal-admin-key).
-- SSM -> /cardinal/* (already name-pattern in security.py).
 - S3 -> the cooked bucket this stack creates (by name).
 - process tier -> sts:AssumeRole on cardinal-satellite-access* (the poller
   assumes each satellite's access role, which carries the real S3/SQS perms;
   there is no local ingest queue here).
 
-Outputs all SG IDs, role ARNs, the cooked bucket name, the license/admin
-secret ARNs, and the two SSM param names so rds + services (wired by the
-deploy driver) can consume them.
+Outputs all SG IDs, role ARNs, the cooked bucket name, and the license/admin
+secret ARNs so rds + services (wired by the deploy driver) can consume them.
 """
 
 from __future__ import annotations
@@ -57,7 +60,6 @@ from troposphere.s3 import (
     ServerSideEncryptionRule,
 )
 from troposphere.secretsmanager import GenerateSecretString, Secret
-from troposphere.ssm import Parameter as SSMParameter
 
 from cardinal_cfn.parameters import add_no_echo_parameter, add_parameter_group_metadata
 
@@ -108,8 +110,9 @@ def build() -> Template:
     t.set_description(
         "Cardinal lakerunner infra base: ALB SG, six per-tier task SGs with "
         "inter-tier ingress, one shared ECS execution role, six per-tier task "
-        "roles (name-pattern scoped), the durable cooked bucket, license/"
-        "admin-key secrets, and the operator-managed SSM config params. "
+        "roles (name-pattern scoped), the durable cooked bucket, and the "
+        "license/admin-key secrets. Lakerunner installs admin-key-only; Maestro "
+        "owns org content via /api/v1/provision. "
         "Deploy first (base -> rds -> services); owns no RDS, no ingest queue."
     )
 
@@ -203,57 +206,12 @@ def build() -> Template:
         ),
         MinLength=1,
     ))
-    storage_profiles_param_name = t.add_parameter(Parameter(
-        "StorageProfilesParamName",
-        Type="String",
-        Default="/cardinal/storage-profiles",
-        Description=(
-            "SSM parameter name for the operator-managed storage-profiles "
-            "YAML. Must match the /cardinal/* pattern the task roles grant."
-        ),
-        AllowedPattern=r"^/[A-Za-z0-9._/-]{1,1011}$",
-    ))
-    api_keys_param_name = t.add_parameter(Parameter(
-        "ApiKeysParamName",
-        Type="String",
-        Default="/cardinal/api-keys",
-        Description=(
-            "SSM parameter name for the operator-managed external API keys "
-            "YAML. Must match the /cardinal/* pattern the task roles grant."
-        ),
-        AllowedPattern=r"^/[A-Za-z0-9._/-]{1,1011}$",
-    ))
-    organization_id = t.add_parameter(Parameter(
-        "OrganizationId",
-        Type="String",
-        AllowedPattern=(
-            r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
-            r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-        ),
-        Description=(
-            "Organization UUID for this install (operator-chosen, no default). "
-            "Must match the OrganizationId used on lakerunner-services and on "
-            "every satellite attributed to it. Used in both the "
-            "storage-profiles and api-keys SSM seeds."
-        ),
-    ))
     license_data = add_no_echo_parameter(
         t,
         "LicenseData",
         description=(
             "Cardinal license token (z64:...). Stored verbatim as the string "
             "body of the license secret."
-        ),
-    )
-    # api-keys is plaintext YAML by design (SSM cannot be SecureString in
-    # CloudFormation); NoEcho only keeps it out of the console echo.
-    initial_ingest_api_key = add_no_echo_parameter(
-        t,
-        "InitialIngestApiKey",
-        default="",
-        description=(
-            "Ingest API key seeded into the api-keys SSM parameter for "
-            "OrganizationId. Leave blank to seed an empty list (no key)."
         ),
     )
 
@@ -286,16 +244,10 @@ def build() -> Template:
                 "parameters": ["LicenseData"],
             },
             {
-                "label": "Organization",
-                "parameters": ["OrganizationId", "InitialIngestApiKey"],
-            },
-            {
                 "label": "Names (advanced)",
                 "parameters": [
                     "LicenseSecretName",
                     "AdminKeySecretName",
-                    "StorageProfilesParamName",
-                    "ApiKeysParamName",
                 ],
             },
         ],
@@ -303,8 +255,6 @@ def build() -> Template:
             "VpcId": "VPC for the security groups",
             "CookedBucketName": "Cooked bucket name (blank = default)",
             "LicenseData": "License token (z64:...)",
-            "OrganizationId": "Organization UUID",
-            "InitialIngestApiKey": "Initial ingest API key (blank = none)",
         },
     )
 
@@ -318,10 +268,6 @@ def build() -> Template:
     t.add_condition(
         "AddCookedBucketPublicAccessBlock",
         Equals(Ref("ConfigureBucketPublicAccessBlock"), "true"),
-    )
-    t.add_condition(
-        "HasInitialIngestApiKey",
-        Not(Equals(Ref(initial_ingest_api_key), "")),
     )
 
     cooked_bucket_name_value = If(
@@ -565,18 +511,6 @@ def build() -> Template:
                             # and base's secrets cardinal-license/cardinal-admin-key.
                             "Resource": _cardinal_secret_arn_pattern(),
                         },
-                        {
-                            "Sid": "ResolveCardinalSsm",
-                            "Effect": "Allow",
-                            "Action": [
-                                "ssm:GetParameter",
-                                "ssm:GetParameters",
-                            ],
-                            "Resource": Sub(
-                                "arn:${AWS::Partition}:ssm:${AWS::Region}:"
-                                "${AWS::AccountId}:parameter/cardinal/*"
-                            ),
-                        },
                     ],
                 },
             ),
@@ -597,10 +531,6 @@ def build() -> Template:
                     "Version": "2012-10-17",
                     "Statement": [
                         _stmt_secrets_read(),
-                        _stmt_ssm_read([
-                            "StorageProfilesParamName",
-                            "ApiKeysParamName",
-                        ]),
                         _stmt_cw_logs(),
                     ],
                 },
@@ -619,10 +549,6 @@ def build() -> Template:
                     "Version": "2012-10-17",
                     "Statement": [
                         _stmt_secrets_read(),
-                        _stmt_ssm_read([
-                            "StorageProfilesParamName",
-                            "ApiKeysParamName",
-                        ]),
                         _stmt_s3_read(cooked_bucket_name_value),
                         _stmt_cw_logs(),
                         {
@@ -655,10 +581,6 @@ def build() -> Template:
                     "Version": "2012-10-17",
                     "Statement": [
                         _stmt_secrets_read(),
-                        _stmt_ssm_read([
-                            "StorageProfilesParamName",
-                            "ApiKeysParamName",
-                        ]),
                         _stmt_s3_readwrite(cooked_bucket_name_value),
                         # NAME-PATTERN DECOUPLING (diverges from security.py's
                         # local _stmt_sqs_consume on a threaded QueueArn): this
@@ -704,10 +626,6 @@ def build() -> Template:
                     "Version": "2012-10-17",
                     "Statement": [
                         _stmt_secrets_read(),
-                        _stmt_ssm_read([
-                            "StorageProfilesParamName",
-                            "ApiKeysParamName",
-                        ]),
                         {
                             "Sid": "SweeperS3Cleanup",
                             "Effect": "Allow",
@@ -759,10 +677,6 @@ def build() -> Template:
                     "Version": "2012-10-17",
                     "Statement": [
                         _stmt_secrets_read(),
-                        _stmt_ssm_read([
-                            "StorageProfilesParamName",
-                            "ApiKeysParamName",
-                        ]),
                         _stmt_cw_logs(),
                     ],
                 },
@@ -845,71 +759,6 @@ def build() -> Template:
     )
 
     # ----------------------------------------------------------------------
-    # SSM parameters (operator-managed YAML). The migrator imports these into
-    # configdb and expects YAML *lists* — a top-level map fails to unmarshal.
-    # Seed storage-profiles with the cooked bucket + region; api-keys with the
-    # initial key or an empty list.
-    # ----------------------------------------------------------------------
-    storage_profiles_param = t.add_resource(
-        _retain(
-            SSMParameter(
-                "StorageProfilesParam",
-                Name=Ref(storage_profiles_param_name),
-                Type="String",
-                Value=Sub(
-                    "- organization_id: ${OrgId}\n"
-                    "  instance_num: 1\n"
-                    "  collector_name: lakerunner\n"
-                    "  cloud_provider: aws\n"
-                    "  region: ${AWS::Region}\n"
-                    "  bucket: ${BucketName}\n"
-                    "  insecure_tls: false\n"
-                    "  use_path_style: true\n",
-                    OrgId=Ref(organization_id),
-                    BucketName=cooked_bucket_name_value,
-                ),
-                Description="Cardinal storage profiles (YAML; operator-managed).",
-                Tags={
-                    "Application": APPLICATION,
-                    "Project": PROJECT,
-                    "ManagedBy": MANAGED_BY,
-                    "Component": "ssm-storage-profiles",
-                    "Name": "cardinal-ssm-storage-profiles",
-                },
-            )
-        )
-    )
-
-    api_keys_param = t.add_resource(
-        _retain(
-            SSMParameter(
-                "ApiKeysParam",
-                Name=Ref(api_keys_param_name),
-                Type="String",
-                Value=If(
-                    "HasInitialIngestApiKey",
-                    Sub(
-                        "- organization_id: ${OrgId}\n"
-                        "  keys:\n"
-                        "    - ${Key}\n",
-                        OrgId=Ref(organization_id),
-                        Key=Ref(initial_ingest_api_key),
-                    ),
-                    "[]",
-                ),
-                Description="Cardinal external API keys (YAML; operator-managed).",
-                Tags={
-                    "Application": APPLICATION,
-                    "Project": PROJECT,
-                    "ManagedBy": MANAGED_BY,
-                    "Component": "ssm-api-keys",
-                    "Name": "cardinal-ssm-api-keys",
-                },
-            )
-        )
-    )
-
-    # ----------------------------------------------------------------------
     # Outputs
     # ----------------------------------------------------------------------
     def _emit(name: str, description: str, value):
@@ -941,10 +790,6 @@ def build() -> Template:
           Ref(license_secret))
     _emit("AdminKeySecretArn", "ARN of the first-boot admin key secret.",
           Ref(admin_key_secret))
-    _emit("StorageProfilesParamName", "Name of the storage-profiles SSM parameter.",
-          Ref(storage_profiles_param))
-    _emit("ApiKeysParamName", "Name of the external API-keys SSM parameter.",
-          Ref(api_keys_param))
 
     return t
 
@@ -985,25 +830,6 @@ def _stmt_secrets_read() -> dict:
             "secretsmanager:DescribeSecret",
         ],
         "Resource": _cardinal_secret_arn_pattern(),
-    }
-
-
-def _stmt_ssm_read(param_names: list[str]) -> dict:
-    return {
-        "Sid": "ReadSsmParams",
-        "Effect": "Allow",
-        "Action": [
-            "ssm:GetParameter",
-            "ssm:GetParameters",
-        ],
-        "Resource": [
-            Sub(
-                "arn:${AWS::Partition}:ssm:${AWS::Region}:"
-                "${AWS::AccountId}:parameter${ParamName}",
-                ParamName=Ref(n),
-            )
-            for n in param_names
-        ],
     }
 
 

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -175,10 +175,6 @@ _INFRA_SETUP_PARAMS = [
      "ARN of the cardinal-license secret (infra output)."),
     ("AdminKeySecretArn", "String", None,
      "ARN of the cardinal-admin-key secret (infra output)."),
-    ("StorageProfilesParamName", "String", None,
-     "Name of the SSM parameter holding storage_profiles YAML (infra output)."),
-    ("ApiKeysParamName", "String", None,
-     "Name of the SSM parameter holding api_keys YAML (infra output)."),
     ("ClusterName", "String", None,
      "Name of the ECS cluster (customer-supplied)."),
     ("ClusterArn", "String", None,
@@ -375,9 +371,10 @@ def build() -> Template:
         ),
         Description=(
             "Organization UUID for this install (operator-chosen, no default). "
-            "Must match the value the infrastructure stack seeded into "
-            "storage-profiles / api-keys and every satellite's OrganizationId; "
-            "Maestro pre-populates this org and wires it to the local lakerunner."
+            "Must match every satellite's OrganizationId. Maestro pre-populates "
+            "this org and provisions it into the local lakerunner (org, storage "
+            "line, and ingest key) via the /api/v1/provision admin API; nothing "
+            "else seeds org content."
         ),
     ))
     t.add_parameter(Parameter(
@@ -587,10 +584,6 @@ def build() -> Template:
         "DbPort": Ref("DbPort"),
         "DbName": Ref("DbName"),
         "DbSecretArn": Ref("DbMasterSecretArn"),
-        "StorageProfilesParamName": Ref("StorageProfilesParamName"),
-        "ApiKeysParamName": Ref("ApiKeysParamName"),
-        "OrgId": Ref("OrganizationId"),
-        "IngestBucketName": Ref("CookedBucketName"),
         "LakerunnerImage": lakerunner_image,
         "DbInitImage": db_init_image,
     })

--- a/tests/templates/test_lakerunner_infra_base.py
+++ b/tests/templates/test_lakerunner_infra_base.py
@@ -28,24 +28,28 @@ def test_required_parameters(td):
         "CookedBucketName",
         "LicenseSecretName",
         "AdminKeySecretName",
-        "StorageProfilesParamName",
-        "ApiKeysParamName",
-        "OrganizationId",
         "LicenseData",
-        "InitialIngestApiKey",
     ):
         assert n in td["Parameters"], f"missing parameter: {n}"
 
 
-def test_organization_id_required_no_default(td):
-    """OrganizationId is operator-chosen: required (no default) and UUID-shaped,
-    so the bootstrap org is predictable and matches the satellites."""
-    p = td["Parameters"]["OrganizationId"]
-    assert "Default" not in p, "OrganizationId must have no default"
-    assert p["AllowedPattern"] == (
-        r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-"
-        r"[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
-    )
+def test_no_org_content_params_or_resources(td):
+    """infra-base seeds NO org content; Maestro owns it via /api/v1/provision.
+
+    Lakerunner installs admin-key-only (ADMIN_INITIAL_API_KEY, already wired on
+    admin-api); the org, its storage line, and its ingest key are provisioned by
+    Maestro, not seeded here.
+    """
+    params = td["Parameters"]
+    for gone in ("OrganizationId", "InitialIngestApiKey",
+                 "StorageProfilesParamName", "ApiKeysParamName"):
+        assert gone not in params, f"{gone} should be removed from infra-base"
+    resources = td["Resources"]
+    assert "StorageProfilesParam" not in resources
+    assert "ApiKeysParam" not in resources
+    outputs = td.get("Outputs", {})
+    assert "StorageProfilesParamName" not in outputs
+    assert "ApiKeysParamName" not in outputs
 
 
 def test_dropped_rds_param(td):
@@ -62,7 +66,6 @@ def test_no_threaded_arn_params(td):
 
 def test_license_data_is_no_echo(td):
     assert td["Parameters"]["LicenseData"].get("NoEcho") is True
-    assert td["Parameters"]["InitialIngestApiKey"].get("NoEcho") is True
 
 
 def test_cooked_bucket_default_name(td):
@@ -175,9 +178,16 @@ def test_exec_role_secrets_scoped_to_cardinal_pattern(td):
     assert res["Fn::Sub"].endswith(":secret:cardinal-*")
 
 
-def test_exec_role_ssm_scoped_to_cardinal(td):
-    s = next(s for s in _exec_statements(td) if s["Sid"] == "ResolveCardinalSsm")
-    assert s["Resource"]["Fn::Sub"].endswith("parameter/cardinal/*")
+def test_no_ssm_read_iam(td):
+    """No SSM parameters remain, so no role grants ssm:GetParameter*."""
+    assert not any(
+        s.get("Sid") == "ResolveCardinalSsm" for s in _exec_statements(td)
+    )
+    for role in ("MigrationRole", "QueryRole", "ProcessRole", "ControlRole",
+                 "MaestroRole"):
+        assert not any(
+            s.get("Sid") == "ReadSsmParams" for s in _role_statements(td, role)
+        ), f"{role} still grants ssm:GetParameter*"
 
 
 def test_all_task_roles_use_name_pattern_secrets(td):
@@ -301,17 +311,6 @@ def test_admin_key_secret_named_and_retained(td):
     assert td["Parameters"]["AdminKeySecretName"]["Default"] == "cardinal-admin-key"
 
 
-def test_ssm_params_seeded_and_retained(td):
-    sp = td["Resources"]["StorageProfilesParam"]
-    assert sp["DeletionPolicy"] == "Retain"
-    # storage-profiles seeded with the cooked bucket + region
-    assert "bucket: ${BucketName}" in sp["Properties"]["Value"]["Fn::Sub"][0]
-    ak = td["Resources"]["ApiKeysParam"]
-    assert ak["DeletionPolicy"] == "Retain"
-    # api-keys conditional on HasInitialIngestApiKey, else "[]"
-    assert ak["Properties"]["Value"]["Fn::If"][2] == "[]"
-
-
 # ---------------------------------------------------------------------------
 # Task 6: outputs
 # ---------------------------------------------------------------------------
@@ -334,7 +333,5 @@ def test_all_outputs_present(td):
         "CookedBucketName",
         "LicenseSecretArn",
         "AdminKeySecretArn",
-        "StorageProfilesParamName",
-        "ApiKeysParamName",
     ):
         assert o in td["Outputs"], f"missing output: {o}"

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -73,13 +73,14 @@ def test_data_plane_params(td):
         "DbMasterSecretArn",
         "LicenseSecretArn",
         "AdminKeySecretArn",
-        "StorageProfilesParamName",
-        "ApiKeysParamName",
     ):
         assert n in params, f"missing data-plane param: {n}"
     # Removed/renamed sources
     assert "IngestBucketName" not in params
     assert "RdsSecurityGroupId" not in params
+    # Org content is Maestro-owned: the SSM-seed param names are gone.
+    assert "StorageProfilesParamName" not in params
+    assert "ApiKeysParamName" not in params
     # QueueArn was never plumbed; QueueUrl/QueueRoleArn are the group-0 inputs.
     assert "QueueArn" not in params, "vestigial queue param present: QueueArn"
 
@@ -140,10 +141,17 @@ def test_children_present(td):
 def test_cooked_bucket_wired_to_children(td):
     """At least one child receives Ref CookedBucketName for its bucket param."""
     ref = {"Ref": "CookedBucketName"}
-    migration = td["Resources"]["Migration"]["Properties"]["Parameters"]
-    assert migration["IngestBucketName"] == ref
     query = td["Resources"]["Query"]["Properties"]["Parameters"]
     assert query["BucketName"] == ref
+
+
+def test_migration_child_gets_no_org_content_params(td):
+    """Org content is Maestro-owned: the Migration child no longer receives the
+    SSM-seed param names, the org id, or the ingest bucket."""
+    migration = td["Resources"]["Migration"]["Properties"]["Parameters"]
+    for gone in ("StorageProfilesParamName", "ApiKeysParamName",
+                 "OrgId", "IngestBucketName"):
+        assert gone not in migration, f"Migration child still gets {gone}"
 
 
 def test_self_telemetry_endpoint_param(td):

--- a/tests/templates/test_migration.py
+++ b/tests/templates/test_migration.py
@@ -39,30 +39,35 @@ def test_required_parameters(template_dict):
     for n in ("InstallIdShort", "InstallIdLong", "ClusterArn", "ClusterName",
               "TaskSecurityGroupId", "ExecutionRoleArn", "TaskRoleArn",
               "PrivateSubnetsCsv", "DbEndpoint", "DbSecretArn",
-              "LakerunnerImage", "DbInitImage",
-              "StorageProfilesParamName", "ApiKeysParamName",
-              "OrgId", "IngestBucketName"):
+              "LakerunnerImage", "DbInitImage"):
         assert n in template_dict["Parameters"], f"missing parameter: {n}"
 
 
-def test_migrator_seeds_configdb_from_ssm(template_dict):
-    """The migrator must read storage-profiles + api-keys YAML from the
-    SSM parameters so initializeIfNeededFunc seeds configdb on first install
-    (issue #109). YAML is injected as env vars via ECS Secrets resolution
-    against the SSM parameter ARN; STORAGE_PROFILE_FILE / API_KEYS_FILE use
-    the binary's `env:VAR` indirection."""
+def test_no_org_content_params(template_dict):
+    """Org content is Maestro-owned; the migration child takes no SSM-seed or
+    org/bucket params."""
+    params = template_dict["Parameters"]
+    for gone in ("StorageProfilesParamName", "ApiKeysParamName",
+                 "OrgId", "IngestBucketName"):
+        assert gone not in params, f"{gone} should be removed from migration child"
+
+
+def test_migrator_does_not_import_ssm(template_dict):
+    """The migrator seeds nothing from SSM; Maestro provisions org content via
+    /api/v1/provision. With empty configdb the binary's initializeIfNeededFunc
+    is a no-op."""
     migrator = _containers(template_dict)["migrator"]
     env = {e["Name"]: e["Value"] for e in migrator["Environment"]}
-    assert env.get("STORAGE_PROFILE_FILE") == "env:STORAGE_PROFILES_YAML"
-    assert env.get("API_KEYS_FILE") == "env:API_KEYS_YAML"
+    assert "STORAGE_PROFILE_FILE" not in env
+    assert "API_KEYS_FILE" not in env
+    secrets = {s["Name"] for s in migrator.get("Secrets", [])}
+    assert "STORAGE_PROFILES_YAML" not in secrets
+    assert "API_KEYS_YAML" not in secrets
 
-    secrets = {s["Name"]: s["ValueFrom"] for s in migrator["Secrets"]}
-    sp_arn = secrets.get("STORAGE_PROFILES_YAML")
-    ak_arn = secrets.get("API_KEYS_YAML")
-    assert sp_arn is not None and "StorageProfilesParamName" in str(sp_arn), \
-        f"STORAGE_PROFILES_YAML secret must reference StorageProfilesParamName: {sp_arn}"
-    assert ak_arn is not None and "ApiKeysParamName" in str(ak_arn), \
-        f"API_KEYS_YAML secret must reference ApiKeysParamName: {ak_arn}"
+
+def test_no_ensure_storage_profile_container(template_dict):
+    """The canonical-profile upsert sidecar is gone; Maestro owns the row."""
+    assert "ensure-storage-profile" not in _containers(template_dict)
 
 
 def test_migration_image_params_are_unified(template_dict):
@@ -99,9 +104,9 @@ def test_creates_task_definition(template_dict):
     assert "AWS::ECS::TaskDefinition" in _types(template_dict)
 
 
-def test_four_containers_present(template_dict):
+def test_three_containers_present(template_dict):
     assert set(_containers(template_dict)) == {
-        "configdb-init", "migrator", "ensure-storage-profile", "keepalive",
+        "configdb-init", "migrator", "keepalive",
     }
 
 
@@ -112,54 +117,17 @@ def test_exactly_one_essential_container(template_dict):
 
 
 def test_container_ordering_chain(template_dict):
-    """configdb-init -> migrator -> ensure-storage-profile -> keepalive. The
-    canonical-profile upsert sits on the keepalive critical path so any
-    failure surfaces as a stack rollback, not silent log noise."""
+    """configdb-init -> migrator -> keepalive. keepalive (the only essential
+    container) waits on migrator=SUCCESS, so the task -- and thus the nested
+    stack -- only stabilizes after migrations succeed."""
     cs = _containers(template_dict)
     assert "DependsOn" not in cs["configdb-init"]
     assert cs["migrator"]["DependsOn"] == [
         {"ContainerName": "configdb-init", "Condition": "COMPLETE"}
     ]
-    assert cs["ensure-storage-profile"]["DependsOn"] == [
+    assert cs["keepalive"]["DependsOn"] == [
         {"ContainerName": "migrator", "Condition": "SUCCESS"}
     ]
-    assert cs["keepalive"]["DependsOn"] == [
-        {"ContainerName": "ensure-storage-profile", "Condition": "SUCCESS"}
-    ]
-
-
-def test_ensure_storage_profile_is_non_essential(template_dict):
-    """It runs the upsert once and exits; keepalive's DependsOn=SUCCESS is
-    what gates task stability on a clean exit."""
-    assert _containers(template_dict)["ensure-storage-profile"].get("Essential") is False
-
-
-def test_ensure_storage_profile_upsert_is_idempotent(template_dict):
-    """SQL must use ON CONFLICT DO NOTHING on both inserts so re-runs after
-    operator edits never clobber existing rows."""
-    cmd = " ".join(_containers(template_dict)["ensure-storage-profile"]["Command"])
-    cmd_oneline = " ".join(cmd.split())  # collapse all whitespace
-    assert "ON CONFLICT (bucket_name) DO NOTHING" in cmd_oneline
-    assert (
-        "ON CONFLICT (organization_id, bucket_id, instance_num, collector_name) DO NOTHING"
-        in cmd_oneline
-    )
-    # collector_name must match the SSM-driven seed in cardinal_infrastructure
-    assert "'lakerunner'" in cmd_oneline
-
-
-def test_ensure_storage_profile_uses_configdb_credentials(template_dict):
-    """Sidecar reads CONFIGDB_* env + secrets and connects with sslmode=require."""
-    c = _containers(template_dict)["ensure-storage-profile"]
-    env = {e["Name"]: e["Value"] for e in c["Environment"]}
-    assert env["CONFIGDB_DBNAME"] == "configdb"
-    assert {"Ref": "DbEndpoint"} == env["CONFIGDB_HOST"]
-    assert {"Ref": "IngestBucketName"} == env["BUCKET_NAME"]
-    assert {"Ref": "OrgId"} == env["ORG_ID"]
-    secrets = {s["Name"] for s in c["Secrets"]}
-    assert {"CONFIGDB_USER", "CONFIGDB_PASSWORD"} <= secrets
-    cmd = " ".join(c["Command"])
-    assert "PGSSLMODE=require" in cmd
 
 
 def test_migrator_container_uses_lakerunner_image(template_dict):

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -158,17 +158,29 @@ def test_satellite_drivers_never_pull_central_stack():
         assert "LicenseSecretArn" not in text, f"{name} still references LicenseSecretArn"
 
 
-def test_central_drivers_require_organization_id():
-    """ORGANIZATION_ID is operator-chosen with no template default, so both
-    central drivers must require it and pass it through as OrganizationId."""
-    for name in ("deploy-lakerunner-infra-base.sh", "deploy-lakerunner-services.sh"):
-        text = (SCRIPTS_DIR / name).read_text()
-        assert 'missing="$missing ORGANIZATION_ID"' in text, (
-            f"{name} must require ORGANIZATION_ID"
-        )
-        assert "OrganizationId=$ORGANIZATION_ID" in text, (
-            f"{name} must pass OrganizationId=$ORGANIZATION_ID"
-        )
+def test_services_driver_requires_organization_id():
+    """ORGANIZATION_ID is operator-chosen with no template default. It now lives
+    ONLY on the services driver (which feeds Maestro's MAESTRO_BOOTSTRAP_ORG_ID);
+    infra-base no longer takes it -- Lakerunner installs admin-key-only and
+    Maestro owns org content via /api/v1/provision."""
+    text = (SCRIPTS_DIR / "deploy-lakerunner-services.sh").read_text()
+    assert 'missing="$missing ORGANIZATION_ID"' in text, (
+        "deploy-lakerunner-services.sh must require ORGANIZATION_ID"
+    )
+    assert "OrganizationId=$ORGANIZATION_ID" in text, (
+        "deploy-lakerunner-services.sh must pass OrganizationId=$ORGANIZATION_ID"
+    )
+
+
+def test_infra_base_driver_has_no_org_content_inputs():
+    """infra-base seeds no org content: no ORGANIZATION_ID requirement, no
+    InitialIngestApiKey, no storage-profiles/api-keys SSM param inputs."""
+    text = (SCRIPTS_DIR / "deploy-lakerunner-infra-base.sh").read_text()
+    assert 'missing="$missing ORGANIZATION_ID"' not in text
+    assert "OrganizationId=$ORGANIZATION_ID" not in text
+    assert "InitialIngestApiKey" not in text
+    assert "StorageProfilesParamName" not in text
+    assert "ApiKeysParamName" not in text
 
 
 def test_lakerunner_services_passes_queue_params():


### PR DESCRIPTION
## Summary

Lakerunner now installs in **"just the admin key exists"** mode. CloudFormation no longer seeds the organization, its storage line, or its ingest key into `configdb` — Maestro becomes the **sole owner** of org content, provisioning it at runtime through Lakerunner's `/api/v1/provision` admin API.

This removes the *second writer* problem: previously CFN seeded org content (SSM → migrator import, plus the `ensure-storage-profile` sidecar) **and** Maestro provisioned via the admin API. Now there is one source of truth.

Design + plan: `docs/superpowers/specs/2026-06-03-maestro-owns-org-provisioning-design.md`, `docs/superpowers/plans/2026-06-03-maestro-owns-org-provisioning.md`.

## What changed (mostly deletion)

- **`lakerunner-infra-base`**: removed `OrganizationId`, `InitialIngestApiKey`, the `StorageProfilesParam`/`ApiKeysParam` SSM resources + their `*ParamName` params/outputs, and all `ssm:GetParameter*` IAM (no SSM params remain).
- **`migration` child**: removed the migrator's `STORAGE_PROFILE_FILE`/`API_KEYS_FILE` SSM wiring and the `ensure-storage-profile` sidecar (+ its `OrgId`/`IngestBucketName` params). Task is now `configdb-init → migrator → keepalive`.
- **`lakerunner-services`**: stopped threading the `*ParamName` outputs and the `OrgId`/`IngestBucketName` params into the migration child. `OrganizationId` stays only here (feeds `MAESTRO_BOOTSTRAP_ORG_ID`).
- **`deploy-lakerunner-infra-base.sh`**: dropped `ORGANIZATION_ID` requirement + `INITIAL_INGEST_API_KEY`/`*_PARAM_NAME` inputs. The services driver still requires `ORGANIZATION_ID`.
- Admin-key auth unchanged — `services-control` already wires `ADMIN_INITIAL_API_KEY` from `cardinal-admin-key`.
- **No conductor changes**: Maestro's bootstrap + provisioning worker already perform this flow.

## Why it's safe

Verified against `../lakerunner`: storage profiles + API keys are read from `configdb` at runtime (never SSM); services boot healthy with empty config; `/api/v1/provision` writes the org + bucket + keys idempotently. Existing installs are untouched — the migrator only seeds empty tables, so this changes the *fresh-install* contract only.

## Operator note (also in CHANGELOG v0.0.124)

No upgrade action for existing installs. Operators who relied on a deterministic ingest key now create it in the Maestro UI rather than via `InitialIngestApiKey`.

## Tests

`make build` (cfn-lint clean) and `make test` — **480 passed, 1 skipped**. Template tests updated to assert the new admin-key-only contract.

## Post-merge verification (Task 6, runtime)

Confirm Maestro's provisioning worker calls `/api/v1/provision` shortly after boot without waiting on collector activity (periodic reconcile), so the central org's storage line exists for `otel-raw/` ingestion. If it only fires on activity, open a conductor follow-up to run the shared-install reconcile on a short startup timer.