### PR TITLE
satellite: drop raw-bucket PutObject grant; bump LakerunnerImage to v1.40.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,22 @@ v0.0.114.
     `INITIAL_INGEST_API_KEY` / `*_PARAM_NAME`. Operators who relied on a
     deterministic ingest key now create it in the Maestro UI rather than via
     `InitialIngestApiKey`.
+- **Traces route to the cooked bucket; satellite raw-bucket grant narrowed.**
+  Default `LakerunnerImage` bumped to `v1.40.4` (was `v1.40.0`): v1.40.4 fixes the
+  trace ingest worklane to honor the read/write storage-profile split, so cooked
+  traces redirect to the cooked bucket via `writes_to_instance_num` (like logs and
+  metrics) instead of being written back to the satellite source bucket. The
+  migrator shares this image, so the bump retriggers migrations on update.
+  Accordingly the `cardinal-satellite-access` role (in `satellite-infra-base`) no
+  longer grants `s3:PutObject` on the raw bucket — its statement Sid changes from
+  `RawBucketReadWriteDelete` to `RawBucketReadDelete` (`s3:DeleteObject` stays for
+  the poller's `delete_sources` cleanup). This also removes the prior risk of
+  cooked trace segments aging out under the raw bucket's lifecycle expiry.
+  - **Upgrade action:** redeploy `satellite-infra-base` (each satellite
+    account/region) and `lakerunner-services`. The narrowed grant requires
+    lakerunner **>= v1.40.4**; if you override `LakerunnerImage` below v1.40.4,
+    trace ingest fails with `AccessDenied` on `s3:PutObject` against the raw
+    bucket — stay on v1.40.4+.
 
 ## v0.0.123
 

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,7 +33,7 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.0"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"

--- a/src/cardinal_cfn/satellite_infra_base.py
+++ b/src/cardinal_cfn/satellite_infra_base.py
@@ -274,19 +274,23 @@ def build() -> Template:
                         "Version": "2012-10-17",
                         "Statement": [
                             {
-                                # PutObject is required because the lakerunner
-                                # trace ingest worklane does not yet split read
-                                # vs write storage profiles (logs/metrics do),
-                                # so it writes cooked trace segments back to
-                                # this source bucket rather than redirecting to
-                                # the cooked bucket via writes_to_instance_num.
-                                # Remove once trace_ingest_worklane.go mirrors
-                                # the logs/metric read/write split.
-                                "Sid": "RawBucketReadWriteDelete",
+                                # The lakerunner poller (assuming this role
+                                # cross-account) reads raw objects for ingest
+                                # and deletes processed sources (delete_sources
+                                # cleanup) -- it does not write here. No
+                                # s3:PutObject: as of lakerunner v1.40.4 the
+                                # trace ingest worklane honors the read/write
+                                # storage-profile split (like logs/metrics) and
+                                # writes cooked trace segments to the cooked
+                                # bucket via writes_to_instance_num, not back to
+                                # this source bucket. Requires LakerunnerImage
+                                # >= v1.40.4 (the default); pinning an older
+                                # image will fail trace ingest with AccessDenied
+                                # on PutObject.
+                                "Sid": "RawBucketReadDelete",
                                 "Effect": "Allow",
                                 "Action": [
                                     "s3:GetObject",
-                                    "s3:PutObject",
                                     "s3:DeleteObject",
                                     "s3:ListBucket",
                                     "s3:GetBucketLocation",

--- a/tests/templates/test_satellite_infra_base.py
+++ b/tests/templates/test_satellite_infra_base.py
@@ -127,22 +127,23 @@ def test_role_external_id_is_conditional(td):
     }
 
 
-def test_role_can_read_write_and_delete_raw(td):
-    # PutObject is present because the lakerunner trace ingest worklane writes
-    # cooked trace segments back to this source bucket (it does not yet split
-    # read vs write storage profiles the way logs/metrics do). See the role
-    # comment in satellite_infra_base.py.
+def test_role_can_read_and_delete_raw(td):
+    # No s3:PutObject: as of lakerunner v1.40.4 the trace ingest worklane
+    # honors the read/write storage-profile split (like logs/metrics) and
+    # writes cooked segments to the cooked bucket, not back to this source
+    # bucket. The poller still needs DeleteObject for delete_sources cleanup.
+    # See the role comment in satellite_infra_base.py.
     stmts = td["Resources"]["LakerunnerAccessRole"]["Properties"]["Policies"][
         0
     ]["PolicyDocument"]["Statement"]
-    s3 = next(s for s in stmts if s["Sid"] == "RawBucketReadWriteDelete")
+    s3 = next(s for s in stmts if s["Sid"] == "RawBucketReadDelete")
     assert set(s3["Action"]) == {
         "s3:GetObject",
-        "s3:PutObject",
         "s3:DeleteObject",
         "s3:ListBucket",
         "s3:GetBucketLocation",
     }
+    assert "s3:PutObject" not in s3["Action"]
 
 
 def test_role_can_consume_only_its_queue(td):


### PR DESCRIPTION
## Summary

lakerunner **v1.40.4** fixes the trace ingest worklane to honor the read/write storage-profile split (cardinalhq/lakerunner#846): cooked traces now redirect to the cooked bucket via `writes_to_instance_num` (like logs/metrics) instead of being written back to the satellite source/raw bucket.

With the binary fixed, the stack no longer needs the `s3:PutObject` workaround on the satellite raw bucket.

## Changes

- **`cardinal-defaults.yaml`**: default `LakerunnerImage` `v1.40.0` → `v1.40.4` (carries the fix; migrator shares the image).
- **`satellite_infra_base.py`**: `cardinal-satellite-access` role drops `s3:PutObject` on the raw bucket; Sid `RawBucketReadWriteDelete` → `RawBucketReadDelete`. `s3:DeleteObject` stays for the poller's `delete_sources` cleanup. Also removes the prior risk of cooked traces aging out under the raw bucket's 7-day lifecycle.
- **`test_satellite_infra_base.py`**: assertion updated to expect read+delete only and to assert `PutObject` absent.
- **`CHANGELOG.md`**: folded into the unreleased `v0.0.124` section.

## Compatibility

The narrowed grant requires lakerunner **>= v1.40.4** on the process tier. Overriding `LakerunnerImage` below v1.40.4 will fail trace ingest with `AccessDenied` on `s3:PutObject`. Documented in the CHANGELOG upgrade action.

## Verification

- `make build` — templates generated, cfn-lint clean.
- `make test` — 480 passed, 1 skipped.