### PR TITLE
satellite: air-gapped image mirroring via OTEL_IMAGE + image manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.125
+
+- **Air-gapped image mirroring for the satellite collector.** A generated
+  `satellite-images.txt` (in `generated-templates/`) lists the upstream
+  image(s) the `cardinal-satellite-services` stack runs, so they can be
+  mirrored and scanned. To deploy from a private mirror, set `OTEL_IMAGE` to
+  the full mirrored image URI when running `deploy-satellite-services.sh`; the
+  script passes it as the literal `OtelImage` parameter. Unset preserves the
+  template's public default. See `docs/air-gapped-images.md`. No upgrade action
+  unless mirroring; no resource replacement.
+
 ## v0.0.124
 
 - **Lakerunner now installs admin-key-only; Maestro is the sole owner of org

--- a/build.sh
+++ b/build.sh
@@ -33,6 +33,9 @@ python3 -m cardinal_cfn.satellite_infra_base > generated-templates/cardinal-sate
 echo "Generating cardinal-satellite-services.yaml..."
 python3 -m cardinal_cfn.satellite_services > generated-templates/cardinal-satellite-services.yaml
 
+echo "Generating satellite-images.txt..."
+python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
+
 echo "Generating cardinal-lakerunner-infra-rds.yaml..."
 python3 -m cardinal_cfn.lakerunner_infra_rds > generated-templates/cardinal-lakerunner-infra-rds.yaml
 

--- a/docs/air-gapped-images.md
+++ b/docs/air-gapped-images.md
@@ -1,0 +1,55 @@
+# Air-gapped image mirroring
+
+Air-gapped installs cannot pull container images from the public registries.
+This page lists the images each Cardinal stack runs and shows how to point the
+stack at a private mirror.
+
+> Scope: this covers the **satellite** stack (`cardinal-satellite-services`).
+> The central Lakerunner stack's images are covered in a later release.
+
+## Images the satellite stack runs
+
+The satellite collector runs a single container image. The canonical,
+machine-readable list is generated at build time:
+
+`generated-templates/satellite-images.txt`
+
+For the current release that is:
+
+- `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0` — the otel
+  collector that receives telemetry and writes to the satellite raw bucket.
+
+This file always lists the upstream public references — the images to pull,
+scan, and mirror *from* — regardless of which image you actually deploy.
+
+## Mirroring
+
+Pull the image listed in `satellite-images.txt`, scan it, and push it into
+your private registry. For example, with
+[skopeo](https://github.com/containers/skopeo) and a mirror prefix of
+`mirror.corp/cardinal`:
+
+```sh
+PREFIX=mirror.corp/cardinal
+while read -r img; do
+  name=${img##*/}                     # cardinalhq-otel-collector:v1.8.0
+  skopeo copy "docker://${img}" "docker://${PREFIX}/${name}"
+done < generated-templates/satellite-images.txt
+```
+
+## Pointing the stack at your mirror
+
+Image selection lives in the deploy script, not the CloudFormation template:
+the template takes a literal `OtelImage` parameter, and
+`deploy-satellite-services.sh` passes whatever you choose.
+
+Set `OTEL_IMAGE` to the full URI of your mirrored image when running the
+deploy script:
+
+```sh
+OTEL_IMAGE=mirror.corp/cardinal/cardinalhq-otel-collector:v1.8.0 \
+  STACK_NAME=... REGION=... VERSION=... \
+  ./scripts/deploy-satellite-services.sh
+```
+
+Leave `OTEL_IMAGE` unset to pull the template's public default.

--- a/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
+++ b/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
@@ -1,686 +1,82 @@
-# Air-gapped Image Registry Override (Phase 1: satellite) Implementation Plan
+# Air-gapped Image Override (Phase 1: satellite) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **Note:** This plan was simplified during execution. The original draft built
+> a three-way `ImageRegistry`/`Fn::If` resolver inside the template plus
+> troposphere helpers (`flatten_suffix`, `add_registry_image`). That was
+> discarded in favor of script-driven selection: the deploy script passes a
+> literal `OtelImage`, the template is unchanged. The tasks below reflect what
+> was actually built. See the spec for rationale.
 
-**Goal:** Give air-gapped customers a single `ImageRegistry` prefix knob on the `cardinal-satellite-services` stack (governing the otel collector image), plus a generated manifest listing the upstream image(s) to mirror and scan.
+**Goal:** Let air-gapped operators deploy the satellite collector from a private
+mirror by setting `OTEL_IMAGE` on the deploy script, and publish a generated
+manifest of the upstream image(s) to mirror and scan.
 
-**Architecture:** Add two reusable helpers to `src/cardinal_cfn/images.py` — a pure `flatten_suffix()` and a registry-aware `add_registry_image()` that declares an `ImageRegistry` prefix parameter, a per-image full-URI override parameter (default empty), the matching CloudFormation `Conditions`, and returns the resolved `Fn::If` expression with precedence override > prefix > public default. Migrate `satellite_services.py`'s single otel image to it. Add an `image_manifest` generator wired into `build.sh` emitting `generated-templates/satellite-images.txt`. Document and changelog the new parameter.
+**Architecture:** `deploy-satellite-services.sh` accepts an optional
+`OTEL_IMAGE` full-URI env var and forwards it as the literal `OtelImage`
+CloudFormation parameter; unset preserves the template's public default. A new
+`image_manifest` generator emits `generated-templates/satellite-images.txt`,
+wired into `build.sh`. The CloudFormation template and `images.py` are
+unchanged.
 
-**Tech Stack:** Python 3, troposphere, pytest, cloud-radar (existing test deps), cfn-lint. Tests run via `make test` / `pytest`. Generators emit YAML through `build.sh` (`make build`).
+**Tech Stack:** POSIX sh (deploy driver), Python 3 (manifest generator),
+pytest, shellcheck, cfn-lint.
 
 **Spec:** `docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md`
 
 ---
 
-## File Structure
-
-- `src/cardinal_cfn/images.py` (modify) — add `flatten_suffix()` and `add_registry_image()` next to the existing `add_image_override()` (which stays for non-migrated callers).
-- `src/cardinal_cfn/image_manifest.py` (create) — stack -> upstream-image-list generator; CLI entrypoint.
-- `src/cardinal_cfn/satellite_services.py` (modify) — use `add_registry_image()` for `OtelImage`; add `ImageRegistry` to the console parameter group.
-- `tests/unit/test_images.py` (modify) — unit tests for `flatten_suffix()` and `add_registry_image()`.
-- `tests/unit/test_image_manifest.py` (create) — unit tests for the manifest generator.
-- `tests/templates/test_satellite_services.py` (modify) — template-level precedence assertions.
-- `build.sh` (modify) — emit `satellite-images.txt`.
-- `docs/air-gapped-images.md` (create) — operator doc (Phase 1 scope).
-- `CHANGELOG.md` (modify) — new version entry.
-
----
-
-### Task 1: `flatten_suffix()` pure helper
+### Task 1: `OTEL_IMAGE` passthrough in the deploy script — DONE
 
 **Files:**
-- Modify: `src/cardinal_cfn/images.py`
-- Test: `tests/unit/test_images.py`
-
-- [ ] **Step 1: Write the failing test**
-
-Append to `tests/unit/test_images.py`:
-
-```python
-from cardinal_cfn.images import flatten_suffix
-
-
-def test_flatten_suffix_tag():
-    assert (
-        flatten_suffix("public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0")
-        == "cardinalhq-otel-collector:v1.8.0"
-    )
-
-
-def test_flatten_suffix_ghcr_and_busybox():
-    assert flatten_suffix("ghcr.io/cardinalhq/initcontainer-grafana:latest") == "initcontainer-grafana:latest"
-    assert flatten_suffix("public.ecr.aws/docker/library/busybox:1.37") == "busybox:1.37"
-
-
-def test_flatten_suffix_digest():
-    assert (
-        flatten_suffix("public.ecr.aws/cardinalhq.io/lakerunner@sha256:abc123")
-        == "lakerunner@sha256:abc123"
-    )
-
-
-def test_flatten_suffix_no_registry():
-    assert flatten_suffix("busybox:1.37") == "busybox:1.37"
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `make install >/dev/null 2>&1; source .venv/bin/activate && pytest tests/unit/test_images.py -k flatten_suffix -v`
-Expected: FAIL with `ImportError: cannot import name 'flatten_suffix'`.
-
-- [ ] **Step 3: Write minimal implementation**
-
-In `src/cardinal_cfn/images.py`, after the existing `add_image_override` function, add:
-
-```python
-def flatten_suffix(image_ref: str) -> str:
-    """Return the repo basename + tag/digest from a full image reference.
-
-    Everything after the final '/'. Correct for ':tag', '@sha256:' digest,
-    and refs with no registry component.
-
-        public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0
-            -> cardinalhq-otel-collector:v1.8.0
-    """
-    return image_ref.rsplit("/", 1)[-1]
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `source .venv/bin/activate && pytest tests/unit/test_images.py -k flatten_suffix -v`
-Expected: PASS (4 tests).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/cardinal_cfn/images.py tests/unit/test_images.py
-git commit -m "feat(images): add flatten_suffix helper for registry-prefix derivation"
-```
-
----
-
-### Task 2: `add_registry_image()` helper
-
-**Files:**
-- Modify: `src/cardinal_cfn/images.py`
-- Test: `tests/unit/test_images.py`
-
-- [ ] **Step 1: Write the failing test**
-
-Append to `tests/unit/test_images.py`:
-
-```python
-from cardinal_cfn.images import add_registry_image
-
-
-def test_add_registry_image_declares_params_and_conditions():
-    t = Template()
-    add_registry_image(
-        t,
-        name="OtelImage",
-        default="public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0",
-        description="otel override",
-    )
-    rendered = _to_dict(t)
-    # Per-image override param defaults to empty (empty == "resolve me").
-    assert rendered["Parameters"]["OtelImage"]["Default"] == ""
-    # Shared registry prefix param is declared once, default empty.
-    assert rendered["Parameters"]["ImageRegistry"]["Default"] == ""
-    # Both gating conditions exist.
-    assert "OtelImageProvided" in rendered["Conditions"]
-    assert "ImageRegistryProvided" in rendered["Conditions"]
-
-
-def test_add_registry_image_returns_three_way_if():
-    t = Template()
-    ref = add_registry_image(
-        t,
-        name="OtelImage",
-        default="public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0",
-        description="otel override",
-    )
-    assert ref.to_dict() == {
-        "Fn::If": [
-            "OtelImageProvided",
-            {"Ref": "OtelImage"},
-            {
-                "Fn::If": [
-                    "ImageRegistryProvided",
-                    {"Fn::Sub": "${ImageRegistry}/cardinalhq-otel-collector:v1.8.0"},
-                    "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0",
-                ]
-            },
-        ]
-    }
-
-
-def test_add_registry_image_shares_one_registry_param():
-    """Calling twice on the same template declares ImageRegistry only once."""
-    t = Template()
-    add_registry_image(t, name="OtelImage", default="r/a:1", description="a")
-    add_registry_image(t, name="MaestroImage", default="r/b:2", description="b")
-    rendered = _to_dict(t)
-    assert "ImageRegistry" in rendered["Parameters"]
-    assert "OtelImageProvided" in rendered["Conditions"]
-    assert "MaestroImageProvided" in rendered["Conditions"]
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `source .venv/bin/activate && pytest tests/unit/test_images.py -k add_registry_image -v`
-Expected: FAIL with `ImportError: cannot import name 'add_registry_image'`.
-
-- [ ] **Step 3: Write minimal implementation**
-
-In `src/cardinal_cfn/images.py`, change the import line at the top from:
-
-```python
-from troposphere import Parameter, Ref, Template
-```
-
-to:
-
-```python
-from troposphere import Equals, If, Not, Parameter, Ref, Sub, Template
-```
-
-Then, after `flatten_suffix`, add:
-
-```python
-def add_registry_image(
-    t: Template,
-    *,
-    name: str,
-    default: str,
-    description: str,
-    registry_param: str = "ImageRegistry",
-):
-    """Declare a registry-aware image parameter; return the resolved image.
-
-    Precedence, highest first:
-      1. ``<name>`` (full-URI override) when non-empty.
-      2. ``${<registry_param>}/<basename>:<tag>`` when ``<registry_param>`` is
-         non-empty (air-gapped mirror; the registry/namespace is flattened to a
-         single prefix).
-      3. ``default`` (the public upstream reference).
-
-    The per-image parameter defaults to "" so the precedence is expressible in
-    CloudFormation: an empty value means "resolve me from the prefix or the
-    default". The shared ``registry_param`` and its condition are declared once
-    per template (safe to call for multiple images).
-    """
-    if registry_param not in t.parameters:
-        t.add_parameter(
-            Parameter(
-                registry_param,
-                Type="String",
-                Default="",
-                Description=(
-                    "Registry/namespace prefix for first-party Cardinal images "
-                    "(air-gapped mirror). Leave empty to pull from the public "
-                    "default. When set, images resolve to <prefix>/<image>:<tag>."
-                ),
-            )
-        )
-    registry_cond = registry_param + "Provided"
-    if registry_cond not in t.conditions:
-        t.add_condition(registry_cond, Not(Equals(Ref(registry_param), "")))
-
-    t.add_parameter(
-        Parameter(name, Type="String", Default="", Description=description)
-    )
-    override_cond = name + "Provided"
-    t.add_condition(override_cond, Not(Equals(Ref(name), "")))
-
-    suffix = flatten_suffix(default)
-    return If(
-        override_cond,
-        Ref(name),
-        If(
-            registry_cond,
-            Sub("${" + registry_param + "}/" + suffix),
-            default,
-        ),
-    )
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `source .venv/bin/activate && pytest tests/unit/test_images.py -v`
-Expected: PASS (all `flatten_suffix`, `add_registry_image`, and pre-existing `add_image_override` tests).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/cardinal_cfn/images.py tests/unit/test_images.py
-git commit -m "feat(images): add registry-aware add_registry_image helper"
-```
-
----
-
-### Task 3: Migrate satellite otel image to `add_registry_image()`
-
-**Files:**
-- Modify: `src/cardinal_cfn/satellite_services.py` (import ~line 74; image_ref ~line 242; param group ~line 291)
-- Test: `tests/templates/test_satellite_services.py`
-
-- [ ] **Step 1: Write the failing test**
-
-Append to `tests/templates/test_satellite_services.py` (the file already imports `json` and defines the `td` fixture):
-
-```python
-from cardinal_cfn.defaults import load_defaults
-
-
-def _otel_image(td):
-    return td["Resources"]["OtelGrpcTaskDef"]["Properties"]["ContainerDefinitions"][0]["Image"]
-
-
-def test_image_registry_parameters_default_empty(td):
-    assert td["Parameters"]["ImageRegistry"]["Default"] == ""
-    assert td["Parameters"]["OtelImage"]["Default"] == ""
-
-
-def test_image_resolution_conditions_present(td):
-    assert "ImageRegistryProvided" in td["Conditions"]
-    assert "OtelImageProvided" in td["Conditions"]
-
-
-def test_otel_image_three_way_precedence(td):
-    otel = load_defaults()["images"]["otel"]
-    suffix = otel.rsplit("/", 1)[-1]
-    assert _otel_image(td) == {
-        "Fn::If": [
-            "OtelImageProvided",
-            {"Ref": "OtelImage"},
-            {
-                "Fn::If": [
-                    "ImageRegistryProvided",
-                    {"Fn::Sub": "${ImageRegistry}/" + suffix},
-                    otel,
-                ]
-            },
-        ]
-    }
-
-
-def test_image_registry_in_parameter_group(td):
-    groups = td["Metadata"]["AWS::CloudFormation::Interface"]["ParameterGroups"]
-    image_group = next(g for g in groups if g["Label"]["default"] == "Image overrides")
-    assert "ImageRegistry" in image_group["Parameters"]
-    assert "OtelImage" in image_group["Parameters"]
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `source .venv/bin/activate && pytest tests/templates/test_satellite_services.py -k "image_registry or three_way or resolution_conditions" -v`
-Expected: FAIL — `ImageRegistry` not in Parameters / Image is `{"Ref": "OtelImage"}` not the `Fn::If`.
-
-- [ ] **Step 3: Write minimal implementation**
-
-In `src/cardinal_cfn/satellite_services.py`:
-
-Change the import (around line 74) from:
-
-```python
-from cardinal_cfn.images import add_image_override
-```
-
-to:
-
-```python
-from cardinal_cfn.images import add_registry_image
-```
-
-Replace the `image_ref = add_image_override(...)` block (around lines 241-247) with:
-
-```python
-    # Image override (registry-aware: ImageRegistry prefix > OtelImage > default)
-    image_ref = add_registry_image(
-        t,
-        name="OtelImage",
-        default=defaults["images"]["otel"],
-        description=(
-            "Full image URI override for the otel collector. Wins over "
-            "ImageRegistry. Leave empty to use ImageRegistry or the public "
-            "default."
-        ),
-    )
-```
-
-In the parameter-group metadata (around line 290-292), change:
-
-```python
-            {
-                "label": "Image overrides",
-                "parameters": ["OtelImage"],
-            },
-```
-
-to:
-
-```python
-            {
-                "label": "Image overrides",
-                "parameters": ["ImageRegistry", "OtelImage"],
-            },
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `source .venv/bin/activate && pytest tests/templates/test_satellite_services.py -v`
-Expected: PASS (new tests + all pre-existing satellite tests).
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add src/cardinal_cfn/satellite_services.py tests/templates/test_satellite_services.py
-git commit -m "feat(satellite): add ImageRegistry prefix override for the otel image"
-```
-
----
-
-### Task 4: Image manifest generator
+- `scripts-src/parts/deploy-satellite-services.sh` (front-half source)
+- `scripts/deploy-satellite-services.sh` (regenerated via `make scripts`)
+
+- [x] Document `OTEL_IMAGE` in `usage()` (Optional inputs), pointing at
+  `satellite-images.txt` / `docs/air-gapped-images.md`.
+- [x] Add `OTEL_IMAGE` to the input-echo diagnostic loop.
+- [x] Append `OtelImage=$OTEL_IMAGE` to `params` when `OTEL_IMAGE` is set
+  (mirrors the existing `ALB_SCHEME` / `INGEST_SOURCE_CIDR` conditional lines);
+  omit when unset so the engine falls back to the template `Default`.
+- [x] Regenerate with `make scripts`; `test_deploy_stack_lint.py` (drift +
+  shellcheck) stays green.
+- [x] Verify behaviorally: front-half with engine stubbed emits
+  `OtelImage=<uri>` when `OTEL_IMAGE` is set and omits it otherwise.
+
+### Task 2: Image manifest generator — DONE
 
 **Files:**
 - Create: `src/cardinal_cfn/image_manifest.py`
 - Test: `tests/unit/test_image_manifest.py`
 
-- [ ] **Step 1: Write the failing test**
+- [x] `manifest_lines(stack)` reads `cardinal-defaults.yaml` `images:` via
+  `load_defaults()`, returns sorted/deduped full refs for the stack's keys;
+  `STACK_IMAGE_KEYS = {"satellite": ["otel"]}`; unknown stack raises
+  `ValueError`. CLI `python3 -m cardinal_cfn.image_manifest <stack>`.
+- [x] Tests: satellite manifest equals `[images.otel]`; unknown stack raises.
 
-Create `tests/unit/test_image_manifest.py`:
+### Task 3: Wire the manifest into `build.sh` — DONE
 
-```python
-"""Tests for the image manifest generator."""
+- [x] After generating `cardinal-satellite-services.yaml`, emit
+  `generated-templates/satellite-images.txt` via the manifest CLI.
+- [x] `make build` emits the file; cfn-lint clean.
 
-import pytest
+### Task 4: Docs + changelog — DONE
 
-from cardinal_cfn import image_manifest
-from cardinal_cfn.defaults import load_defaults
+- [x] `docs/air-gapped-images.md`: satellite image list, skopeo mirror loop,
+  `OTEL_IMAGE` usage.
+- [x] `CHANGELOG.md` `v0.0.125` entry: manifest + `OTEL_IMAGE` input; unset =
+  public default; no resource replacement.
 
+### Task 5: Full verification — DONE
 
-def test_satellite_manifest_is_otel_image():
-    assert image_manifest.manifest_lines("satellite") == [
-        load_defaults()["images"]["otel"]
-    ]
-
-
-def test_unknown_stack_raises():
-    with pytest.raises(ValueError):
-        image_manifest.manifest_lines("nope")
-```
-
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `source .venv/bin/activate && pytest tests/unit/test_image_manifest.py -v`
-Expected: FAIL with `ModuleNotFoundError: No module named 'cardinal_cfn.image_manifest'`.
-
-- [ ] **Step 3: Write minimal implementation**
-
-Create `src/cardinal_cfn/image_manifest.py`:
-
-```python
-"""Image manifest generator.
-
-Emits the upstream public container images a given stack runs, one per line,
-sorted and deduped. This is the source list air-gapped customers mirror and
-scan FROM; it always reflects the public defaults in cardinal-defaults.yaml,
-never a customer's ImageRegistry override.
-"""
-
-import sys
-
-from cardinal_cfn.defaults import load_defaults
-
-# Which cardinal-defaults.yaml images.* keys each stack runs.
-# Phase 1: satellite only. Phase 2 adds the lakerunner stack's keys.
-STACK_IMAGE_KEYS = {
-    "satellite": ["otel"],
-}
-
-
-def manifest_lines(stack: str) -> list:
-    """Return the sorted, deduped upstream image refs for a stack."""
-    if stack not in STACK_IMAGE_KEYS:
-        known = ", ".join(sorted(STACK_IMAGE_KEYS))
-        raise ValueError(f"unknown stack: {stack!r} (known: {known})")
-    images = load_defaults()["images"]
-    refs = {images[key] for key in STACK_IMAGE_KEYS[stack]}
-    return sorted(refs)
-
-
-def main(argv: list) -> int:
-    if len(argv) != 1:
-        print(
-            "usage: python3 -m cardinal_cfn.image_manifest <stack>",
-            file=sys.stderr,
-        )
-        return 2
-    for line in manifest_lines(argv[0]):
-        print(line)
-    return 0
-
-
-if __name__ == "__main__":
-    raise SystemExit(main(sys.argv[1:]))
-```
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `source .venv/bin/activate && pytest tests/unit/test_image_manifest.py -v`
-Expected: PASS (2 tests).
-
-- [ ] **Step 5: Verify the CLI emits the satellite image**
-
-Run: `PYTHONPATH=src python3 -m cardinal_cfn.image_manifest satellite`
-Expected output (single line, matches the otel default in cardinal-defaults.yaml):
-`public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0`
-
-- [ ] **Step 6: Commit**
-
-```bash
-git add src/cardinal_cfn/image_manifest.py tests/unit/test_image_manifest.py
-git commit -m "feat: add image manifest generator (satellite scope)"
-```
+- [x] `make build` (generate + lint) and `make test` (482 passed, 1 skipped).
 
 ---
 
-### Task 5: Wire the manifest into `build.sh`
+## Phase 2 (later PR, not built here)
 
-**Files:**
-- Modify: `build.sh` (after the cardinal-satellite-services generation, ~line 34)
-
-- [ ] **Step 1: Add the manifest generation line**
-
-In `build.sh`, immediately after the two lines that generate `cardinal-satellite-services.yaml`:
-
-```sh
-echo "Generating cardinal-satellite-services.yaml..."
-python3 -m cardinal_cfn.satellite_services > generated-templates/cardinal-satellite-services.yaml
-```
-
-insert:
-
-```sh
-echo "Generating satellite-images.txt..."
-python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
-```
-
-- [ ] **Step 2: Run the full build and verify the manifest is emitted**
-
-Run: `make build`
-Expected: build completes; `generated-templates/satellite-images.txt` exists.
-
-Run: `cat generated-templates/satellite-images.txt`
-Expected: `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0`
-
-- [ ] **Step 3: Verify cfn-lint is still clean on the satellite template**
-
-Run: `source .venv/bin/activate && cfn-lint generated-templates/cardinal-satellite-services.yaml`
-Expected: no errors (exit 0). Warnings only if pre-existing.
-
-- [ ] **Step 4: Commit**
-
-```bash
-git add build.sh
-git commit -m "build: emit generated-templates/satellite-images.txt"
-```
-
----
-
-### Task 6: Operator documentation
-
-**Files:**
-- Create: `docs/air-gapped-images.md`
-
-- [ ] **Step 1: Write the doc**
-
-Create `docs/air-gapped-images.md`:
-
-```markdown
-# Air-gapped image mirroring
-
-Air-gapped installs cannot pull container images from the public registries.
-This page lists the images each Cardinal stack runs and shows how to point the
-stack at a private mirror.
-
-> Scope: this covers the **satellite** stack (`cardinal-satellite-services`).
-> The central Lakerunner stack's images are covered in a later release.
-
-## Images the satellite stack runs
-
-The satellite collector runs a single container image. The canonical,
-machine-readable list is generated at build time:
-
-`generated-templates/satellite-images.txt`
-
-For the current release that is:
-
-- `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0` — the otel
-  collector that receives telemetry and writes to the satellite raw bucket.
-
-This file always lists the upstream public references — the images to pull,
-scan, and mirror *from* — regardless of any `ImageRegistry` override you set at
-deploy time.
-
-## Mirroring
-
-Pull each image listed in `satellite-images.txt`, scan it, and push it into
-your private registry under a single namespace prefix. For example, with
-[skopeo](https://github.com/containers/skopeo) and a mirror prefix of
-`mirror.corp/cardinal`:
-
-```sh
-PREFIX=mirror.corp/cardinal
-while read -r img; do
-  name=${img##*/}                     # cardinalhq-otel-collector:v1.8.0
-  skopeo copy "docker://${img}" "docker://${PREFIX}/${name}"
-done < generated-templates/satellite-images.txt
-```
-
-## Pointing the stack at your mirror
-
-Two override paths on `cardinal-satellite-services`, highest precedence first:
-
-1. `OtelImage` — a full image URI that overrides the otel image outright. Wins
-   over `ImageRegistry`. Example: `registry.internal/team/otel:v1.8.0`.
-2. `ImageRegistry` — a registry/namespace prefix applied to first-party
-   Cardinal images. When set, the otel image resolves to
-   `${ImageRegistry}/cardinalhq-otel-collector:v1.8.0`. This matches the
-   flattened layout produced by the mirror loop above (set
-   `ImageRegistry=mirror.corp/cardinal`).
-
-Leave both empty to pull from the public default.
-```
-
-- [ ] **Step 2: Commit**
-
-```bash
-git add docs/air-gapped-images.md
-git commit -m "docs: air-gapped image mirroring guide (satellite)"
-```
-
----
-
-### Task 7: Changelog entry
-
-**Files:**
-- Modify: `CHANGELOG.md`
-
-- [ ] **Step 1: Determine the next version**
-
-Run: `grep -m1 '^## v0.0.' CHANGELOG.md`
-Note the highest version shown (e.g. `## v0.0.124`). The new entry uses the
-next patch number (e.g. `v0.0.125`). Call it `vNEW` below.
-
-- [ ] **Step 2: Insert the new entry**
-
-Insert a new section directly above the current top `## v0.0.NNN` heading (i.e.
-after the preamble paragraph that ends with the "Earliest recorded version"
-line), using the next version number determined in Step 1:
-
-```markdown
-## vNEW
-
-- **New `ImageRegistry` parameter on `cardinal-satellite-services`** for
-  air-gapped installs. When set, first-party Cardinal images (currently the
-  otel collector) resolve to `<ImageRegistry>/<image>:<tag>` — e.g.
-  `mirror.corp/cardinal/cardinalhq-otel-collector:v1.8.0`. Leave empty to pull
-  from the public default. The existing `OtelImage` full-URI override still
-  wins over `ImageRegistry`.
-- **`OtelImage` default is now empty.** Empty means "resolve from
-  `ImageRegistry` or the public default" — no behavior change for installs that
-  set neither parameter; the collector still runs the public default image.
-- A generated `satellite-images.txt` (in `generated-templates/`) lists the
-  upstream image(s) to mirror and scan. See `docs/air-gapped-images.md`.
-- No data-bearing resource is replaced. Upgrade action: none, unless you are
-  mirroring images for an air-gapped install.
-```
-
-(Replace `vNEW` with the actual `## v0.0.NNN` heading from Step 1.)
-
-- [ ] **Step 3: Commit**
-
-```bash
-git add CHANGELOG.md
-git commit -m "docs: changelog entry for satellite ImageRegistry parameter"
-```
-
----
-
-### Task 8: Final full verification
-
-- [ ] **Step 1: Run the full build (generate + lint)**
-
-Run: `make build`
-Expected: all templates generated; `generated-templates/satellite-images.txt` present; cfn-lint reports no errors.
-
-- [ ] **Step 2: Run the full test suite**
-
-Run: `make test`
-Expected: all tests pass (helper unit + per-template).
-
-- [ ] **Step 3: Sanity-check the generated satellite template**
-
-Run: `grep -n "ImageRegistry\|OtelImage\|cardinalhq-otel-collector" generated-templates/cardinal-satellite-services.yaml | head`
-Expected: shows the `ImageRegistry` and `OtelImage` parameters and the `Fn::If` / `Fn::Sub` image resolution.
-
-- [ ] **Step 4: Commit any regenerated artifacts (if the repo tracks them)**
-
-Run: `git status --short`
-If `generated-templates/` is tracked and changed, commit it:
-
-```bash
-git add generated-templates/
-git commit -m "build: regenerate satellite template + image manifest"
-```
-
-If `generated-templates/` is gitignored, skip this step.
-
----
-
-## Self-Review Notes
-
-- **Spec coverage:** resolution model (Task 2, 3), shared helper (Task 1, 2), manifest generator (Task 4), build wiring (Task 5), doc (Task 6), changelog (Task 7), testing — suffix derivation + manifest + satellite precedence + lint (Tasks 1-5, 8). The `OtelImage` default flip and parameter-group update are in Task 3.
-- **Type consistency:** `flatten_suffix(image_ref)` and `add_registry_image(t, *, name, default, description, registry_param="ImageRegistry")` and `manifest_lines(stack)` / `STACK_IMAGE_KEYS` are used identically wherever referenced.
-- **Out of scope (Phase 2):** main `lakerunner_services.py` images, busybox/`db_init` utility-image handling, extending the manifest/doc to all six images.
+Extend the script-driven override + manifest to the main lakerunner stack
+(`lakerunner`, `maestro`, `dex`), handle the two utility images
+(`busybox`/`dex_init`, `initcontainer-grafana`/`db_init` — the psql step can't
+be dropped without a binary change), and extend the manifest/doc to all six
+images.

--- a/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
+++ b/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
@@ -1,0 +1,686 @@
+# Air-gapped Image Registry Override (Phase 1: satellite) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give air-gapped customers a single `ImageRegistry` prefix knob on the `cardinal-satellite-services` stack (governing the otel collector image), plus a generated manifest listing the upstream image(s) to mirror and scan.
+
+**Architecture:** Add two reusable helpers to `src/cardinal_cfn/images.py` — a pure `flatten_suffix()` and a registry-aware `add_registry_image()` that declares an `ImageRegistry` prefix parameter, a per-image full-URI override parameter (default empty), the matching CloudFormation `Conditions`, and returns the resolved `Fn::If` expression with precedence override > prefix > public default. Migrate `satellite_services.py`'s single otel image to it. Add an `image_manifest` generator wired into `build.sh` emitting `generated-templates/satellite-images.txt`. Document and changelog the new parameter.
+
+**Tech Stack:** Python 3, troposphere, pytest, cloud-radar (existing test deps), cfn-lint. Tests run via `make test` / `pytest`. Generators emit YAML through `build.sh` (`make build`).
+
+**Spec:** `docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md`
+
+---
+
+## File Structure
+
+- `src/cardinal_cfn/images.py` (modify) — add `flatten_suffix()` and `add_registry_image()` next to the existing `add_image_override()` (which stays for non-migrated callers).
+- `src/cardinal_cfn/image_manifest.py` (create) — stack -> upstream-image-list generator; CLI entrypoint.
+- `src/cardinal_cfn/satellite_services.py` (modify) — use `add_registry_image()` for `OtelImage`; add `ImageRegistry` to the console parameter group.
+- `tests/unit/test_images.py` (modify) — unit tests for `flatten_suffix()` and `add_registry_image()`.
+- `tests/unit/test_image_manifest.py` (create) — unit tests for the manifest generator.
+- `tests/templates/test_satellite_services.py` (modify) — template-level precedence assertions.
+- `build.sh` (modify) — emit `satellite-images.txt`.
+- `docs/air-gapped-images.md` (create) — operator doc (Phase 1 scope).
+- `CHANGELOG.md` (modify) — new version entry.
+
+---
+
+### Task 1: `flatten_suffix()` pure helper
+
+**Files:**
+- Modify: `src/cardinal_cfn/images.py`
+- Test: `tests/unit/test_images.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_images.py`:
+
+```python
+from cardinal_cfn.images import flatten_suffix
+
+
+def test_flatten_suffix_tag():
+    assert (
+        flatten_suffix("public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0")
+        == "cardinalhq-otel-collector:v1.8.0"
+    )
+
+
+def test_flatten_suffix_ghcr_and_busybox():
+    assert flatten_suffix("ghcr.io/cardinalhq/initcontainer-grafana:latest") == "initcontainer-grafana:latest"
+    assert flatten_suffix("public.ecr.aws/docker/library/busybox:1.37") == "busybox:1.37"
+
+
+def test_flatten_suffix_digest():
+    assert (
+        flatten_suffix("public.ecr.aws/cardinalhq.io/lakerunner@sha256:abc123")
+        == "lakerunner@sha256:abc123"
+    )
+
+
+def test_flatten_suffix_no_registry():
+    assert flatten_suffix("busybox:1.37") == "busybox:1.37"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `make install >/dev/null 2>&1; source .venv/bin/activate && pytest tests/unit/test_images.py -k flatten_suffix -v`
+Expected: FAIL with `ImportError: cannot import name 'flatten_suffix'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/cardinal_cfn/images.py`, after the existing `add_image_override` function, add:
+
+```python
+def flatten_suffix(image_ref: str) -> str:
+    """Return the repo basename + tag/digest from a full image reference.
+
+    Everything after the final '/'. Correct for ':tag', '@sha256:' digest,
+    and refs with no registry component.
+
+        public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0
+            -> cardinalhq-otel-collector:v1.8.0
+    """
+    return image_ref.rsplit("/", 1)[-1]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_images.py -k flatten_suffix -v`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cardinal_cfn/images.py tests/unit/test_images.py
+git commit -m "feat(images): add flatten_suffix helper for registry-prefix derivation"
+```
+
+---
+
+### Task 2: `add_registry_image()` helper
+
+**Files:**
+- Modify: `src/cardinal_cfn/images.py`
+- Test: `tests/unit/test_images.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/unit/test_images.py`:
+
+```python
+from cardinal_cfn.images import add_registry_image
+
+
+def test_add_registry_image_declares_params_and_conditions():
+    t = Template()
+    add_registry_image(
+        t,
+        name="OtelImage",
+        default="public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0",
+        description="otel override",
+    )
+    rendered = _to_dict(t)
+    # Per-image override param defaults to empty (empty == "resolve me").
+    assert rendered["Parameters"]["OtelImage"]["Default"] == ""
+    # Shared registry prefix param is declared once, default empty.
+    assert rendered["Parameters"]["ImageRegistry"]["Default"] == ""
+    # Both gating conditions exist.
+    assert "OtelImageProvided" in rendered["Conditions"]
+    assert "ImageRegistryProvided" in rendered["Conditions"]
+
+
+def test_add_registry_image_returns_three_way_if():
+    t = Template()
+    ref = add_registry_image(
+        t,
+        name="OtelImage",
+        default="public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0",
+        description="otel override",
+    )
+    assert ref.to_dict() == {
+        "Fn::If": [
+            "OtelImageProvided",
+            {"Ref": "OtelImage"},
+            {
+                "Fn::If": [
+                    "ImageRegistryProvided",
+                    {"Fn::Sub": "${ImageRegistry}/cardinalhq-otel-collector:v1.8.0"},
+                    "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0",
+                ]
+            },
+        ]
+    }
+
+
+def test_add_registry_image_shares_one_registry_param():
+    """Calling twice on the same template declares ImageRegistry only once."""
+    t = Template()
+    add_registry_image(t, name="OtelImage", default="r/a:1", description="a")
+    add_registry_image(t, name="MaestroImage", default="r/b:2", description="b")
+    rendered = _to_dict(t)
+    assert "ImageRegistry" in rendered["Parameters"]
+    assert "OtelImageProvided" in rendered["Conditions"]
+    assert "MaestroImageProvided" in rendered["Conditions"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_images.py -k add_registry_image -v`
+Expected: FAIL with `ImportError: cannot import name 'add_registry_image'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/cardinal_cfn/images.py`, change the import line at the top from:
+
+```python
+from troposphere import Parameter, Ref, Template
+```
+
+to:
+
+```python
+from troposphere import Equals, If, Not, Parameter, Ref, Sub, Template
+```
+
+Then, after `flatten_suffix`, add:
+
+```python
+def add_registry_image(
+    t: Template,
+    *,
+    name: str,
+    default: str,
+    description: str,
+    registry_param: str = "ImageRegistry",
+):
+    """Declare a registry-aware image parameter; return the resolved image.
+
+    Precedence, highest first:
+      1. ``<name>`` (full-URI override) when non-empty.
+      2. ``${<registry_param>}/<basename>:<tag>`` when ``<registry_param>`` is
+         non-empty (air-gapped mirror; the registry/namespace is flattened to a
+         single prefix).
+      3. ``default`` (the public upstream reference).
+
+    The per-image parameter defaults to "" so the precedence is expressible in
+    CloudFormation: an empty value means "resolve me from the prefix or the
+    default". The shared ``registry_param`` and its condition are declared once
+    per template (safe to call for multiple images).
+    """
+    if registry_param not in t.parameters:
+        t.add_parameter(
+            Parameter(
+                registry_param,
+                Type="String",
+                Default="",
+                Description=(
+                    "Registry/namespace prefix for first-party Cardinal images "
+                    "(air-gapped mirror). Leave empty to pull from the public "
+                    "default. When set, images resolve to <prefix>/<image>:<tag>."
+                ),
+            )
+        )
+    registry_cond = registry_param + "Provided"
+    if registry_cond not in t.conditions:
+        t.add_condition(registry_cond, Not(Equals(Ref(registry_param), "")))
+
+    t.add_parameter(
+        Parameter(name, Type="String", Default="", Description=description)
+    )
+    override_cond = name + "Provided"
+    t.add_condition(override_cond, Not(Equals(Ref(name), "")))
+
+    suffix = flatten_suffix(default)
+    return If(
+        override_cond,
+        Ref(name),
+        If(
+            registry_cond,
+            Sub("${" + registry_param + "}/" + suffix),
+            default,
+        ),
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_images.py -v`
+Expected: PASS (all `flatten_suffix`, `add_registry_image`, and pre-existing `add_image_override` tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cardinal_cfn/images.py tests/unit/test_images.py
+git commit -m "feat(images): add registry-aware add_registry_image helper"
+```
+
+---
+
+### Task 3: Migrate satellite otel image to `add_registry_image()`
+
+**Files:**
+- Modify: `src/cardinal_cfn/satellite_services.py` (import ~line 74; image_ref ~line 242; param group ~line 291)
+- Test: `tests/templates/test_satellite_services.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/templates/test_satellite_services.py` (the file already imports `json` and defines the `td` fixture):
+
+```python
+from cardinal_cfn.defaults import load_defaults
+
+
+def _otel_image(td):
+    return td["Resources"]["OtelGrpcTaskDef"]["Properties"]["ContainerDefinitions"][0]["Image"]
+
+
+def test_image_registry_parameters_default_empty(td):
+    assert td["Parameters"]["ImageRegistry"]["Default"] == ""
+    assert td["Parameters"]["OtelImage"]["Default"] == ""
+
+
+def test_image_resolution_conditions_present(td):
+    assert "ImageRegistryProvided" in td["Conditions"]
+    assert "OtelImageProvided" in td["Conditions"]
+
+
+def test_otel_image_three_way_precedence(td):
+    otel = load_defaults()["images"]["otel"]
+    suffix = otel.rsplit("/", 1)[-1]
+    assert _otel_image(td) == {
+        "Fn::If": [
+            "OtelImageProvided",
+            {"Ref": "OtelImage"},
+            {
+                "Fn::If": [
+                    "ImageRegistryProvided",
+                    {"Fn::Sub": "${ImageRegistry}/" + suffix},
+                    otel,
+                ]
+            },
+        ]
+    }
+
+
+def test_image_registry_in_parameter_group(td):
+    groups = td["Metadata"]["AWS::CloudFormation::Interface"]["ParameterGroups"]
+    image_group = next(g for g in groups if g["Label"]["default"] == "Image overrides")
+    assert "ImageRegistry" in image_group["Parameters"]
+    assert "OtelImage" in image_group["Parameters"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest tests/templates/test_satellite_services.py -k "image_registry or three_way or resolution_conditions" -v`
+Expected: FAIL — `ImageRegistry` not in Parameters / Image is `{"Ref": "OtelImage"}` not the `Fn::If`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/cardinal_cfn/satellite_services.py`:
+
+Change the import (around line 74) from:
+
+```python
+from cardinal_cfn.images import add_image_override
+```
+
+to:
+
+```python
+from cardinal_cfn.images import add_registry_image
+```
+
+Replace the `image_ref = add_image_override(...)` block (around lines 241-247) with:
+
+```python
+    # Image override (registry-aware: ImageRegistry prefix > OtelImage > default)
+    image_ref = add_registry_image(
+        t,
+        name="OtelImage",
+        default=defaults["images"]["otel"],
+        description=(
+            "Full image URI override for the otel collector. Wins over "
+            "ImageRegistry. Leave empty to use ImageRegistry or the public "
+            "default."
+        ),
+    )
+```
+
+In the parameter-group metadata (around line 290-292), change:
+
+```python
+            {
+                "label": "Image overrides",
+                "parameters": ["OtelImage"],
+            },
+```
+
+to:
+
+```python
+            {
+                "label": "Image overrides",
+                "parameters": ["ImageRegistry", "OtelImage"],
+            },
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/templates/test_satellite_services.py -v`
+Expected: PASS (new tests + all pre-existing satellite tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cardinal_cfn/satellite_services.py tests/templates/test_satellite_services.py
+git commit -m "feat(satellite): add ImageRegistry prefix override for the otel image"
+```
+
+---
+
+### Task 4: Image manifest generator
+
+**Files:**
+- Create: `src/cardinal_cfn/image_manifest.py`
+- Test: `tests/unit/test_image_manifest.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/test_image_manifest.py`:
+
+```python
+"""Tests for the image manifest generator."""
+
+import pytest
+
+from cardinal_cfn import image_manifest
+from cardinal_cfn.defaults import load_defaults
+
+
+def test_satellite_manifest_is_otel_image():
+    assert image_manifest.manifest_lines("satellite") == [
+        load_defaults()["images"]["otel"]
+    ]
+
+
+def test_unknown_stack_raises():
+    with pytest.raises(ValueError):
+        image_manifest.manifest_lines("nope")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_image_manifest.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'cardinal_cfn.image_manifest'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/cardinal_cfn/image_manifest.py`:
+
+```python
+"""Image manifest generator.
+
+Emits the upstream public container images a given stack runs, one per line,
+sorted and deduped. This is the source list air-gapped customers mirror and
+scan FROM; it always reflects the public defaults in cardinal-defaults.yaml,
+never a customer's ImageRegistry override.
+"""
+
+import sys
+
+from cardinal_cfn.defaults import load_defaults
+
+# Which cardinal-defaults.yaml images.* keys each stack runs.
+# Phase 1: satellite only. Phase 2 adds the lakerunner stack's keys.
+STACK_IMAGE_KEYS = {
+    "satellite": ["otel"],
+}
+
+
+def manifest_lines(stack: str) -> list:
+    """Return the sorted, deduped upstream image refs for a stack."""
+    if stack not in STACK_IMAGE_KEYS:
+        known = ", ".join(sorted(STACK_IMAGE_KEYS))
+        raise ValueError(f"unknown stack: {stack!r} (known: {known})")
+    images = load_defaults()["images"]
+    refs = {images[key] for key in STACK_IMAGE_KEYS[stack]}
+    return sorted(refs)
+
+
+def main(argv: list) -> int:
+    if len(argv) != 1:
+        print(
+            "usage: python3 -m cardinal_cfn.image_manifest <stack>",
+            file=sys.stderr,
+        )
+        return 2
+    for line in manifest_lines(argv[0]):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `source .venv/bin/activate && pytest tests/unit/test_image_manifest.py -v`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Verify the CLI emits the satellite image**
+
+Run: `PYTHONPATH=src python3 -m cardinal_cfn.image_manifest satellite`
+Expected output (single line, matches the otel default in cardinal-defaults.yaml):
+`public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/cardinal_cfn/image_manifest.py tests/unit/test_image_manifest.py
+git commit -m "feat: add image manifest generator (satellite scope)"
+```
+
+---
+
+### Task 5: Wire the manifest into `build.sh`
+
+**Files:**
+- Modify: `build.sh` (after the cardinal-satellite-services generation, ~line 34)
+
+- [ ] **Step 1: Add the manifest generation line**
+
+In `build.sh`, immediately after the two lines that generate `cardinal-satellite-services.yaml`:
+
+```sh
+echo "Generating cardinal-satellite-services.yaml..."
+python3 -m cardinal_cfn.satellite_services > generated-templates/cardinal-satellite-services.yaml
+```
+
+insert:
+
+```sh
+echo "Generating satellite-images.txt..."
+python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
+```
+
+- [ ] **Step 2: Run the full build and verify the manifest is emitted**
+
+Run: `make build`
+Expected: build completes; `generated-templates/satellite-images.txt` exists.
+
+Run: `cat generated-templates/satellite-images.txt`
+Expected: `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0`
+
+- [ ] **Step 3: Verify cfn-lint is still clean on the satellite template**
+
+Run: `source .venv/bin/activate && cfn-lint generated-templates/cardinal-satellite-services.yaml`
+Expected: no errors (exit 0). Warnings only if pre-existing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add build.sh
+git commit -m "build: emit generated-templates/satellite-images.txt"
+```
+
+---
+
+### Task 6: Operator documentation
+
+**Files:**
+- Create: `docs/air-gapped-images.md`
+
+- [ ] **Step 1: Write the doc**
+
+Create `docs/air-gapped-images.md`:
+
+```markdown
+# Air-gapped image mirroring
+
+Air-gapped installs cannot pull container images from the public registries.
+This page lists the images each Cardinal stack runs and shows how to point the
+stack at a private mirror.
+
+> Scope: this covers the **satellite** stack (`cardinal-satellite-services`).
+> The central Lakerunner stack's images are covered in a later release.
+
+## Images the satellite stack runs
+
+The satellite collector runs a single container image. The canonical,
+machine-readable list is generated at build time:
+
+`generated-templates/satellite-images.txt`
+
+For the current release that is:
+
+- `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0` — the otel
+  collector that receives telemetry and writes to the satellite raw bucket.
+
+This file always lists the upstream public references — the images to pull,
+scan, and mirror *from* — regardless of any `ImageRegistry` override you set at
+deploy time.
+
+## Mirroring
+
+Pull each image listed in `satellite-images.txt`, scan it, and push it into
+your private registry under a single namespace prefix. For example, with
+[skopeo](https://github.com/containers/skopeo) and a mirror prefix of
+`mirror.corp/cardinal`:
+
+```sh
+PREFIX=mirror.corp/cardinal
+while read -r img; do
+  name=${img##*/}                     # cardinalhq-otel-collector:v1.8.0
+  skopeo copy "docker://${img}" "docker://${PREFIX}/${name}"
+done < generated-templates/satellite-images.txt
+```
+
+## Pointing the stack at your mirror
+
+Two override paths on `cardinal-satellite-services`, highest precedence first:
+
+1. `OtelImage` — a full image URI that overrides the otel image outright. Wins
+   over `ImageRegistry`. Example: `registry.internal/team/otel:v1.8.0`.
+2. `ImageRegistry` — a registry/namespace prefix applied to first-party
+   Cardinal images. When set, the otel image resolves to
+   `${ImageRegistry}/cardinalhq-otel-collector:v1.8.0`. This matches the
+   flattened layout produced by the mirror loop above (set
+   `ImageRegistry=mirror.corp/cardinal`).
+
+Leave both empty to pull from the public default.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/air-gapped-images.md
+git commit -m "docs: air-gapped image mirroring guide (satellite)"
+```
+
+---
+
+### Task 7: Changelog entry
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Determine the next version**
+
+Run: `grep -m1 '^## v0.0.' CHANGELOG.md`
+Note the highest version shown (e.g. `## v0.0.124`). The new entry uses the
+next patch number (e.g. `v0.0.125`). Call it `vNEW` below.
+
+- [ ] **Step 2: Insert the new entry**
+
+Insert a new section directly above the current top `## v0.0.NNN` heading (i.e.
+after the preamble paragraph that ends with the "Earliest recorded version"
+line), using the next version number determined in Step 1:
+
+```markdown
+## vNEW
+
+- **New `ImageRegistry` parameter on `cardinal-satellite-services`** for
+  air-gapped installs. When set, first-party Cardinal images (currently the
+  otel collector) resolve to `<ImageRegistry>/<image>:<tag>` — e.g.
+  `mirror.corp/cardinal/cardinalhq-otel-collector:v1.8.0`. Leave empty to pull
+  from the public default. The existing `OtelImage` full-URI override still
+  wins over `ImageRegistry`.
+- **`OtelImage` default is now empty.** Empty means "resolve from
+  `ImageRegistry` or the public default" — no behavior change for installs that
+  set neither parameter; the collector still runs the public default image.
+- A generated `satellite-images.txt` (in `generated-templates/`) lists the
+  upstream image(s) to mirror and scan. See `docs/air-gapped-images.md`.
+- No data-bearing resource is replaced. Upgrade action: none, unless you are
+  mirroring images for an air-gapped install.
+```
+
+(Replace `vNEW` with the actual `## v0.0.NNN` heading from Step 1.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs: changelog entry for satellite ImageRegistry parameter"
+```
+
+---
+
+### Task 8: Final full verification
+
+- [ ] **Step 1: Run the full build (generate + lint)**
+
+Run: `make build`
+Expected: all templates generated; `generated-templates/satellite-images.txt` present; cfn-lint reports no errors.
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `make test`
+Expected: all tests pass (helper unit + per-template).
+
+- [ ] **Step 3: Sanity-check the generated satellite template**
+
+Run: `grep -n "ImageRegistry\|OtelImage\|cardinalhq-otel-collector" generated-templates/cardinal-satellite-services.yaml | head`
+Expected: shows the `ImageRegistry` and `OtelImage` parameters and the `Fn::If` / `Fn::Sub` image resolution.
+
+- [ ] **Step 4: Commit any regenerated artifacts (if the repo tracks them)**
+
+Run: `git status --short`
+If `generated-templates/` is tracked and changed, commit it:
+
+```bash
+git add generated-templates/
+git commit -m "build: regenerate satellite template + image manifest"
+```
+
+If `generated-templates/` is gitignored, skip this step.
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** resolution model (Task 2, 3), shared helper (Task 1, 2), manifest generator (Task 4), build wiring (Task 5), doc (Task 6), changelog (Task 7), testing — suffix derivation + manifest + satellite precedence + lint (Tasks 1-5, 8). The `OtelImage` default flip and parameter-group update are in Task 3.
+- **Type consistency:** `flatten_suffix(image_ref)` and `add_registry_image(t, *, name, default, description, registry_param="ImageRegistry")` and `manifest_lines(stack)` / `STACK_IMAGE_KEYS` are used identically wherever referenced.
+- **Out of scope (Phase 2):** main `lakerunner_services.py` images, busybox/`db_init` utility-image handling, extending the manifest/doc to all six images.

--- a/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
+++ b/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
@@ -1,0 +1,213 @@
+# Air-gapped image registry override + image manifest (Phase 1: satellite)
+
+Date: 2026-06-04
+Status: approved (Phase 1 scoped; Phase 2 deferred to a later PR)
+
+## Problem
+
+Air-gapped customers cannot pull our container images from the public
+registries (`public.ecr.aws`, `ghcr.io`). They need two things:
+
+1. A way to point the stacks at their own private mirror instead of the
+   public registries.
+2. A concrete, machine-readable list of every image a stack runs, so their
+   security team can mirror and scan each image before allowing it into the
+   private registry.
+
+We already let customers override templates from a private mirror via the
+single `TemplateBaseUrl` parameter (one prefix, child filenames appended).
+There is no equivalent single knob for container images: today each image is
+its own full-URI parameter (`OtelImage`, `LakerunnerImage`, ...), so an
+operator must override each one with a complete URI. There is also no image
+manifest artifact.
+
+## Scope
+
+This work is split into two phases. **This spec covers Phase 1 only.**
+
+- **Phase 1 (this PR): satellite stacks/scripts.** The satellite is the
+  smallest, self-contained surface: `satellite_services.py` runs exactly one
+  container image (the otel collector); `satellite_infra_base.py` runs no
+  containers (IAM/S3/SQS only); the satellite deploy scripts reference no
+  images. Phase 1 establishes the `ImageRegistry` pattern and the manifest
+  generator against this small surface.
+- **Phase 2 (later PR, out of scope here): the main lakerunner stack.** Apply
+  the same `ImageRegistry` pattern to `lakerunner_services.py`
+  (lakerunner/maestro/dex), decide the handling of the two utility images
+  (`busybox`/`dex_init` and `initcontainer-grafana`/`db_init`), and extend the
+  manifest + doc to all six images. Phase 2 design notes are recorded at the
+  end of this document so the decisions are not lost, but nothing in Phase 2
+  is built now.
+
+## Decisions
+
+- **First-party Cardinal images flatten under a single `ImageRegistry`
+  prefix.** In Phase 1 the only such image is the otel collector. When
+  `ImageRegistry` is set, the image resolves to
+  `${ImageRegistry}/<basename>:<tag>` (the registry/namespace prefix is
+  swapped; the customer mirrors the image into one flat namespace).
+- **The existing per-image full-URI parameter remains as an escape hatch**
+  that wins over the prefix.
+- **The manifest is the upstream source list.** It always lists the public
+  upstream image references (what to pull/scan/mirror *from*), regardless of
+  `ImageRegistry`.
+- **Phase 1 manifest lists satellite images only** (the otel collector). It
+  honestly reflects what a satellite-only customer runs.
+
+## Design
+
+### 1. Resolution model (three-way precedence)
+
+A new root parameter `ImageRegistry` (Type String, Default `""`) is added to
+`satellite_services.py`. The otel image is resolved in the template body via
+CloudFormation `Conditions` + `Fn::If`, in this precedence order:
+
+1. If the per-image override `OtelImage` is non-empty -> use it verbatim
+   (full-URI escape hatch wins).
+2. Else if `ImageRegistry` is non-empty -> `Fn::Sub("${ImageRegistry}/<suffix>")`
+   where `<suffix>` is the flattened `basename:tag` (or `basename@digest`).
+3. Else -> the public default
+   (`public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0`).
+
+To make the precedence expressible in CloudFormation, **`OtelImage`'s default
+flips from the full public URI to `""`** (empty means "resolve me"). The
+public default and the flattened suffix are both computed in Python from the
+`images.otel` value in `cardinal-defaults.yaml`; they are baked into the
+template as literals, so the generated template is self-contained.
+
+Concretely, the rendered template gains:
+
+- Parameter `ImageRegistry`, `Default: ""`,
+  `Description`: registry/namespace prefix for first-party Cardinal images;
+  leave empty to pull from the public default. When set, images resolve to
+  `<ImageRegistry>/<image>:<tag>`.
+- Parameter `OtelImage`, `Default: ""` (was the full URI),
+  `Description`: full image URI override for the otel collector; wins over
+  `ImageRegistry`; leave empty to use `ImageRegistry` or the public default.
+- Condition `OtelImageProvided = Not(Equals(Ref(OtelImage), ""))`.
+- Condition `ImageRegistryProvided = Not(Equals(Ref(ImageRegistry), ""))`.
+- The container `Image` becomes:
+  `If(OtelImageProvided, Ref(OtelImage), If(ImageRegistryProvided, Sub("${ImageRegistry}/cardinalhq-otel-collector:v1.8.0"), "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"))`.
+
+### 2. Shared helper in `images.py`
+
+Add a registry-aware image helper alongside the existing `add_image_override`
+(the old helper stays for any caller not yet migrated). The new helper:
+
+- Ensures the `ImageRegistry` parameter exists on the template (adds it once;
+  safe to call for multiple images in Phase 2).
+- Adds the per-image parameter with `Default: ""`.
+- Adds the `*Provided` conditions (idempotent on the shared `ImageRegistry`
+  condition).
+- Returns the resolved `Fn::If` expression to assign to the container `Image`.
+
+The flattened suffix is derived from the default URI as "everything after the
+last `/`" -- this yields `cardinalhq-otel-collector:v1.8.0` for the otel
+image, and is correct for `:tag`, `@sha256:` digest, and busybox/ghcr forms
+(needed in Phase 2). This derivation lives in a small pure function with its
+own unit test.
+
+`satellite_services.py` switches its `image_ref = add_image_override(...)`
+call (line ~242) to the new helper, and adds `ImageRegistry` to the console
+parameter-group metadata (next to `OtelImage` in the "Image overrides"
+group).
+
+### 3. Image manifest generator
+
+A new module `src/cardinal_cfn/image_manifest.py` reads the `images:` block
+from `cardinal-defaults.yaml` and emits a newline-delimited, sorted, deduped
+list of full upstream image references for a given stack. It carries a
+stack -> image-keys mapping; Phase 1 registers `satellite -> ["otel"]`
+(Phase 2 adds the lakerunner stack's keys).
+
+`build.sh` is extended to emit the satellite manifest after generating the
+satellite-services template:
+
+```
+python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
+```
+
+For Phase 1 `satellite-images.txt` contains exactly:
+
+```
+public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0
+```
+
+The manifest reflects the upstream public references, never the customer's
+`ImageRegistry` value -- it is the list to mirror *from*.
+
+### 4. Documentation
+
+New `docs/air-gapped-images.md`, Phase-1 scope:
+
+- States the satellite collector runs a single image (the otel collector) and
+  points at `generated-templates/satellite-images.txt` as the canonical list.
+- Explains the two override paths: set `ImageRegistry=<mirror-prefix>` to
+  flatten the image to `<mirror-prefix>/cardinalhq-otel-collector:v1.8.0`, or
+  set `OtelImage=<full-uri>` to override outright (wins over `ImageRegistry`).
+- Includes a short illustrative mirror snippet (e.g. a skopeo/docker
+  pull-retag-push loop reading `satellite-images.txt`).
+- Notes that the central lakerunner stack's images are covered in a later
+  release (Phase 2).
+
+### 5. Changelog
+
+Add a `CHANGELOG.md` entry (operator-facing):
+
+- New `ImageRegistry` parameter on `cardinal-satellite-services`.
+- `OtelImage` default is now empty (resolves to the public default when both
+  `OtelImage` and `ImageRegistry` are empty -- no behavior change for existing
+  installs that set neither).
+- No data-bearing resource is replaced.
+- Upgrade action: none, unless mirroring images for an air-gapped install.
+
+## Testing
+
+- **Unit -- suffix derivation:** `cardinalhq-otel-collector:v1.8.0` from the
+  otel default; plus `:tag`, `@sha256:` digest, and a ghcr/busybox-style input
+  (so the function is ready for Phase 2).
+- **Unit -- manifest:** `image_manifest satellite` output equals
+  `[cardinal-defaults.yaml images.otel]`.
+- **Template (cloud-radar) on `cardinal-satellite-services`:**
+  - Defaults (both params empty) -> otel container `Image` is the public
+    default.
+  - `ImageRegistry=mirror.example/cardinal` -> `Image ==
+    mirror.example/cardinal/cardinalhq-otel-collector:v1.8.0`.
+  - `OtelImage=registry.internal/otel:custom` (with and without
+    `ImageRegistry` set) -> `Image == registry.internal/otel:custom`.
+- **Lint:** `cardinal-satellite-services.yaml` passes cfn-lint with no new
+  errors (conditions + `Fn::If` + `Fn::Sub` render cleanly).
+
+## Explicit scope choices / risks
+
+- `OtelImage`'s default flips from a full URI to `""`. This is a visible
+  parameter-surface change (the console no longer shows the default URI) but
+  is behavior-preserving for installs that set neither knob. Documented in the
+  changelog.
+- The satellite stack runs only one image, so the single-prefix value is
+  modest in isolation; its purpose is to establish the pattern Phase 2 reuses
+  across the main stack and to give a registry-level knob now.
+
+## Phase 2 notes (not built in this PR)
+
+Recorded so the prior decisions are not lost:
+
+- Apply the same `ImageRegistry` resolution to `lakerunner_services.py` for
+  the first-party images `lakerunner`, `maestro`, `dex`. Resolve in the root
+  and pass the final strings down to the existing child `*Image` parameters,
+  leaving children otherwise unchanged (preserves the B -> C service-tier
+  split rule). Standalone child deploys that bypass the root will not get the
+  prefix -- an accepted limitation.
+- **Utility images keep their own per-image knobs** (not folded into
+  `ImageRegistry`): `dex_init` (busybox `public.ecr.aws/docker/library/busybox:1.37`,
+  used purely as a shell to render the dex config) and `db_init`
+  (`ghcr.io/cardinalhq/initcontainer-grafana:latest`, repurposed as a psql
+  client for two `CREATE DATABASE` calls + a keepalive sleeper). The lakerunner
+  `migrate` command connects to an already-existing database and does not
+  create it, so the psql step cannot be dropped without a change in the
+  `lakerunner`/`maestro` binaries.
+- `db_init` is intentionally left as-is for now (the `:latest` mutable tag and
+  the "grafana" misnomer/registry mismatch with the charts are known and will
+  be revisited).
+- Extend the manifest generator (`lakerunner -> [...]`) and
+  `docs/air-gapped-images.md` to cover all six images.

--- a/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
+++ b/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
@@ -1,127 +1,89 @@
-# Air-gapped image registry override + image manifest (Phase 1: satellite)
+# Air-gapped image override + image manifest (Phase 1: satellite)
 
 Date: 2026-06-04
-Status: approved (Phase 1 scoped; Phase 2 deferred to a later PR)
+Status: implemented (Phase 1; Phase 2 deferred to a later PR)
+
+Note: this spec was simplified during implementation. The original draft put a
+three-way `ImageRegistry`/`Fn::If` resolver inside the CloudFormation template;
+the final design moves image selection into the deploy script and keeps the
+template a plain literal parameter. See "Design" below for what was built.
 
 ## Problem
 
 Air-gapped customers cannot pull our container images from the public
 registries (`public.ecr.aws`, `ghcr.io`). They need two things:
 
-1. A way to point the stacks at their own private mirror instead of the
-   public registries.
+1. A way to point the stack at their own private mirror instead of the public
+   registries.
 2. A concrete, machine-readable list of every image a stack runs, so their
    security team can mirror and scan each image before allowing it into the
    private registry.
-
-We already let customers override templates from a private mirror via the
-single `TemplateBaseUrl` parameter (one prefix, child filenames appended).
-There is no equivalent single knob for container images: today each image is
-its own full-URI parameter (`OtelImage`, `LakerunnerImage`, ...), so an
-operator must override each one with a complete URI. There is also no image
-manifest artifact.
 
 ## Scope
 
 This work is split into two phases. **This spec covers Phase 1 only.**
 
-- **Phase 1 (this PR): satellite stacks/scripts.** The satellite is the
-  smallest, self-contained surface: `satellite_services.py` runs exactly one
-  container image (the otel collector); `satellite_infra_base.py` runs no
-  containers (IAM/S3/SQS only); the satellite deploy scripts reference no
-  images. Phase 1 establishes the `ImageRegistry` pattern and the manifest
-  generator against this small surface.
-- **Phase 2 (later PR, out of scope here): the main lakerunner stack.** Apply
-  the same `ImageRegistry` pattern to `lakerunner_services.py`
-  (lakerunner/maestro/dex), decide the handling of the two utility images
-  (`busybox`/`dex_init` and `initcontainer-grafana`/`db_init`), and extend the
-  manifest + doc to all six images. Phase 2 design notes are recorded at the
-  end of this document so the decisions are not lost, but nothing in Phase 2
-  is built now.
+- **Phase 1 (this PR): satellite stack/script.** The satellite is the smallest,
+  self-contained surface: `satellite_services.py` runs exactly one container
+  image (the otel collector); `satellite_infra_base.py` runs no containers
+  (IAM/S3/SQS only). Phase 1 establishes the script-driven override pattern and
+  the manifest generator against this small surface.
+- **Phase 2 (later PR, out of scope here): the main lakerunner stack.** Extend
+  the same script-driven override + manifest to `lakerunner_services.py`
+  (lakerunner/maestro/dex) and decide the handling of the two utility images
+  (`busybox`/`dex_init` and `initcontainer-grafana`/`db_init`). Phase 2 notes
+  are recorded at the end so the decisions are not lost; nothing in Phase 2 is
+  built now.
 
 ## Decisions
 
-- **First-party Cardinal images flatten under a single `ImageRegistry`
-  prefix.** In Phase 1 the only such image is the otel collector. When
-  `ImageRegistry` is set, the image resolves to
-  `${ImageRegistry}/<basename>:<tag>` (the registry/namespace prefix is
-  swapped; the customer mirrors the image into one flat namespace).
-- **The existing per-image full-URI parameter remains as an escape hatch**
-  that wins over the prefix.
+- **The deploy script selects the image; the template takes it as a literal.**
+  `deploy-satellite-services.sh` accepts an optional `OTEL_IMAGE` full-URI
+  environment variable and passes it through as the literal `OtelImage`
+  CloudFormation parameter. The template is unchanged — `OtelImage` is the
+  plain pass-through parameter it already was, defaulting to the public image.
+  No registry-prefix math, no `Fn::If`, no conditions in the template.
+- **Why a full-URI passthrough rather than a registry prefix:** the satellite
+  runs exactly one image, so a single `OTEL_IMAGE` value is exactly as
+  ergonomic as a prefix, with far less machinery. A registry-prefix knob only
+  earns its keep across many images (Phase 2), where the script can derive
+  per-image suffixes from the generated manifest.
 - **The manifest is the upstream source list.** It always lists the public
-  upstream image references (what to pull/scan/mirror *from*), regardless of
-  `ImageRegistry`.
-- **Phase 1 manifest lists satellite images only** (the otel collector). It
-  honestly reflects what a satellite-only customer runs.
+  upstream image reference (what to pull/scan/mirror *from*), regardless of
+  what the operator deploys. Phase 1 lists satellite images only (the otel
+  collector).
 
 ## Design
 
-### 1. Resolution model (three-way precedence)
+### 1. Image selection in the deploy script
 
-A new root parameter `ImageRegistry` (Type String, Default `""`) is added to
-`satellite_services.py`. The otel image is resolved in the template body via
-CloudFormation `Conditions` + `Fn::If`, in this precedence order:
+`scripts-src/parts/deploy-satellite-services.sh` (the front-half source for the
+generated single-file driver `scripts/deploy-satellite-services.sh`) gains an
+optional `OTEL_IMAGE` input:
 
-1. If the per-image override `OtelImage` is non-empty -> use it verbatim
-   (full-URI escape hatch wins).
-2. Else if `ImageRegistry` is non-empty -> `Fn::Sub("${ImageRegistry}/<suffix>")`
-   where `<suffix>` is the flattened `basename:tag` (or `basename@digest`).
-3. Else -> the public default
-   (`public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0`).
+- Documented in the script's `usage()` under Optional inputs.
+- Added to the input-echo diagnostic loop.
+- When set, appends `OtelImage=$OTEL_IMAGE` to the `PARAMS` list the engine
+  passes to `create-change-set`. When unset, no `OtelImage` override is sent and
+  the engine falls back to the template's `Default` (the public image).
 
-To make the precedence expressible in CloudFormation, **`OtelImage`'s default
-flips from the full public URI to `""`** (empty means "resolve me"). The
-public default and the flattened suffix are both computed in Python from the
-`images.otel` value in `cardinal-defaults.yaml`; they are baked into the
-template as literals, so the generated template is self-contained.
+The driver is regenerated with `make scripts`; `tests/unit/test_deploy_stack_lint.py`
+asserts the generated copy matches a fresh build (drift gate), and the script
+passes shellcheck.
 
-Concretely, the rendered template gains:
+No change to `satellite_services.py` or `images.py`: the template already
+declares `OtelImage` as a literal pass-through parameter (`add_image_override`).
 
-- Parameter `ImageRegistry`, `Default: ""`,
-  `Description`: registry/namespace prefix for first-party Cardinal images;
-  leave empty to pull from the public default. When set, images resolve to
-  `<ImageRegistry>/<image>:<tag>`.
-- Parameter `OtelImage`, `Default: ""` (was the full URI),
-  `Description`: full image URI override for the otel collector; wins over
-  `ImageRegistry`; leave empty to use `ImageRegistry` or the public default.
-- Condition `OtelImageProvided = Not(Equals(Ref(OtelImage), ""))`.
-- Condition `ImageRegistryProvided = Not(Equals(Ref(ImageRegistry), ""))`.
-- The container `Image` becomes:
-  `If(OtelImageProvided, Ref(OtelImage), If(ImageRegistryProvided, Sub("${ImageRegistry}/cardinalhq-otel-collector:v1.8.0"), "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"))`.
+### 2. Image manifest generator
 
-### 2. Shared helper in `images.py`
+`src/cardinal_cfn/image_manifest.py` reads the `images:` block from
+`cardinal-defaults.yaml` and emits a newline-delimited, sorted, deduped list of
+full upstream image references for a given stack. It carries a stack ->
+image-keys mapping; Phase 1 registers `satellite -> ["otel"]` (Phase 2 adds the
+lakerunner stack's keys).
 
-Add a registry-aware image helper alongside the existing `add_image_override`
-(the old helper stays for any caller not yet migrated). The new helper:
-
-- Ensures the `ImageRegistry` parameter exists on the template (adds it once;
-  safe to call for multiple images in Phase 2).
-- Adds the per-image parameter with `Default: ""`.
-- Adds the `*Provided` conditions (idempotent on the shared `ImageRegistry`
-  condition).
-- Returns the resolved `Fn::If` expression to assign to the container `Image`.
-
-The flattened suffix is derived from the default URI as "everything after the
-last `/`" -- this yields `cardinalhq-otel-collector:v1.8.0` for the otel
-image, and is correct for `:tag`, `@sha256:` digest, and busybox/ghcr forms
-(needed in Phase 2). This derivation lives in a small pure function with its
-own unit test.
-
-`satellite_services.py` switches its `image_ref = add_image_override(...)`
-call (line ~242) to the new helper, and adds `ImageRegistry` to the console
-parameter-group metadata (next to `OtelImage` in the "Image overrides"
-group).
-
-### 3. Image manifest generator
-
-A new module `src/cardinal_cfn/image_manifest.py` reads the `images:` block
-from `cardinal-defaults.yaml` and emits a newline-delimited, sorted, deduped
-list of full upstream image references for a given stack. It carries a
-stack -> image-keys mapping; Phase 1 registers `satellite -> ["otel"]`
-(Phase 2 adds the lakerunner stack's keys).
-
-`build.sh` is extended to emit the satellite manifest after generating the
-satellite-services template:
+`build.sh` emits the satellite manifest after generating the satellite-services
+template:
 
 ```
 python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
@@ -133,81 +95,53 @@ For Phase 1 `satellite-images.txt` contains exactly:
 public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0
 ```
 
-The manifest reflects the upstream public references, never the customer's
-`ImageRegistry` value -- it is the list to mirror *from*.
+The manifest reflects the upstream public reference, never the operator's
+override — it is the list to mirror *from*. (`generated-templates/` is
+gitignored; the manifest is a build artifact, published alongside templates.)
 
-### 4. Documentation
+### 3. Documentation
 
-New `docs/air-gapped-images.md`, Phase-1 scope:
+`docs/air-gapped-images.md` (Phase-1 scope): states the satellite collector
+runs a single image and points at `satellite-images.txt`; shows a skopeo mirror
+loop; and documents setting `OTEL_IMAGE` on the deploy script to deploy the
+mirrored image (unset = public default). Notes the central lakerunner stack's
+images are covered in a later release.
 
-- States the satellite collector runs a single image (the otel collector) and
-  points at `generated-templates/satellite-images.txt` as the canonical list.
-- Explains the two override paths: set `ImageRegistry=<mirror-prefix>` to
-  flatten the image to `<mirror-prefix>/cardinalhq-otel-collector:v1.8.0`, or
-  set `OtelImage=<full-uri>` to override outright (wins over `ImageRegistry`).
-- Includes a short illustrative mirror snippet (e.g. a skopeo/docker
-  pull-retag-push loop reading `satellite-images.txt`).
-- Notes that the central lakerunner stack's images are covered in a later
-  release (Phase 2).
+### 4. Changelog
 
-### 5. Changelog
-
-Add a `CHANGELOG.md` entry (operator-facing):
-
-- New `ImageRegistry` parameter on `cardinal-satellite-services`.
-- `OtelImage` default is now empty (resolves to the public default when both
-  `OtelImage` and `ImageRegistry` are empty -- no behavior change for existing
-  installs that set neither).
-- No data-bearing resource is replaced.
-- Upgrade action: none, unless mirroring images for an air-gapped install.
+`CHANGELOG.md` entry (`v0.0.125`): the generated `satellite-images.txt`; the
+`OTEL_IMAGE` deploy-script input that maps to the literal `OtelImage` param;
+unset preserves the public default; no resource replacement; upgrade action =
+none unless mirroring.
 
 ## Testing
 
-- **Unit -- suffix derivation:** `cardinalhq-otel-collector:v1.8.0` from the
-  otel default; plus `:tag`, `@sha256:` digest, and a ghcr/busybox-style input
-  (so the function is ready for Phase 2).
-- **Unit -- manifest:** `image_manifest satellite` output equals
-  `[cardinal-defaults.yaml images.otel]`.
-- **Template (cloud-radar) on `cardinal-satellite-services`:**
-  - Defaults (both params empty) -> otel container `Image` is the public
-    default.
-  - `ImageRegistry=mirror.example/cardinal` -> `Image ==
-    mirror.example/cardinal/cardinalhq-otel-collector:v1.8.0`.
-  - `OtelImage=registry.internal/otel:custom` (with and without
-    `ImageRegistry` set) -> `Image == registry.internal/otel:custom`.
-- **Lint:** `cardinal-satellite-services.yaml` passes cfn-lint with no new
-  errors (conditions + `Fn::If` + `Fn::Sub` render cleanly).
-
-## Explicit scope choices / risks
-
-- `OtelImage`'s default flips from a full URI to `""`. This is a visible
-  parameter-surface change (the console no longer shows the default URI) but
-  is behavior-preserving for installs that set neither knob. Documented in the
-  changelog.
-- The satellite stack runs only one image, so the single-prefix value is
-  modest in isolation; its purpose is to establish the pattern Phase 2 reuses
-  across the main stack and to give a registry-level knob now.
+- **Unit -- manifest:** `image_manifest.manifest_lines("satellite")` equals
+  `[cardinal-defaults.yaml images.otel]`; an unknown stack raises `ValueError`.
+- **Drift + lint:** the regenerated `deploy-satellite-services.sh` matches a
+  fresh `make scripts` build and passes shellcheck (existing
+  `test_deploy_stack_lint.py`).
+- **Build:** `make build` emits `generated-templates/satellite-images.txt` and
+  cfn-lint stays clean.
+- The front-half's `OTEL_IMAGE -> OtelImage=` mapping is verified behaviorally
+  (run the front-half with the engine stubbed); the combined single-file driver
+  rejects arguments, so the engine's internal test hooks cannot be reached
+  through it — matching the repo's existing approach of linting the front-half
+  rather than unit-testing its env→PARAMS assembly.
 
 ## Phase 2 notes (not built in this PR)
 
-Recorded so the prior decisions are not lost:
-
-- Apply the same `ImageRegistry` resolution to `lakerunner_services.py` for
-  the first-party images `lakerunner`, `maestro`, `dex`. Resolve in the root
-  and pass the final strings down to the existing child `*Image` parameters,
-  leaving children otherwise unchanged (preserves the B -> C service-tier
-  split rule). Standalone child deploys that bypass the root will not get the
-  prefix -- an accepted limitation.
-- **Utility images keep their own per-image knobs** (not folded into
-  `ImageRegistry`): `dex_init` (busybox `public.ecr.aws/docker/library/busybox:1.37`,
-  used purely as a shell to render the dex config) and `db_init`
+- Extend `OTEL_IMAGE`-style passthrough (or a registry prefix that flattens via
+  the manifest) to the main lakerunner stack's first-party images
+  (`lakerunner`, `maestro`, `dex`), and extend the manifest generator
+  (`lakerunner -> [...]`) and `docs/air-gapped-images.md` to all six images.
+- **Utility images** in the main stack: `dex_init` (busybox
+  `public.ecr.aws/docker/library/busybox:1.37`, used purely as a shell to
+  render the dex config) and `db_init`
   (`ghcr.io/cardinalhq/initcontainer-grafana:latest`, repurposed as a psql
   client for two `CREATE DATABASE` calls + a keepalive sleeper). The lakerunner
   `migrate` command connects to an already-existing database and does not
   create it, so the psql step cannot be dropped without a change in the
-  `lakerunner`/`maestro` binaries.
-- `db_init` is intentionally left as-is for now (the `:latest` mutable tag and
-  the "grafana" misnomer/registry mismatch with the charts are known and will
-  be revisited).
-- Extend the manifest generator (`lakerunner -> [...]`) and
-  `docs/air-gapped-images.md` to cover all six images.
+  `lakerunner`/`maestro` binaries. `db_init` is intentionally left as-is for now
+  (the `:latest` mutable tag and the "grafana" misnomer/registry mismatch with
+  the charts are known and will be revisited).

--- a/scripts-src/parts/deploy-satellite-services.sh
+++ b/scripts-src/parts/deploy-satellite-services.sh
@@ -41,6 +41,10 @@ Optional (template defaults preserved when unset):
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
+  OTEL_IMAGE           Full image URI for the otel collector (e.g. an
+                       air-gapped private mirror). Unset: the template's public
+                       default. The public image to mirror is listed in
+                       satellite-images.txt (see docs/air-gapped-images.md).
   TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN    Passed to create-change-set.
   NO_EXECUTE           Non-empty: change-set only, do not execute.
@@ -60,7 +64,7 @@ esac
 echo "[deploy-satellite-services] inputs visible to this process:" >&2
 for _v in STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK ORGANIZATION_ID \
           VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
-          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS TEMPLATE_BASE_URL \
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS OTEL_IMAGE TEMPLATE_BASE_URL \
           DEPLOYER_ROLE_ARN NO_EXECUTE; do
     eval "_val=\${$_v:-}"
     printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
@@ -103,6 +107,10 @@ OtelReplicas=$otel_replicas"
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
+# OTEL_IMAGE: full image URI override passed as the literal OtelImage param.
+# Unset -> omitted, so the template's public default governs.
+[ -n "${OTEL_IMAGE:-}" ] && params="$params
+OtelImage=$OTEL_IMAGE"
 
 PARAMS="$params"
 

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -42,6 +42,10 @@ Optional (template defaults preserved when unset):
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
+  OTEL_IMAGE           Full image URI for the otel collector (e.g. an
+                       air-gapped private mirror). Unset: the template's public
+                       default. The public image to mirror is listed in
+                       satellite-images.txt (see docs/air-gapped-images.md).
   TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN    Passed to create-change-set.
   NO_EXECUTE           Non-empty: change-set only, do not execute.
@@ -61,7 +65,7 @@ esac
 echo "[deploy-satellite-services] inputs visible to this process:" >&2
 for _v in STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK ORGANIZATION_ID \
           VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
-          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS TEMPLATE_BASE_URL \
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS OTEL_IMAGE TEMPLATE_BASE_URL \
           DEPLOYER_ROLE_ARN NO_EXECUTE; do
     eval "_val=\${$_v:-}"
     printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
@@ -104,6 +108,10 @@ OtelReplicas=$otel_replicas"
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
+# OTEL_IMAGE: full image URI override passed as the literal OtelImage param.
+# Unset -> omitted, so the template's public default governs.
+[ -n "${OTEL_IMAGE:-}" ] && params="$params
+OtelImage=$OTEL_IMAGE"
 
 PARAMS="$params"
 

--- a/src/cardinal_cfn/image_manifest.py
+++ b/src/cardinal_cfn/image_manifest.py
@@ -1,0 +1,43 @@
+"""Image manifest generator.
+
+Emits the upstream public container images a given stack runs, one per line,
+sorted and deduped. This is the source list air-gapped customers mirror and
+scan FROM; it always reflects the public defaults in cardinal-defaults.yaml,
+never a customer's overridden image.
+"""
+
+import sys
+
+from cardinal_cfn.defaults import load_defaults
+
+# Which cardinal-defaults.yaml images.* keys each stack runs.
+# Phase 1: satellite only. Phase 2 adds the lakerunner stack's keys.
+STACK_IMAGE_KEYS = {
+    "satellite": ["otel"],
+}
+
+
+def manifest_lines(stack: str) -> list:
+    """Return the sorted, deduped upstream image refs for a stack."""
+    if stack not in STACK_IMAGE_KEYS:
+        known = ", ".join(sorted(STACK_IMAGE_KEYS))
+        raise ValueError(f"unknown stack: {stack!r} (known: {known})")
+    images = load_defaults()["images"]
+    refs = {images[key] for key in STACK_IMAGE_KEYS[stack]}
+    return sorted(refs)
+
+
+def main(argv: list) -> int:
+    if len(argv) != 1:
+        print(
+            "usage: python3 -m cardinal_cfn.image_manifest <stack>",
+            file=sys.stderr,
+        )
+        return 2
+    for line in manifest_lines(argv[0]):
+        print(line)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/unit/test_image_manifest.py
+++ b/tests/unit/test_image_manifest.py
@@ -1,0 +1,17 @@
+"""Tests for the image manifest generator."""
+
+import pytest
+
+from cardinal_cfn import image_manifest
+from cardinal_cfn.defaults import load_defaults
+
+
+def test_satellite_manifest_is_otel_image():
+    assert image_manifest.manifest_lines("satellite") == [
+        load_defaults()["images"]["otel"]
+    ]
+
+
+def test_unknown_stack_raises():
+    with pytest.raises(ValueError):
+        image_manifest.manifest_lines("nope")


### PR DESCRIPTION
## Summary

Phase 1 (satellite) of air-gapped image support. Lets an operator deploy the satellite otel collector from a private mirror, and publishes a machine-readable list of the upstream image(s) to mirror and scan.

Image selection lives in the deploy script; the CloudFormation template stays a plain literal parameter (no `Fn::If`, no registry-prefix math).

## Changes

- **`deploy-satellite-services.sh`**: new optional `OTEL_IMAGE` env var, forwarded as the literal `OtelImage` parameter. Unset preserves the template's public default. (Edited in `scripts-src/parts/`, regenerated single-file driver.)
- **`image_manifest.py`** + test: emits the upstream image list; `build.sh` writes `generated-templates/satellite-images.txt` (currently the one otel collector image).
- **`docs/air-gapped-images.md`**: image list, skopeo mirror loop, `OTEL_IMAGE` usage.
- **`CHANGELOG.md`**: `v0.0.125`.

The template and `images.py` are unchanged.

## Testing

- `make build` — clean (cfn-lint passes; `satellite-images.txt` emitted).
- `make test` — 482 passed, 1 skipped (incl. deploy-driver drift + shellcheck lint).
- Verified behaviorally: `OTEL_IMAGE` set → `OtelImage=<uri>` in change-set params; unset → omitted.

## Scope

Phase 1 = satellite only. Phase 2 (main lakerunner stack + busybox/grafana utility images) is deferred to a later PR; see the spec/plan under `docs/superpowers/`.