### PR TITLE
satellite: lock collector image in driver (IMAGE_REGISTRY), optional STACK_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.126
+
+- **Satellite collector image is now locked in the deploy driver; operators
+  supply only a registry prefix.** `deploy-satellite-services.sh` no longer
+  takes a full `OTEL_IMAGE` URI (the v0.0.125 input). Instead set `IMAGE_REGISTRY`
+  to your registry/pull-through-cache root (default `public.ecr.aws`); the
+  collector repo path and pinned tag/digest are baked into the published driver
+  and only the prefix is operator-supplied. Example:
+  `IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public`. See
+  `docs/air-gapped-images.md` (includes the first-pull IAM note for ECR
+  pull-through). **Upgrade action:** anyone who set `OTEL_IMAGE` (only available
+  in v0.0.125) must switch to `IMAGE_REGISTRY`.
+- **`VERSION` is now optional, renamed `STACK_VERSION`.** The published driver
+  defaults to the version baked into it at publish time, so it deploys its own
+  matching templates. Set `STACK_VERSION` to target a different published
+  version. `VERSION` is still accepted as a legacy alias, so existing automation
+  keeps working. **Upgrade action:** none required.
+- **otel collector image is digest-pinned.** `cardinal-defaults.yaml` now pins
+  `cardinalhq-otel-collector:v1.8.0@sha256:9906…` (multi-arch index digest),
+  which flows into the template default and `satellite-images.txt`. No resource
+  replacement.
+
 ## v0.0.125
 
 - **Air-gapped image mirroring for the satellite collector.** A generated

--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ echo "Generating cardinal-satellite-services.yaml..."
 python3 -m cardinal_cfn.satellite_services > generated-templates/cardinal-satellite-services.yaml
 
 echo "Generating satellite-images.txt..."
-python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
+python3 -m cardinal_cfn.image_manifest manifest satellite > generated-templates/satellite-images.txt
 
 echo "Generating cardinal-lakerunner-infra-rds.yaml..."
 python3 -m cardinal_cfn.lakerunner_infra_rds > generated-templates/cardinal-lakerunner-infra-rds.yaml

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -35,7 +35,7 @@ storage_profiles:
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0"
-  otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0"
+  otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"

--- a/docs/air-gapped-images.md
+++ b/docs/air-gapped-images.md
@@ -2,54 +2,86 @@
 
 Air-gapped installs cannot pull container images from the public registries.
 This page lists the images each Cardinal stack runs and shows how to point the
-stack at a private mirror.
+deploy driver at a private mirror.
 
-> Scope: this covers the **satellite** stack (`cardinal-satellite-services`).
-> The central Lakerunner stack's images are covered in a later release.
+> Scope: this covers the **satellite** stack (`cardinal-satellite-services`),
+> deployed via `deploy-satellite-services.sh`. The central Lakerunner stack's
+> images are covered in a later release.
+
+## How image selection works
+
+The deploy driver, not the operator, owns the image identity. The collector's
+repository path and pinned tag/digest are **baked into the published driver**
+(single-sourced from `cardinal-defaults.yaml`); the operator supplies only the
+registry/prefix to pull from. This keeps the driver + stack the supported,
+version-locked deploy path — there is no per-image URL to hand-edit and no
+console deploy.
+
+The image the driver deploys is:
+
+```
+${IMAGE_REGISTRY}/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906…
+```
+
+- `IMAGE_REGISTRY` — operator-supplied registry/prefix. Default: `public.ecr.aws`.
+- the rest (repo path + pinned tag + digest) — locked in the driver.
 
 ## Images the satellite stack runs
 
 The satellite collector runs a single container image. The canonical,
-machine-readable list is generated at build time:
+digest-pinned, machine-readable list is generated at build time:
 
 `generated-templates/satellite-images.txt`
 
-For the current release that is:
+For the current release:
 
-- `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0` — the otel
-  collector that receives telemetry and writes to the satellite raw bucket.
+- `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151`
+  — the otel collector that receives telemetry and writes to the satellite raw
+  bucket. (Multi-arch index digest; the collector task runs ARM64.)
 
-This file always lists the upstream public references — the images to pull,
-scan, and mirror *from* — regardless of which image you actually deploy.
+This file always lists the upstream public reference — the image to pull, scan,
+and mirror *from* — regardless of `IMAGE_REGISTRY`.
 
 ## Mirroring
 
-Pull the image listed in `satellite-images.txt`, scan it, and push it into
-your private registry. For example, with
-[skopeo](https://github.com/containers/skopeo) and a mirror prefix of
-`mirror.corp/cardinal`:
+### Option A — ECR pull-through cache (recommended)
+
+Create a pull-through cache rule for ECR Public, then point `IMAGE_REGISTRY` at
+the cache root. ECR preserves the full upstream path and digest, so the locked
+suffix resolves unchanged:
 
 ```sh
-PREFIX=mirror.corp/cardinal
-while read -r img; do
-  name=${img##*/}                     # cardinalhq-otel-collector:v1.8.0
-  skopeo copy "docker://${img}" "docker://${PREFIX}/${name}"
-done < generated-templates/satellite-images.txt
+aws ecr create-pull-through-cache-rule \
+  --ecr-repository-prefix aws-public \
+  --upstream-registry-url public.ecr.aws
+
+IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public
+# -> <acct>.dkr.ecr.<region>.amazonaws.com/aws-public/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906…
 ```
 
-## Pointing the stack at your mirror
+Note: on the *first* pull of a not-yet-cached image, the ECS task **execution
+role** needs `ecr:BatchImportUpstreamImage` (and repository auto-creation:
+`ecr:CreateRepository` on the principal or a registry repository-creation
+template) in addition to the usual pull permissions. Once cached, standard pull
+permissions suffice.
 
-Image selection lives in the deploy script, not the CloudFormation template:
-the template takes a literal `OtelImage` parameter, and
-`deploy-satellite-services.sh` passes whatever you choose.
+### Option B — manual mirror
 
-Set `OTEL_IMAGE` to the full URI of your mirrored image when running the
-deploy script:
+Pull each image in `satellite-images.txt`, scan it, and push it into your
+registry preserving the repo path and digest (e.g. with skopeo). Then set
+`IMAGE_REGISTRY` to your registry root.
+
+## Deploying from the mirror
 
 ```sh
-OTEL_IMAGE=mirror.corp/cardinal/cardinalhq-otel-collector:v1.8.0 \
-  STACK_NAME=... REGION=... VERSION=... \
+IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public \
+  STACK_NAME=... REGION=... \
   ./scripts/deploy-satellite-services.sh
 ```
 
-Leave `OTEL_IMAGE` unset to pull the template's public default.
+Leave `IMAGE_REGISTRY` unset to pull from the public default.
+
+`STACK_VERSION` is optional and defaults to the version baked into the driver at
+publish time, so a published driver deploys its own matching templates. Set
+`STACK_VERSION` to deploy a different published version. (`VERSION` is accepted
+as a legacy alias.)

--- a/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
+++ b/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
@@ -73,10 +73,33 @@ pytest, shellcheck, cfn-lint.
 
 ---
 
+## v0.0.126 rework (locked image + STACK_VERSION) — DONE
+
+Superseded the v0.0.125 `OTEL_IMAGE` full-URI passthrough with a driver-locked
+image and an optional baked `STACK_VERSION`.
+
+- [x] **Pin the otel digest** in `cardinal-defaults.yaml`
+  (`...:v1.8.0@sha256:9906…`, multi-arch index digest). Flows into the template
+  default + manifest (single source).
+- [x] **`image_manifest.py`**: subcommands `manifest <stack>` / `suffix <key>`;
+  `image_ref` + `registry_relative` helpers; tests updated. `build.sh` uses
+  `manifest satellite`.
+- [x] **`scripts-src/build.sh`**: bake `@@STACK_VERSION@@` (`${CARDINAL_VERSION:-dev}`)
+  and `@@OTEL_IMAGE_SUFFIX@@` (`image_manifest suffix otel`) into generated
+  drivers via `sed`.
+- [x] **`deploy-satellite-services.sh` front-half**: replace `OTEL_IMAGE` with
+  `IMAGE_REGISTRY` (default `public.ecr.aws`) composing the baked suffix into a
+  literal `OtelImage`; `VERSION` -> optional `STACK_VERSION` (baked default,
+  `VERSION` legacy alias). Regenerated; drift + shellcheck green.
+- [x] **Docs/changelog**: `docs/air-gapped-images.md` (IMAGE_REGISTRY + ECR
+  pull-through + first-pull IAM note), `CHANGELOG.md` `v0.0.126`.
+- [x] **Verify**: `make build` (digest-pinned manifest, cfn-lint clean),
+  `make test` (487 passed, 1 skipped), behavioral front-half check.
+
 ## Phase 2 (later PR, not built here)
 
-Extend the script-driven override + manifest to the main lakerunner stack
-(`lakerunner`, `maestro`, `dex`), handle the two utility images
+Extend the locked-suffix + `IMAGE_REGISTRY` baking + manifest to the main
+lakerunner stack (`lakerunner`, `maestro`, `dex`), handle the two utility images
 (`busybox`/`dex_init`, `initcontainer-grafana`/`db_init` — the psql step can't
 be dropped without a binary change), and extend the manifest/doc to all six
 images.

--- a/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
+++ b/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
@@ -3,145 +3,119 @@
 Date: 2026-06-04
 Status: implemented (Phase 1; Phase 2 deferred to a later PR)
 
-Note: this spec was simplified during implementation. The original draft put a
-three-way `ImageRegistry`/`Fn::If` resolver inside the CloudFormation template;
-the final design moves image selection into the deploy script and keeps the
-template a plain literal parameter. See "Design" below for what was built.
+This design evolved across two releases:
+
+- **v0.0.125** introduced a generated image manifest and a full-URI `OTEL_IMAGE`
+  passthrough on the deploy driver (template stays a literal `OtelImage` param).
+- **v0.0.126** (current) locked the image identity into the driver: the
+  collector repo path + pinned tag/digest are baked at publish time, and the
+  operator supplies only `IMAGE_REGISTRY` (a registry/pull-through prefix). The
+  driver also made the stack version optional (`STACK_VERSION`, baked default).
+
+The sections below describe the v0.0.126 end state.
 
 ## Problem
 
-Air-gapped customers cannot pull our container images from the public
-registries (`public.ecr.aws`, `ghcr.io`). They need two things:
-
-1. A way to point the stack at their own private mirror instead of the public
-   registries.
-2. A concrete, machine-readable list of every image a stack runs, so their
-   security team can mirror and scan each image before allowing it into the
-   private registry.
+Air-gapped customers cannot pull container images from the public registries
+(`public.ecr.aws`, `ghcr.io`). They need (1) to point the deploy at a private
+mirror, and (2) a concrete, machine-readable list of every image a stack runs
+so their security team can mirror and scan it. The supported deploy path is the
+driver + stack (no CloudFormation console), so the driver is where image and
+version selection live.
 
 ## Scope
 
-This work is split into two phases. **This spec covers Phase 1 only.**
-
-- **Phase 1 (this PR): satellite stack/script.** The satellite is the smallest,
-  self-contained surface: `satellite_services.py` runs exactly one container
-  image (the otel collector); `satellite_infra_base.py` runs no containers
-  (IAM/S3/SQS only). Phase 1 establishes the script-driven override pattern and
-  the manifest generator against this small surface.
-- **Phase 2 (later PR, out of scope here): the main lakerunner stack.** Extend
-  the same script-driven override + manifest to `lakerunner_services.py`
-  (lakerunner/maestro/dex) and decide the handling of the two utility images
-  (`busybox`/`dex_init` and `initcontainer-grafana`/`db_init`). Phase 2 notes
-  are recorded at the end so the decisions are not lost; nothing in Phase 2 is
-  built now.
+- **Phase 1 (done): satellite.** `satellite_services.py` runs one image (the
+  otel collector); `satellite_infra_base.py` runs none. The driver
+  `deploy-satellite-services.sh` owns selection.
+- **Phase 2 (later PR): the main lakerunner stack** (lakerunner/maestro/dex +
+  the busybox/grafana utility images). Notes preserved at the end.
 
 ## Decisions
 
-- **The deploy script selects the image; the template takes it as a literal.**
-  `deploy-satellite-services.sh` accepts an optional `OTEL_IMAGE` full-URI
-  environment variable and passes it through as the literal `OtelImage`
-  CloudFormation parameter. The template is unchanged — `OtelImage` is the
-  plain pass-through parameter it already was, defaulting to the public image.
-  No registry-prefix math, no `Fn::If`, no conditions in the template.
-- **Why a full-URI passthrough rather than a registry prefix:** the satellite
-  runs exactly one image, so a single `OTEL_IMAGE` value is exactly as
-  ergonomic as a prefix, with far less machinery. A registry-prefix knob only
-  earns its keep across many images (Phase 2), where the script can derive
-  per-image suffixes from the generated manifest.
-- **The manifest is the upstream source list.** It always lists the public
-  upstream image reference (what to pull/scan/mirror *from*), regardless of
-  what the operator deploys. Phase 1 lists satellite images only (the otel
-  collector).
+- **The driver locks the image identity; the operator supplies only a registry
+  prefix.** The collector's registry-relative path + pinned tag/digest
+  (`cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:…`) is baked into the
+  published driver from `cardinal-defaults.yaml`. The operator sets
+  `IMAGE_REGISTRY` (default `public.ecr.aws`); the driver composes
+  `${IMAGE_REGISTRY}/<locked-suffix>` and passes it as the literal `OtelImage`
+  parameter. This suits ECR pull-through caches, which preserve the full
+  upstream path and digest under a prefix.
+- **The image is digest-pinned.** `cardinal-defaults.yaml` pins the multi-arch
+  index digest; it flows into the template default and the manifest, so the
+  template, manifest, and driver are single-sourced.
+- **`STACK_VERSION` is optional, baked.** The published driver defaults to the
+  version baked at publish time (deploying its own matching templates).
+  `VERSION` remains a legacy alias.
+- **Manifest is the upstream source list** — the public, pinned reference to
+  mirror/scan FROM, independent of `IMAGE_REGISTRY`. Phase 1 lists satellite
+  images only.
 
 ## Design
 
-### 1. Image selection in the deploy script
+### 1. Build-time baking (one mechanism)
 
-`scripts-src/parts/deploy-satellite-services.sh` (the front-half source for the
-generated single-file driver `scripts/deploy-satellite-services.sh`) gains an
-optional `OTEL_IMAGE` input:
+`scripts-src/build.sh` substitutes two placeholders into each generated driver:
 
-- Documented in the script's `usage()` under Optional inputs.
-- Added to the input-echo diagnostic loop.
-- When set, appends `OtelImage=$OTEL_IMAGE` to the `PARAMS` list the engine
-  passes to `create-change-set`. When unset, no `OtelImage` override is sent and
-  the engine falls back to the template's `Default` (the public image).
+- `@@STACK_VERSION@@` -> `${CARDINAL_VERSION:-dev}` (the release tag; `dev`
+  locally — so committed drivers carry `dev`, published drivers carry the tag).
+- `@@OTEL_IMAGE_SUFFIX@@` -> `python3 -m cardinal_cfn.image_manifest suffix otel`
+  (the otel image's registry-relative path from `cardinal-defaults.yaml`).
 
-The driver is regenerated with `make scripts`; `tests/unit/test_deploy_stack_lint.py`
-asserts the generated copy matches a fresh build (drift gate), and the script
-passes shellcheck.
+The release already runs `./build.sh` with `CARDINAL_VERSION` set and publishes
+`scripts/` to S3, so published drivers are version- and image-locked.
+`tests/unit/test_deploy_stack_lint.py` asserts the committed drivers match a
+fresh build (drift gate) and pass shellcheck.
 
-No change to `satellite_services.py` or `images.py`: the template already
-declares `OtelImage` as a literal pass-through parameter (`add_image_override`).
+### 2. Driver front-half (`deploy-satellite-services.sh`)
 
-### 2. Image manifest generator
+- `STACK_VERSION` (optional) -> `${STACK_VERSION:-${VERSION:-<baked>}}`; used in
+  `TEMPLATE_URL`. `VERSION` no longer required.
+- `IMAGE_REGISTRY` (optional, default `public.ecr.aws`) + baked suffix ->
+  `OtelImage=${IMAGE_REGISTRY}/<suffix>`, always passed as a `PARAMS` override.
+- `usage()`, the input-echo loop, and resolved-value diagnostics updated.
 
-`src/cardinal_cfn/image_manifest.py` reads the `images:` block from
-`cardinal-defaults.yaml` and emits a newline-delimited, sorted, deduped list of
-full upstream image references for a given stack. It carries a stack ->
-image-keys mapping; Phase 1 registers `satellite -> ["otel"]` (Phase 2 adds the
-lakerunner stack's keys).
+No change to `satellite_services.py` (it already declares `OtelImage` as a
+literal param; its default now carries the pinned digest via defaults).
 
-`build.sh` emits the satellite manifest after generating the satellite-services
-template:
+### 3. Manifest generator (`image_manifest.py`)
 
-```
-python3 -m cardinal_cfn.image_manifest satellite > generated-templates/satellite-images.txt
-```
+- `manifest <stack>` — sorted/deduped upstream refs for a stack
+  (`satellite -> ["otel"]`). `build.sh` writes `satellite-images.txt`.
+- `suffix <image-key>` — the image's registry-relative path (everything after
+  the registry host), used by `scripts-src/build.sh` to bake the driver.
+- `image_ref(key)` / `registry_relative(ref)` helpers; all read the pinned
+  `cardinal-defaults.yaml`.
 
-For Phase 1 `satellite-images.txt` contains exactly:
+### 4. Docs + changelog
 
-```
-public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0
-```
-
-The manifest reflects the upstream public reference, never the operator's
-override — it is the list to mirror *from*. (`generated-templates/` is
-gitignored; the manifest is a build artifact, published alongside templates.)
-
-### 3. Documentation
-
-`docs/air-gapped-images.md` (Phase-1 scope): states the satellite collector
-runs a single image and points at `satellite-images.txt`; shows a skopeo mirror
-loop; and documents setting `OTEL_IMAGE` on the deploy script to deploy the
-mirrored image (unset = public default). Notes the central lakerunner stack's
-images are covered in a later release.
-
-### 4. Changelog
-
-`CHANGELOG.md` entry (`v0.0.125`): the generated `satellite-images.txt`; the
-`OTEL_IMAGE` deploy-script input that maps to the literal `OtelImage` param;
-unset preserves the public default; no resource replacement; upgrade action =
-none unless mirroring.
+`docs/air-gapped-images.md`: how selection works, the pinned image list, an ECR
+pull-through example (with the first-pull IAM note), and `IMAGE_REGISTRY` /
+`STACK_VERSION` usage. `CHANGELOG.md` `v0.0.126`.
 
 ## Testing
 
-- **Unit -- manifest:** `image_manifest.manifest_lines("satellite")` equals
-  `[cardinal-defaults.yaml images.otel]`; an unknown stack raises `ValueError`.
-- **Drift + lint:** the regenerated `deploy-satellite-services.sh` matches a
-  fresh `make scripts` build and passes shellcheck (existing
-  `test_deploy_stack_lint.py`).
-- **Build:** `make build` emits `generated-templates/satellite-images.txt` and
-  cfn-lint stays clean.
-- The front-half's `OTEL_IMAGE -> OtelImage=` mapping is verified behaviorally
-  (run the front-half with the engine stubbed); the combined single-file driver
-  rejects arguments, so the engine's internal test hooks cannot be reached
-  through it — matching the repo's existing approach of linting the front-half
-  rather than unit-testing its env→PARAMS assembly.
+- **Unit (`image_manifest`):** manifest equals the pinned otel default; unknown
+  stack/key raise; `registry_relative` strips the registry host and requires
+  one; otel suffix equals the default minus its registry.
+- **Drift + lint:** committed `deploy-satellite-services.sh` matches a fresh
+  `make scripts` build (which bakes `dev` + the pinned suffix) and passes
+  shellcheck.
+- **Build:** `make build` emits a digest-pinned `satellite-images.txt`; the
+  template `OtelImage` default carries the digest; cfn-lint clean.
+- **Behavioral:** front-half (engine stubbed) composes
+  `OtelImage=${IMAGE_REGISTRY}/<pinned-suffix>` and resolves `STACK_VERSION`
+  (default baked, `VERSION` alias honored). The combined driver rejects
+  arguments, so the engine's internal hooks can't be reached through it —
+  matching the repo's lint-the-front-half approach.
 
 ## Phase 2 notes (not built in this PR)
 
-- Extend `OTEL_IMAGE`-style passthrough (or a registry prefix that flattens via
-  the manifest) to the main lakerunner stack's first-party images
-  (`lakerunner`, `maestro`, `dex`), and extend the manifest generator
-  (`lakerunner -> [...]`) and `docs/air-gapped-images.md` to all six images.
-- **Utility images** in the main stack: `dex_init` (busybox
-  `public.ecr.aws/docker/library/busybox:1.37`, used purely as a shell to
-  render the dex config) and `db_init`
-  (`ghcr.io/cardinalhq/initcontainer-grafana:latest`, repurposed as a psql
-  client for two `CREATE DATABASE` calls + a keepalive sleeper). The lakerunner
-  `migrate` command connects to an already-existing database and does not
-  create it, so the psql step cannot be dropped without a change in the
-  `lakerunner`/`maestro` binaries. `db_init` is intentionally left as-is for now
-  (the `:latest` mutable tag and the "grafana" misnomer/registry mismatch with
-  the charts are known and will be revisited).
+Extend the locked-suffix + `IMAGE_REGISTRY` baking and the manifest to the main
+lakerunner stack's first-party images (`lakerunner`, `maestro`, `dex`). Utility
+images: `dex_init` (busybox, a shell to render the dex config) and `db_init`
+(`initcontainer-grafana`, a psql client for two `CREATE DATABASE` calls + a
+keepalive sleeper). The lakerunner `migrate` command connects to an existing
+database and does not create it, so the psql step can't be dropped without a
+binary change. `db_init` is left as-is for now (`:latest` + the grafana
+misnomer/registry mismatch are known and will be revisited).

--- a/scripts-src/build.sh
+++ b/scripts-src/build.sh
@@ -12,12 +12,27 @@ set -eu
 
 src_dir=$(cd -- "$(dirname -- "$0")" >/dev/null 2>&1 && pwd)
 parts_dir="$src_dir/parts"
+repo_root=$(cd -- "$src_dir/.." >/dev/null 2>&1 && pwd)
 # OUT_DIR overrides the destination (the drift test builds into a temp dir);
 # default is the customer-facing scripts/ at the repo root.
-out_dir="${OUT_DIR:-$(cd -- "$src_dir/.." >/dev/null 2>&1 && pwd)/scripts}"
+out_dir="${OUT_DIR:-$repo_root/scripts}"
 
 base="$parts_dir/base.sh"
 [ -r "$base" ] || { echo "build.sh: missing engine part: $base" >&2; exit 1; }
+
+# Values baked into the generated drivers so each published driver is a
+# self-contained, version-locked unit.  Single-sourced from
+# cardinal-defaults.yaml and the build's release version:
+#   @@STACK_VERSION@@      the published version this driver defaults to
+#                          (CARDINAL_VERSION at release time; "dev" locally).
+#   @@OTEL_IMAGE_SUFFIX@@  the otel collector's registry-relative path
+#                          (repo + pinned tag/digest); only the registry prefix
+#                          is operator-supplied at deploy time.
+stack_version="${CARDINAL_VERSION:-dev}"
+py="python3"
+[ -x "$repo_root/.venv/bin/python3" ] && py="$repo_root/.venv/bin/python3"
+otel_image_suffix=$(PYTHONPATH="$repo_root/src" "$py" -m cardinal_cfn.image_manifest suffix otel)
+[ -n "$otel_image_suffix" ] || { echo "build.sh: failed to resolve otel image suffix" >&2; exit 1; }
 
 for fragment in "$parts_dir"/*.sh; do
     name=$(basename "$fragment")
@@ -29,7 +44,10 @@ for fragment in "$parts_dir"/*.sh; do
         tail -n +2 "$fragment"
         printf '\n# --- embedded engine (scripts-src/parts/base.sh) ---\n'
         tail -n +2 "$base"
-    } >"$out"
+    } | sed \
+        -e "s|@@STACK_VERSION@@|$stack_version|g" \
+        -e "s|@@OTEL_IMAGE_SUFFIX@@|$otel_image_suffix|g" \
+        >"$out"
     chmod +x "$out"
     echo "wrote $out"
 done

--- a/scripts-src/parts/deploy-satellite-services.sh
+++ b/scripts-src/parts/deploy-satellite-services.sh
@@ -10,6 +10,12 @@
 # OTEL_REPLICAS defaults to 1 here (the collector config must change before
 # scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
 #
+# This driver is version-locked: the published template version and the otel
+# collector image (repo + pinned tag/digest) are baked in at publish time, so
+# the driver + stack are the supported deploy path (no console deploys).  The
+# operator supplies only their image registry/prefix and (optionally) a
+# different STACK_VERSION.
+#
 # Self-contained single-file driver: this front-half sets the engine env, then
 # falls through into the engine embedded below by scripts-src/build.sh (do not
 # edit the generated copy).  Pure environment-variable interface (no flags).
@@ -18,6 +24,12 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-services.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
+# Baked at publish time: the otel collector's registry-relative path (repo +
+# pinned tag/digest).  Only the registry prefix is operator-supplied.
+OTEL_IMAGE_SUFFIX="@@OTEL_IMAGE_SUFFIX@@"
+DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 
 usage() {
     cat <<EOF
@@ -28,7 +40,6 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME                  Stack to create/update.
   REGION                      AWS region (never defaulted; must be set explicitly).
-  VERSION                     Published template tag.
   SATELLITE_INFRA_BASE_STACK  Upstream satellite-infra-base (RawBucketName).
   ORGANIZATION_ID             Org UUID this satellite's telemetry is attributed to.
   VPC_ID                      VPC for the collector.
@@ -37,14 +48,19 @@ Required:
   ECS_CLUSTER_ARN             ECS cluster for the collector.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION        Published template version to deploy. Default: the
+                       version baked into this driver ($DEFAULT_STACK_VERSION).
+                       (VERSION is accepted as a legacy alias.)
+  IMAGE_REGISTRY       Registry (and optional namespace/prefix) the collector
+                       image is pulled from -- e.g. an ECR pull-through cache
+                       root like <acct>.dkr.ecr.<region>.amazonaws.com/aws-public.
+                       The image path and pinned tag/digest are locked into this
+                       driver; only this prefix is operator-supplied.
+                       Default: $DEFAULT_IMAGE_REGISTRY (the public registry).
   ALB_SCHEME           internet-facing | internal (default internal).
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
-  OTEL_IMAGE           Full image URI for the otel collector (e.g. an
-                       air-gapped private mirror). Unset: the template's public
-                       default. The public image to mirror is listed in
-                       satellite-images.txt (see docs/air-gapped-images.md).
   TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN    Passed to create-change-set.
   NO_EXECUTE           Non-empty: change-set only, do not execute.
@@ -57,23 +73,30 @@ case "${1:-}" in
     *) echo "[deploy-satellite-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
 esac
 
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
+# IMAGE_REGISTRY prefix + the baked, locked image path -> the literal OtelImage.
+image_registry="${IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
+otel_image="$image_registry/$OTEL_IMAGE_SUFFIX"
+
 # Echo the inputs this script can actually see before validating, so a
 # "missing required" failure is easy to diagnose.  The usual cause is a value
 # set as a plain shell variable but not exported -- this child process then
 # never receives it, and it shows as <unset> below.
 echo "[deploy-satellite-services] inputs visible to this process:" >&2
-for _v in STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK ORGANIZATION_ID \
-          VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
-          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS OTEL_IMAGE TEMPLATE_BASE_URL \
-          DEPLOYER_ROLE_ARN NO_EXECUTE; do
+for _v in STACK_NAME REGION STACK_VERSION VERSION SATELLITE_INFRA_BASE_STACK \
+          ORGANIZATION_ID VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS IMAGE_REGISTRY \
+          TEMPLATE_BASE_URL DEPLOYER_ROLE_ARN NO_EXECUTE; do
     eval "_val=\${$_v:-}"
     printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
 done
+echo "[deploy-satellite-services]   resolved STACK_VERSION       = $stack_version" >&2
+echo "[deploy-satellite-services]   resolved OtelImage           = $otel_image" >&2
 
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
 [ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
@@ -93,7 +116,7 @@ template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 # default, governs.
 otel_replicas="${OTEL_REPLICAS:-1}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 FROM_STACKS="$SATELLITE_INFRA_BASE_STACK"
 MAPS=""
 
@@ -102,15 +125,12 @@ VpcId=$VPC_ID
 AlbSubnetsCsv=$ALB_SUBNETS
 TaskSubnetsCsv=$TASK_SUBNETS
 EcsClusterArn=$ECS_CLUSTER_ARN
-OtelReplicas=$otel_replicas"
+OtelReplicas=$otel_replicas
+OtelImage=$otel_image"
 [ -n "${ALB_SCHEME:-}" ] && params="$params
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
-# OTEL_IMAGE: full image URI override passed as the literal OtelImage param.
-# Unset -> omitted, so the template's public default governs.
-[ -n "${OTEL_IMAGE:-}" ] && params="$params
-OtelImage=$OTEL_IMAGE"
 
 PARAMS="$params"
 

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -11,6 +11,12 @@
 # OTEL_REPLICAS defaults to 1 here (the collector config must change before
 # scaling past one replica -- see docs/operations/jenkins-chained-deploy.md).
 #
+# This driver is version-locked: the published template version and the otel
+# collector image (repo + pinned tag/digest) are baked in at publish time, so
+# the driver + stack are the supported deploy path (no console deploys).  The
+# operator supplies only their image registry/prefix and (optionally) a
+# different STACK_VERSION.
+#
 # Self-contained single-file driver: this front-half sets the engine env, then
 # falls through into the engine embedded below by scripts-src/build.sh (do not
 # edit the generated copy).  Pure environment-variable interface (no flags).
@@ -19,6 +25,12 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-services.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="dev"
+# Baked at publish time: the otel collector's registry-relative path (repo +
+# pinned tag/digest).  Only the registry prefix is operator-supplied.
+OTEL_IMAGE_SUFFIX="cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
+DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 
 usage() {
     cat <<EOF
@@ -29,7 +41,6 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME                  Stack to create/update.
   REGION                      AWS region (never defaulted; must be set explicitly).
-  VERSION                     Published template tag.
   SATELLITE_INFRA_BASE_STACK  Upstream satellite-infra-base (RawBucketName).
   ORGANIZATION_ID             Org UUID this satellite's telemetry is attributed to.
   VPC_ID                      VPC for the collector.
@@ -38,14 +49,19 @@ Required:
   ECS_CLUSTER_ARN             ECS cluster for the collector.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION        Published template version to deploy. Default: the
+                       version baked into this driver ($DEFAULT_STACK_VERSION).
+                       (VERSION is accepted as a legacy alias.)
+  IMAGE_REGISTRY       Registry (and optional namespace/prefix) the collector
+                       image is pulled from -- e.g. an ECR pull-through cache
+                       root like <acct>.dkr.ecr.<region>.amazonaws.com/aws-public.
+                       The image path and pinned tag/digest are locked into this
+                       driver; only this prefix is operator-supplied.
+                       Default: $DEFAULT_IMAGE_REGISTRY (the public registry).
   ALB_SCHEME           internet-facing | internal (default internal).
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
-  OTEL_IMAGE           Full image URI for the otel collector (e.g. an
-                       air-gapped private mirror). Unset: the template's public
-                       default. The public image to mirror is listed in
-                       satellite-images.txt (see docs/air-gapped-images.md).
   TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN    Passed to create-change-set.
   NO_EXECUTE           Non-empty: change-set only, do not execute.
@@ -58,23 +74,30 @@ case "${1:-}" in
     *) echo "[deploy-satellite-services] ERROR: this script takes no arguments; configure it via environment variables" >&2; usage >&2; exit 2 ;;
 esac
 
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
+# IMAGE_REGISTRY prefix + the baked, locked image path -> the literal OtelImage.
+image_registry="${IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
+otel_image="$image_registry/$OTEL_IMAGE_SUFFIX"
+
 # Echo the inputs this script can actually see before validating, so a
 # "missing required" failure is easy to diagnose.  The usual cause is a value
 # set as a plain shell variable but not exported -- this child process then
 # never receives it, and it shows as <unset> below.
 echo "[deploy-satellite-services] inputs visible to this process:" >&2
-for _v in STACK_NAME REGION VERSION SATELLITE_INFRA_BASE_STACK ORGANIZATION_ID \
-          VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
-          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS OTEL_IMAGE TEMPLATE_BASE_URL \
-          DEPLOYER_ROLE_ARN NO_EXECUTE; do
+for _v in STACK_NAME REGION STACK_VERSION VERSION SATELLITE_INFRA_BASE_STACK \
+          ORGANIZATION_ID VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS IMAGE_REGISTRY \
+          TEMPLATE_BASE_URL DEPLOYER_ROLE_ARN NO_EXECUTE; do
     eval "_val=\${$_v:-}"
     printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
 done
+echo "[deploy-satellite-services]   resolved STACK_VERSION       = $stack_version" >&2
+echo "[deploy-satellite-services]   resolved OtelImage           = $otel_image" >&2
 
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
 [ -z "${ORGANIZATION_ID:-}" ] && missing="$missing ORGANIZATION_ID"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
@@ -94,7 +117,7 @@ template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 # default, governs.
 otel_replicas="${OTEL_REPLICAS:-1}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 FROM_STACKS="$SATELLITE_INFRA_BASE_STACK"
 MAPS=""
 
@@ -103,15 +126,12 @@ VpcId=$VPC_ID
 AlbSubnetsCsv=$ALB_SUBNETS
 TaskSubnetsCsv=$TASK_SUBNETS
 EcsClusterArn=$ECS_CLUSTER_ARN
-OtelReplicas=$otel_replicas"
+OtelReplicas=$otel_replicas
+OtelImage=$otel_image"
 [ -n "${ALB_SCHEME:-}" ] && params="$params
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
-# OTEL_IMAGE: full image URI override passed as the literal OtelImage param.
-# Unset -> omitted, so the template's public default governs.
-[ -n "${OTEL_IMAGE:-}" ] && params="$params
-OtelImage=$OTEL_IMAGE"
 
 PARAMS="$params"
 

--- a/src/cardinal_cfn/image_manifest.py
+++ b/src/cardinal_cfn/image_manifest.py
@@ -1,9 +1,11 @@
-"""Image manifest generator.
+"""Image manifest + image-reference helpers.
 
-Emits the upstream public container images a given stack runs, one per line,
-sorted and deduped. This is the source list air-gapped customers mirror and
-scan FROM; it always reflects the public defaults in cardinal-defaults.yaml,
-never a customer's overridden image.
+`manifest <stack>` emits the upstream public container images a stack runs, one
+per line, sorted and deduped -- the source list air-gapped customers mirror and
+scan FROM. `suffix <key>` emits an image's registry-relative path (everything
+after the registry host), which the deploy drivers bake in so only the registry
+prefix is operator-supplied. Both read the pinned defaults in
+cardinal-defaults.yaml, so there is a single source of truth for image refs.
 """
 
 import sys
@@ -17,26 +19,52 @@ STACK_IMAGE_KEYS = {
 }
 
 
+def image_ref(key: str) -> str:
+    """Return the full pinned image reference for an images.* key."""
+    images = load_defaults()["images"]
+    if key not in images:
+        known = ", ".join(sorted(images))
+        raise ValueError(f"unknown image key: {key!r} (known: {known})")
+    return images[key]
+
+
+def registry_relative(ref: str) -> str:
+    """Return the registry-relative path of an image reference.
+
+    Everything after the registry host (the first '/'). The drivers bake this
+    so the operator supplies only the registry/prefix:
+
+        public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:...
+            -> cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:...
+    """
+    if "/" not in ref:
+        raise ValueError(f"image reference has no registry component: {ref!r}")
+    return ref.split("/", 1)[1]
+
+
 def manifest_lines(stack: str) -> list:
     """Return the sorted, deduped upstream image refs for a stack."""
     if stack not in STACK_IMAGE_KEYS:
         known = ", ".join(sorted(STACK_IMAGE_KEYS))
         raise ValueError(f"unknown stack: {stack!r} (known: {known})")
-    images = load_defaults()["images"]
-    refs = {images[key] for key in STACK_IMAGE_KEYS[stack]}
+    refs = {image_ref(key) for key in STACK_IMAGE_KEYS[stack]}
     return sorted(refs)
 
 
 def main(argv: list) -> int:
-    if len(argv) != 1:
-        print(
-            "usage: python3 -m cardinal_cfn.image_manifest <stack>",
-            file=sys.stderr,
-        )
-        return 2
-    for line in manifest_lines(argv[0]):
-        print(line)
-    return 0
+    if len(argv) == 2 and argv[0] == "manifest":
+        for line in manifest_lines(argv[1]):
+            print(line)
+        return 0
+    if len(argv) == 2 and argv[0] == "suffix":
+        print(registry_relative(image_ref(argv[1])))
+        return 0
+    print(
+        "usage: python3 -m cardinal_cfn.image_manifest manifest <stack>\n"
+        "       python3 -m cardinal_cfn.image_manifest suffix <image-key>",
+        file=sys.stderr,
+    )
+    return 2
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_image_manifest.py
+++ b/tests/unit/test_image_manifest.py
@@ -1,4 +1,4 @@
-"""Tests for the image manifest generator."""
+"""Tests for the image manifest + image-reference helpers."""
 
 import pytest
 
@@ -15,3 +15,29 @@ def test_satellite_manifest_is_otel_image():
 def test_unknown_stack_raises():
     with pytest.raises(ValueError):
         image_manifest.manifest_lines("nope")
+
+
+def test_image_ref_returns_pinned_default():
+    assert image_manifest.image_ref("otel") == load_defaults()["images"]["otel"]
+
+
+def test_image_ref_unknown_key_raises():
+    with pytest.raises(ValueError):
+        image_manifest.image_ref("nope")
+
+
+def test_registry_relative_strips_registry_host():
+    ref = "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:abc"
+    assert image_manifest.registry_relative(ref) == (
+        "cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:abc"
+    )
+
+
+def test_registry_relative_requires_registry():
+    with pytest.raises(ValueError):
+        image_manifest.registry_relative("busybox:1.37")
+
+
+def test_otel_suffix_matches_default_minus_registry():
+    otel = load_defaults()["images"]["otel"]
+    assert image_manifest.registry_relative(otel) == otel.split("/", 1)[1]


### PR DESCRIPTION
## Summary

Reworks satellite air-gapped image handling (follow-up to #191 / v0.0.125) so the **driver + stack are the version-locked, supported deploy path** — no per-image URL editing, no console deploy.

- **Image locked in the driver.** The collector's repo path + pinned tag/digest (`cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906…`) is baked into the published driver from `cardinal-defaults.yaml`. The operator sets only `IMAGE_REGISTRY` (default `public.ecr.aws`); the driver composes `${IMAGE_REGISTRY}/<locked-suffix>` → literal `OtelImage`. Suited to ECR pull-through caches (path + digest preserved). Replaces the v0.0.125 full-URI `OTEL_IMAGE`.
- **`VERSION` → optional `STACK_VERSION`**, defaulting to the version baked at publish time (driver deploys its own matching templates). `VERSION` kept as a legacy alias.
- **Digest-pinned** otel image (multi-arch index digest) in defaults → flows into the template default and `satellite-images.txt`.

## Mechanism

`scripts-src/build.sh` substitutes `@@STACK_VERSION@@` (`${CARDINAL_VERSION:-dev}`) and `@@OTEL_IMAGE_SUFFIX@@` (`image_manifest suffix otel`) into generated drivers. The release already runs `./build.sh` with `CARDINAL_VERSION` set and publishes `scripts/`, so published drivers are version- and image-locked. Committed drivers carry `dev` + the pinned suffix; the drift lint enforces it.

## Testing

- `make build` — digest-pinned `satellite-images.txt`; template `OtelImage` default carries the digest; cfn-lint clean.
- `make test` — 487 passed, 1 skipped (incl. deploy-driver drift + shellcheck).
- Behavioral: front-half composes `OtelImage=${IMAGE_REGISTRY}/<pinned-suffix>` and resolves `STACK_VERSION` (baked default; `VERSION` alias honored).

## Upgrade action

Anyone who set `OTEL_IMAGE` (only in v0.0.125) switches to `IMAGE_REGISTRY`. `VERSION` automation keeps working.

See `docs/air-gapped-images.md` (incl. the ECR pull-through first-pull IAM note) and the updated spec/plan under `docs/superpowers/`.