### PR TITLE
lock images + STACK_VERSION across all deploy drivers (Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.127
+
+- **The locked-image + registry-prefix model now covers all stacks.** Following
+  the satellite work in v0.0.126, `deploy-lakerunner-services.sh` no longer takes
+  per-image `LAKERUNNER_IMAGE` / `MAESTRO_IMAGE` / `DEX_IMAGE` / `OTEL_IMAGE`
+  overrides. The lakerunner, maestro, and dex images (our public ECR) are now
+  baked (repo path + pinned digest) into the driver; set `IMAGE_REGISTRY` to
+  your registry/pull-through-cache root to redirect all three with one knob
+  (default `public.ecr.aws`). **Upgrade action:** anyone setting those per-image
+  vars switches to `IMAGE_REGISTRY`.
+- **External/utility images stay as explicit overrides.** busybox (dex-init) and
+  the ghcr `initcontainer-grafana` (db-init) are not on our public ECR and are
+  not governed by `IMAGE_REGISTRY`; mirror them via `DEX_INIT_IMAGE` /
+  `DB_INIT_IMAGE` as before.
+- **`VERSION` is now optional (`STACK_VERSION`) on every deploy driver**
+  (`infra-base`, `infra-rds`, `services`, `satellite-infra-base`,
+  `satellite-services`). Each published driver defaults to the version baked
+  into it at publish time, so it deploys its own matching templates. `VERSION`
+  remains a legacy alias. **Upgrade action:** none required.
+- **lakerunner, maestro, dex are digest-pinned** in `cardinal-defaults.yaml`
+  (multi-arch index digests), flowing into the template defaults. A new
+  `lakerunner-images.txt` (in `generated-templates/`) lists the full
+  mirror/scan surface for the application stack. No resource replacement.
+
 ## v0.0.126
 
 - **Satellite collector image is now locked in the deploy driver; operators

--- a/build.sh
+++ b/build.sh
@@ -50,6 +50,9 @@ python3 -m cardinal_cfn.lakerunner_infra_base > generated-templates/cardinal-lak
 echo "Generating cardinal-lakerunner-services.yaml (param-driven root)..."
 python3 -m cardinal_cfn.lakerunner_services > generated-templates/cardinal-lakerunner-services.yaml
 
+echo "Generating lakerunner-images.txt..."
+python3 -m cardinal_cfn.image_manifest manifest lakerunner > generated-templates/lakerunner-images.txt
+
 for child in alb cert migration \
              services_query services_process services_control maestro; do
   out_name=$(echo "$child" | tr '_' '-')

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,10 +33,10 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0@sha256:642e93afbbf846535923fc4ad59ea790fd0aff85cc6889355e866ab883da5001"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
-  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0"
+  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0@sha256:a1d0af5a99068516df067af803312c03b62b1bd07eefb16e914bd1d55deacf9c"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
 

--- a/docs/air-gapped-images.md
+++ b/docs/air-gapped-images.md
@@ -2,53 +2,60 @@
 
 Air-gapped installs cannot pull container images from the public registries.
 This page lists the images each Cardinal stack runs and shows how to point the
-deploy driver at a private mirror.
-
-> Scope: this covers the **satellite** stack (`cardinal-satellite-services`),
-> deployed via `deploy-satellite-services.sh`. The central Lakerunner stack's
-> images are covered in a later release.
+deploy drivers at a private mirror.
 
 ## How image selection works
 
-The deploy driver, not the operator, owns the image identity. The collector's
-repository path and pinned tag/digest are **baked into the published driver**
-(single-sourced from `cardinal-defaults.yaml`); the operator supplies only the
-registry/prefix to pull from. This keeps the driver + stack the supported,
-version-locked deploy path — there is no per-image URL to hand-edit and no
-console deploy.
+The deploy drivers, not the operator, own image identity. For our first-party
+images on **public ECR** (`public.ecr.aws/cardinalhq.io/*`), the repository path
+and pinned tag/digest are **baked into the published driver** (single-sourced
+from `cardinal-defaults.yaml`); the operator supplies only `IMAGE_REGISTRY` —
+the registry/prefix to pull from. The driver composes
+`${IMAGE_REGISTRY}/<locked-path>:<tag>@<digest>` and passes it as a literal
+stack parameter. This keeps the driver + stack the supported, version-locked
+deploy path (no console deploys, no hand-edited image URLs).
 
-The image the driver deploys is:
+`IMAGE_REGISTRY` defaults to `public.ecr.aws`. Point it at an ECR pull-through
+cache root (or any mirror that preserves the upstream path) and every
+first-party image resolves under it with one knob.
 
-```
-${IMAGE_REGISTRY}/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906…
-```
+### External / utility images are special-cased
 
-- `IMAGE_REGISTRY` — operator-supplied registry/prefix. Default: `public.ecr.aws`.
-- the rest (repo path + pinned tag + digest) — locked in the driver.
+Two images are not on our public ECR and are **not** governed by
+`IMAGE_REGISTRY`. They keep their own full-URI override env vars (default: the
+template default), so you mirror them however your registry organizes
+third-party content:
 
-## Images the satellite stack runs
+- `busybox` (`public.ecr.aws/docker/library/busybox`, the dex-init shell) —
+  override with `DEX_INIT_IMAGE`.
+- `initcontainer-grafana` (`ghcr.io/cardinalhq/...`, the db-init psql client) —
+  override with `DB_INIT_IMAGE`.
 
-The satellite collector runs a single container image. The canonical,
-digest-pinned, machine-readable list is generated at build time:
+## Image lists (mirror + scan)
 
-`generated-templates/satellite-images.txt`
+Generated at build time, one ref per line — the upstream public references to
+pull, scan, and mirror FROM (independent of `IMAGE_REGISTRY`):
 
-For the current release:
+- `generated-templates/satellite-images.txt` — the satellite stack.
+- `generated-templates/lakerunner-images.txt` — the lakerunner application stack.
 
-- `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151`
-  — the otel collector that receives telemetry and writes to the satellite raw
-  bucket. (Multi-arch index digest; the collector task runs ARM64.)
+First-party images are digest-pinned (multi-arch index digests; tasks run
+ARM64). Current refs:
 
-This file always lists the upstream public reference — the image to pull, scan,
-and mirror *from* — regardless of `IMAGE_REGISTRY`.
+| Stack | Image | IMAGE_REGISTRY? |
+|---|---|---|
+| satellite | `public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906…` | yes |
+| lakerunner | `public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4@sha256:532a…` | yes |
+| lakerunner | `public.ecr.aws/cardinalhq.io/maestro:v1.50.0@sha256:642e…` | yes |
+| lakerunner | `public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0@sha256:a1d0…` | yes |
+| lakerunner | `public.ecr.aws/docker/library/busybox:1.37` | no — `DEX_INIT_IMAGE` |
+| lakerunner | `ghcr.io/cardinalhq/initcontainer-grafana:latest` | no — `DB_INIT_IMAGE` |
 
-## Mirroring
-
-### Option A — ECR pull-through cache (recommended)
+## Mirroring with an ECR pull-through cache (recommended)
 
 Create a pull-through cache rule for ECR Public, then point `IMAGE_REGISTRY` at
 the cache root. ECR preserves the full upstream path and digest, so the locked
-suffix resolves unchanged:
+suffixes resolve unchanged:
 
 ```sh
 aws ecr create-pull-through-cache-rule \
@@ -56,22 +63,21 @@ aws ecr create-pull-through-cache-rule \
   --upstream-registry-url public.ecr.aws
 
 IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public
-# -> <acct>.dkr.ecr.<region>.amazonaws.com/aws-public/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906…
 ```
 
-Note: on the *first* pull of a not-yet-cached image, the ECS task **execution
-role** needs `ecr:BatchImportUpstreamImage` (and repository auto-creation:
-`ecr:CreateRepository` on the principal or a registry repository-creation
-template) in addition to the usual pull permissions. Once cached, standard pull
-permissions suffice.
+A single public-ECR pull-through cache covers every first-party image (and the
+busybox utility image, if you also point `DEX_INIT_IMAGE` at it). The
+`ghcr.io` db-init image needs its own mirror/rule (set `DB_INIT_IMAGE`).
 
-### Option B — manual mirror
-
-Pull each image in `satellite-images.txt`, scan it, and push it into your
-registry preserving the repo path and digest (e.g. with skopeo). Then set
-`IMAGE_REGISTRY` to your registry root.
+First-pull IAM note: on the first pull of a not-yet-cached image, the ECS task
+**execution role** needs `ecr:BatchImportUpstreamImage` plus repository
+auto-creation (`ecr:CreateRepository` on the principal, or a registry
+repository-creation template) in addition to the usual pull permissions. Once
+cached, standard pull permissions suffice.
 
 ## Deploying from the mirror
+
+Satellite:
 
 ```sh
 IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public \
@@ -79,9 +85,23 @@ IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public \
   ./scripts/deploy-satellite-services.sh
 ```
 
-Leave `IMAGE_REGISTRY` unset to pull from the public default.
+Lakerunner application stack:
 
-`STACK_VERSION` is optional and defaults to the version baked into the driver at
-publish time, so a published driver deploys its own matching templates. Set
-`STACK_VERSION` to deploy a different published version. (`VERSION` is accepted
-as a legacy alias.)
+```sh
+IMAGE_REGISTRY=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public \
+  DEX_INIT_IMAGE=<acct>.dkr.ecr.<region>.amazonaws.com/aws-public/docker/library/busybox:1.37 \
+  DB_INIT_IMAGE=<your-mirror>/initcontainer-grafana:<tag> \
+  STACK_NAME=... REGION=... INFRA_BASE_STACK=... INFRA_RDS_STACK=... \
+  SATELLITE_INFRA_BASE_STACK=... CLUSTER_ARN=... CLUSTER_NAME=... \
+  VPC_ID=... PRIVATE_SUBNETS=... ORGANIZATION_ID=... DEX_ADMIN_PASSWORD_HASH=... \
+  ./scripts/deploy-lakerunner-services.sh
+```
+
+Leave `IMAGE_REGISTRY` unset to pull first-party images from the public default.
+
+## Stack version
+
+Every deploy driver bakes its published version at publish time, so a published
+driver deploys its own matching templates. `STACK_VERSION` is optional and
+defaults to that baked version; set it to target a different published version.
+`VERSION` is accepted as a legacy alias.

--- a/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
+++ b/docs/superpowers/plans/2026-06-04-air-gapped-image-registry.md
@@ -96,10 +96,22 @@ image and an optional baked `STACK_VERSION`.
 - [x] **Verify**: `make build` (digest-pinned manifest, cfn-lint clean),
   `make test` (487 passed, 1 skipped), behavioral front-half check.
 
-## Phase 2 (later PR, not built here)
+## v0.0.127 — Phase 2 (all remaining stacks) — DONE
 
-Extend the locked-suffix + `IMAGE_REGISTRY` baking + manifest to the main
-lakerunner stack (`lakerunner`, `maestro`, `dex`), handle the two utility images
-(`busybox`/`dex_init`, `initcontainer-grafana`/`db_init` — the psql step can't
-be dropped without a binary change), and extend the manifest/doc to all six
-images.
+- [x] **Pin digests** for lakerunner/maestro/dex in `cardinal-defaults.yaml`
+  (multi-arch index digests; otel already pinned in v0.0.126).
+- [x] **`scripts-src/build.sh`**: bake `@@LAKERUNNER_IMAGE_SUFFIX@@`,
+  `@@MAESTRO_IMAGE_SUFFIX@@`, `@@DEX_IMAGE_SUFFIX@@` (via `image_manifest suffix
+  <key>`) in addition to otel + `@@STACK_VERSION@@`.
+- [x] **`deploy-lakerunner-services.sh`**: `IMAGE_REGISTRY` composes literal
+  LakerunnerImage/MaestroImage/DexImage from baked suffixes; dropped the
+  per-image full-URI overrides and the dead `OTEL_IMAGE`; kept `DEX_INIT_IMAGE`
+  / `DB_INIT_IMAGE` as external overrides; `VERSION` -> optional `STACK_VERSION`.
+- [x] **`STACK_VERSION`** rolled to `infra-base`, `infra-rds`,
+  `satellite-infra-base` (version change only; no images).
+- [x] **`image_manifest`**: `lakerunner` stack key (5 images) + `build.sh` emits
+  `lakerunner-images.txt`; test added.
+- [x] **Docs/changelog**: `docs/air-gapped-images.md` covers both stacks + the
+  external-image split + ECR pull-through; `CHANGELOG.md` `v0.0.127`.
+- [x] **Verify**: `make build` (pinned manifests, cfn-lint clean), `make test`
+  (487 passed, 1 skipped; drift + shellcheck), behavioral checks on both drivers.

--- a/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
+++ b/docs/superpowers/specs/2026-06-04-air-gapped-image-registry-design.md
@@ -7,12 +7,16 @@ This design evolved across two releases:
 
 - **v0.0.125** introduced a generated image manifest and a full-URI `OTEL_IMAGE`
   passthrough on the deploy driver (template stays a literal `OtelImage` param).
-- **v0.0.126** (current) locked the image identity into the driver: the
+- **v0.0.126** locked the image identity into the satellite driver: the
   collector repo path + pinned tag/digest are baked at publish time, and the
   operator supplies only `IMAGE_REGISTRY` (a registry/pull-through prefix). The
   driver also made the stack version optional (`STACK_VERSION`, baked default).
+- **v0.0.127** (current) rolled the same model across all stacks: the lakerunner
+  application driver bakes lakerunner/maestro/dex (digest-pinned) behind
+  `IMAGE_REGISTRY`; the external busybox/db-init images keep full-URI overrides;
+  and `STACK_VERSION` is now optional on every deploy driver.
 
-The sections below describe the v0.0.126 end state.
+The sections below describe the v0.0.127 end state.
 
 ## Problem
 
@@ -25,11 +29,14 @@ version selection live.
 
 ## Scope
 
-- **Phase 1 (done): satellite.** `satellite_services.py` runs one image (the
-  otel collector); `satellite_infra_base.py` runs none. The driver
+- **Phase 1 (done, v0.0.125–126): satellite.** `satellite_services.py` runs one
+  image (the otel collector); `satellite_infra_base.py` runs none. The driver
   `deploy-satellite-services.sh` owns selection.
-- **Phase 2 (later PR): the main lakerunner stack** (lakerunner/maestro/dex +
-  the busybox/grafana utility images). Notes preserved at the end.
+- **Phase 2 (done, v0.0.127): all remaining stacks.** The lakerunner application
+  driver bakes lakerunner/maestro/dex behind `IMAGE_REGISTRY`; the
+  busybox/grafana utility images stay as full-URI overrides; and `STACK_VERSION`
+  is optional on every deploy driver (the infra drivers run no images, so they
+  get only the version change).
 
 ## Decisions
 
@@ -109,13 +116,25 @@ pull-through example (with the first-pull IAM note), and `IMAGE_REGISTRY` /
   arguments, so the engine's internal hooks can't be reached through it —
   matching the repo's lint-the-front-half approach.
 
-## Phase 2 notes (not built in this PR)
+## Phase 2 implementation (v0.0.127)
 
-Extend the locked-suffix + `IMAGE_REGISTRY` baking and the manifest to the main
-lakerunner stack's first-party images (`lakerunner`, `maestro`, `dex`). Utility
-images: `dex_init` (busybox, a shell to render the dex config) and `db_init`
-(`initcontainer-grafana`, a psql client for two `CREATE DATABASE` calls + a
-keepalive sleeper). The lakerunner `migrate` command connects to an existing
-database and does not create it, so the psql step can't be dropped without a
-binary change. `db_init` is left as-is for now (`:latest` + the grafana
-misnomer/registry mismatch are known and will be revisited).
+- `cardinal-defaults.yaml` pins lakerunner/maestro/dex to their multi-arch index
+  digests (alongside otel). `scripts-src/build.sh` bakes the registry-relative
+  suffix for each first-party image (`image_manifest suffix <key>`) and
+  `@@STACK_VERSION@@` into every driver.
+- `deploy-lakerunner-services.sh` composes `${IMAGE_REGISTRY}/<suffix>` for
+  lakerunner/maestro/dex (always passed as literal params) and drops the old
+  per-image full-URI overrides + the dead `OTEL_IMAGE` passthrough (the
+  lakerunner root has no `OtelImage` param).
+- The external/utility images stay as full-URI overrides: `DEX_INIT_IMAGE`
+  (busybox, a shell to render the dex config) and `DB_INIT_IMAGE`
+  (`initcontainer-grafana`, a psql client for two `CREATE DATABASE` calls + a
+  keepalive sleeper). They are not on our public ECR and are not driven by
+  `IMAGE_REGISTRY`. The lakerunner `migrate` command connects to an existing
+  database and does not create it, so the psql step can't be dropped without a
+  binary change; `db_init` stays `:latest` (the grafana misnomer/registry
+  mismatch are known and out of scope).
+- The infra drivers (`infra-base`, `infra-rds`, `satellite-infra-base`) run no
+  images, so they receive only the `STACK_VERSION` change.
+- `image_manifest` gains a `lakerunner` stack key (all five images) and
+  `build.sh` emits `lakerunner-images.txt`.

--- a/scripts-src/build.sh
+++ b/scripts-src/build.sh
@@ -31,8 +31,18 @@ base="$parts_dir/base.sh"
 stack_version="${CARDINAL_VERSION:-dev}"
 py="python3"
 [ -x "$repo_root/.venv/bin/python3" ] && py="$repo_root/.venv/bin/python3"
-otel_image_suffix=$(PYTHONPATH="$repo_root/src" "$py" -m cardinal_cfn.image_manifest suffix otel)
-[ -n "$otel_image_suffix" ] || { echo "build.sh: failed to resolve otel image suffix" >&2; exit 1; }
+# Registry-relative suffixes for the first-party public-ECR images that respect
+# the IMAGE_REGISTRY prefix.  External images (busybox, the ghcr db-init) are
+# not baked here -- the drivers keep full-URI overrides for those.
+image_suffix() {
+    s=$(PYTHONPATH="$repo_root/src" "$py" -m cardinal_cfn.image_manifest suffix "$1")
+    [ -n "$s" ] || { echo "build.sh: failed to resolve $1 image suffix" >&2; exit 1; }
+    printf '%s' "$s"
+}
+otel_image_suffix=$(image_suffix otel)
+lakerunner_image_suffix=$(image_suffix lakerunner)
+maestro_image_suffix=$(image_suffix maestro)
+dex_image_suffix=$(image_suffix dex)
 
 for fragment in "$parts_dir"/*.sh; do
     name=$(basename "$fragment")
@@ -47,6 +57,9 @@ for fragment in "$parts_dir"/*.sh; do
     } | sed \
         -e "s|@@STACK_VERSION@@|$stack_version|g" \
         -e "s|@@OTEL_IMAGE_SUFFIX@@|$otel_image_suffix|g" \
+        -e "s|@@LAKERUNNER_IMAGE_SUFFIX@@|$lakerunner_image_suffix|g" \
+        -e "s|@@MAESTRO_IMAGE_SUFFIX@@|$maestro_image_suffix|g" \
+        -e "s|@@DEX_IMAGE_SUFFIX@@|$dex_image_suffix|g" \
         >"$out"
     chmod +x "$out"
     echo "wrote $out"

--- a/scripts-src/parts/deploy-lakerunner-infra-base.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-base.sh
@@ -17,6 +17,8 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-base.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 
 usage() {
     cat <<EOF
@@ -27,13 +29,15 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME           Stack to create/update.
   REGION               AWS region (never defaulted; must be set explicitly).
-  VERSION              Published template tag, e.g. v0.0.70.
   VPC_ID               VPC for the security groups.
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
   LICENSE_DATA         Cardinal license token (z64:...), seeds the license
                        secret. Or supply LICENSE_DATA_FILE instead.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION                Published template version to deploy. Default: the
+                               version baked into this driver ($DEFAULT_STACK_VERSION).
+                               (VERSION is accepted as a legacy alias.)
   LICENSE_DATA_FILE            Path to a file holding the license token
                                (fallback for LICENSE_DATA).
   ALB_SCHEME                   internet-facing | internal (template default: internal).
@@ -62,7 +66,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
 { [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
@@ -84,9 +87,11 @@ else
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
 
 # --- Compose the deploy-stack.sh environment. --------------------------------
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 
 # Build PARAMS (newline-separated Key=Value).  Required values always present;
 # optional ones added only when set so the template default applies otherwise.

--- a/scripts-src/parts/deploy-lakerunner-infra-rds.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-rds.sh
@@ -14,6 +14,8 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-rds.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 
 usage() {
     cat <<EOF
@@ -24,13 +26,15 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME         Stack to create/update.
   REGION             AWS region (never defaulted; must be set explicitly).
-  VERSION            Published template tag.
   INFRA_BASE_STACK   Upstream lakerunner-infra-base stack (supplies the service
                      security-group ids via FROM_STACKS).
   VPC_ID             VPC for the DB.
   PRIVATE_SUBNETS    Comma-separated private subnet ids for the DB.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION         Published template version to deploy. Default: the
+                        version baked into this driver ($DEFAULT_STACK_VERSION).
+                        (VERSION is accepted as a legacy alias.)
   DB_ENGINE_VERSION     (template default 18.4).
   DB_INSTANCE_CLASS     (template default db.r7g.large).
   DB_ALLOCATED_STORAGE  (template default 100).
@@ -49,7 +53,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${PRIVATE_SUBNETS:-}" ] && missing="$missing PRIVATE_SUBNETS"
@@ -60,8 +63,10 @@ if [ -n "$missing" ]; then
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 FROM_STACKS="$INFRA_BASE_STACK"
 MAPS=""
 

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -22,6 +22,15 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-services.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
+DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
+# Baked, locked registry-relative paths (repo + pinned tag/digest) for the
+# first-party public-ECR images.  Only the registry prefix is operator-supplied;
+# external images (busybox, the ghcr db-init) keep their own full-URI overrides.
+LAKERUNNER_IMAGE_SUFFIX="@@LAKERUNNER_IMAGE_SUFFIX@@"
+MAESTRO_IMAGE_SUFFIX="@@MAESTRO_IMAGE_SUFFIX@@"
+DEX_IMAGE_SUFFIX="@@DEX_IMAGE_SUFFIX@@"
 
 usage() {
     cat <<EOF
@@ -32,7 +41,6 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME                  Stack to create/update.
   REGION                      AWS region (never defaulted; must be set explicitly).
-  VERSION                     Published template tag.
   INFRA_BASE_STACK            Upstream lakerunner-infra-base.
   INFRA_RDS_STACK             Upstream lakerunner-infra-rds.
   SATELLITE_INFRA_BASE_STACK  Source of RawQueueUrl / LakerunnerAccessRoleArn
@@ -50,6 +58,15 @@ Required:
                               back.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION               Published template version to deploy. Default: the
+                              version baked into this driver ($DEFAULT_STACK_VERSION).
+                              (VERSION is accepted as a legacy alias.)
+  IMAGE_REGISTRY              Registry (and optional namespace/prefix) the first-
+                              party images are pulled from -- e.g. an ECR pull-
+                              through cache root. The image paths and pinned
+                              tags/digests for lakerunner, maestro and dex are
+                              locked into this driver; only this prefix is
+                              operator-supplied. Default: $DEFAULT_IMAGE_REGISTRY.
   CERTIFICATE_ARN             ACM/IAM cert ARN for the Maestro HTTPS listener.
                               If unset, the script auto-generates a self-signed
                               internal cert ON FIRST CREATE only (browsers will
@@ -84,8 +101,12 @@ Optional (template defaults preserved when unset):
                               PUBLIC_SUBNETS, and the ALB SG internet ingress is
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
-  LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
-  DB_INIT_IMAGE               Image overrides (template defaults otherwise).
+  DEX_INIT_IMAGE              Full image URI override for the dex-init busybox
+                              (a non-public-ECR/utility image, not covered by
+                              IMAGE_REGISTRY). Default: the template default.
+  DB_INIT_IMAGE               Full image URI override for the db-init image
+                              (ghcr, not covered by IMAGE_REGISTRY). Default:
+                              the template default.
   PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
                               (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are
@@ -117,7 +138,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${INFRA_RDS_STACK:-}" ] && missing="$missing INFRA_RDS_STACK"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
@@ -140,7 +160,19 @@ fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
+# IMAGE_REGISTRY prefix + the baked, locked image paths -> literal image params.
+image_registry="${IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
+lakerunner_image="$image_registry/$LAKERUNNER_IMAGE_SUFFIX"
+maestro_image="$image_registry/$MAESTRO_IMAGE_SUFFIX"
+dex_image="$image_registry/$DEX_IMAGE_SUFFIX"
+echo "[deploy-lakerunner-services] resolved STACK_VERSION = $stack_version" >&2
+echo "[deploy-lakerunner-services] resolved LakerunnerImage = $lakerunner_image" >&2
+echo "[deploy-lakerunner-services] resolved MaestroImage    = $maestro_image" >&2
+echo "[deploy-lakerunner-services] resolved DexImage        = $dex_image" >&2
+
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 
 # --- Read QueueUrl / QueueRoleArn from the satellite-infra-base stack. --------
 sat_outputs=$(aws cloudformation describe-stacks \
@@ -190,7 +222,7 @@ MAPS=""
 params="QueueUrl=$queue_url
 QueueRoleArn=$role_arn
 OrganizationId=$ORGANIZATION_ID
-TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
+TemplateBaseUrl=$template_base_url/$stack_version/cardinal-lakerunner/
 ClusterArn=$CLUSTER_ARN
 ClusterName=$CLUSTER_NAME
 VpcId=$VPC_ID
@@ -205,14 +237,14 @@ ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
 
-[ -n "${LAKERUNNER_IMAGE:-}" ] && params="$params
-LakerunnerImage=$LAKERUNNER_IMAGE"
-[ -n "${MAESTRO_IMAGE:-}" ] && params="$params
-MaestroImage=$MAESTRO_IMAGE"
-[ -n "${OTEL_IMAGE:-}" ] && params="$params
-OtelImage=$OTEL_IMAGE"
-[ -n "${DEX_IMAGE:-}" ] && params="$params
-DexImage=$DEX_IMAGE"
+# First-party public-ECR images: composed from IMAGE_REGISTRY + the baked,
+# locked suffixes, always passed as literal params.
+params="$params
+LakerunnerImage=$lakerunner_image
+MaestroImage=$maestro_image
+DexImage=$dex_image"
+# External/utility images: full-URI overrides, not driven by IMAGE_REGISTRY.
+# Unset -> the template default governs.
 [ -n "${DEX_INIT_IMAGE:-}" ] && params="$params
 DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params

--- a/scripts-src/parts/deploy-satellite-infra-base.sh
+++ b/scripts-src/parts/deploy-satellite-infra-base.sh
@@ -17,6 +17,8 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-infra-base.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 
 usage() {
     cat <<EOF
@@ -27,12 +29,14 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME          Stack to create/update.
   REGION              AWS region (never defaulted; must be set explicitly).
-  VERSION             Published template tag.
   LAKERUNNER_PRINCIPAL  ARN of the central lakerunner process role (its
                       ProcessRoleArn output) allowed to assume the satellite
                       access role.  Read once out of band; works cross-account.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION              Published template version to deploy. Default: the
+                             version baked into this driver ($DEFAULT_STACK_VERSION).
+                             (VERSION is accepted as a legacy alias.)
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
   RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
   RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
@@ -54,7 +58,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${LAKERUNNER_PRINCIPAL:-}" ] && missing="$missing LAKERUNNER_PRINCIPAL"
 if [ -n "$missing" ]; then
     usage >&2
@@ -63,8 +66,10 @@ if [ -n "$missing" ]; then
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 # No upstream-stack pull (cross-account safe): the central principal arrives
 # directly, never mapped from a stack output.
 FROM_STACKS=""

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -18,6 +18,8 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-base.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="dev"
 
 usage() {
     cat <<EOF
@@ -28,13 +30,15 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME           Stack to create/update.
   REGION               AWS region (never defaulted; must be set explicitly).
-  VERSION              Published template tag, e.g. v0.0.70.
   VPC_ID               VPC for the security groups.
   CLUSTER_ARN          Customer-supplied ECS cluster ARN.
   LICENSE_DATA         Cardinal license token (z64:...), seeds the license
                        secret. Or supply LICENSE_DATA_FILE instead.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION                Published template version to deploy. Default: the
+                               version baked into this driver ($DEFAULT_STACK_VERSION).
+                               (VERSION is accepted as a legacy alias.)
   LICENSE_DATA_FILE            Path to a file holding the license token
                                (fallback for LICENSE_DATA).
   ALB_SCHEME                   internet-facing | internal (template default: internal).
@@ -63,7 +67,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${CLUSTER_ARN:-}" ] && missing="$missing CLUSTER_ARN"
 { [ -z "${LICENSE_DATA:-}" ] && [ -z "${LICENSE_DATA_FILE:-}" ]; } && missing="$missing LICENSE_DATA"
@@ -85,9 +88,11 @@ else
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
 
 # --- Compose the deploy-stack.sh environment. --------------------------------
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 
 # Build PARAMS (newline-separated Key=Value).  Required values always present;
 # optional ones added only when set so the template default applies otherwise.

--- a/scripts/deploy-lakerunner-infra-rds.sh
+++ b/scripts/deploy-lakerunner-infra-rds.sh
@@ -15,6 +15,8 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-infra-rds.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="dev"
 
 usage() {
     cat <<EOF
@@ -25,13 +27,15 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME         Stack to create/update.
   REGION             AWS region (never defaulted; must be set explicitly).
-  VERSION            Published template tag.
   INFRA_BASE_STACK   Upstream lakerunner-infra-base stack (supplies the service
                      security-group ids via FROM_STACKS).
   VPC_ID             VPC for the DB.
   PRIVATE_SUBNETS    Comma-separated private subnet ids for the DB.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION         Published template version to deploy. Default: the
+                        version baked into this driver ($DEFAULT_STACK_VERSION).
+                        (VERSION is accepted as a legacy alias.)
   DB_ENGINE_VERSION     (template default 18.4).
   DB_INSTANCE_CLASS     (template default db.r7g.large).
   DB_ALLOCATED_STORAGE  (template default 100).
@@ -50,7 +54,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${VPC_ID:-}" ] && missing="$missing VPC_ID"
 [ -z "${PRIVATE_SUBNETS:-}" ] && missing="$missing PRIVATE_SUBNETS"
@@ -61,8 +64,10 @@ if [ -n "$missing" ]; then
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 FROM_STACKS="$INFRA_BASE_STACK"
 MAPS=""
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -23,6 +23,15 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-lakerunner-services.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="dev"
+DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
+# Baked, locked registry-relative paths (repo + pinned tag/digest) for the
+# first-party public-ECR images.  Only the registry prefix is operator-supplied;
+# external images (busybox, the ghcr db-init) keep their own full-URI overrides.
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.50.0@sha256:642e93afbbf846535923fc4ad59ea790fd0aff85cc6889355e866ab883da5001"
+DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.1.0@sha256:a1d0af5a99068516df067af803312c03b62b1bd07eefb16e914bd1d55deacf9c"
 
 usage() {
     cat <<EOF
@@ -33,7 +42,6 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME                  Stack to create/update.
   REGION                      AWS region (never defaulted; must be set explicitly).
-  VERSION                     Published template tag.
   INFRA_BASE_STACK            Upstream lakerunner-infra-base.
   INFRA_RDS_STACK             Upstream lakerunner-infra-rds.
   SATELLITE_INFRA_BASE_STACK  Source of RawQueueUrl / LakerunnerAccessRoleArn
@@ -51,6 +59,15 @@ Required:
                               back.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION               Published template version to deploy. Default: the
+                              version baked into this driver ($DEFAULT_STACK_VERSION).
+                              (VERSION is accepted as a legacy alias.)
+  IMAGE_REGISTRY              Registry (and optional namespace/prefix) the first-
+                              party images are pulled from -- e.g. an ECR pull-
+                              through cache root. The image paths and pinned
+                              tags/digests for lakerunner, maestro and dex are
+                              locked into this driver; only this prefix is
+                              operator-supplied. Default: $DEFAULT_IMAGE_REGISTRY.
   CERTIFICATE_ARN             ACM/IAM cert ARN for the Maestro HTTPS listener.
                               If unset, the script auto-generates a self-signed
                               internal cert ON FIRST CREATE only (browsers will
@@ -85,8 +102,12 @@ Optional (template defaults preserved when unset):
                               PUBLIC_SUBNETS, and the ALB SG internet ingress is
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
-  LAKERUNNER_IMAGE, MAESTRO_IMAGE, OTEL_IMAGE, DEX_IMAGE, DEX_INIT_IMAGE,
-  DB_INIT_IMAGE               Image overrides (template defaults otherwise).
+  DEX_INIT_IMAGE              Full image URI override for the dex-init busybox
+                              (a non-public-ECR/utility image, not covered by
+                              IMAGE_REGISTRY). Default: the template default.
+  DB_INIT_IMAGE               Full image URI override for the db-init image
+                              (ghcr, not covered by IMAGE_REGISTRY). Default:
+                              the template default.
   PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
                               (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are
@@ -118,7 +139,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${INFRA_BASE_STACK:-}" ] && missing="$missing INFRA_BASE_STACK"
 [ -z "${INFRA_RDS_STACK:-}" ] && missing="$missing INFRA_RDS_STACK"
 [ -z "${SATELLITE_INFRA_BASE_STACK:-}" ] && missing="$missing SATELLITE_INFRA_BASE_STACK"
@@ -141,7 +161,19 @@ fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
+# IMAGE_REGISTRY prefix + the baked, locked image paths -> literal image params.
+image_registry="${IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
+lakerunner_image="$image_registry/$LAKERUNNER_IMAGE_SUFFIX"
+maestro_image="$image_registry/$MAESTRO_IMAGE_SUFFIX"
+dex_image="$image_registry/$DEX_IMAGE_SUFFIX"
+echo "[deploy-lakerunner-services] resolved STACK_VERSION = $stack_version" >&2
+echo "[deploy-lakerunner-services] resolved LakerunnerImage = $lakerunner_image" >&2
+echo "[deploy-lakerunner-services] resolved MaestroImage    = $maestro_image" >&2
+echo "[deploy-lakerunner-services] resolved DexImage        = $dex_image" >&2
+
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 
 # --- Read QueueUrl / QueueRoleArn from the satellite-infra-base stack. --------
 sat_outputs=$(aws cloudformation describe-stacks \
@@ -191,7 +223,7 @@ MAPS=""
 params="QueueUrl=$queue_url
 QueueRoleArn=$role_arn
 OrganizationId=$ORGANIZATION_ID
-TemplateBaseUrl=$template_base_url/$VERSION/cardinal-lakerunner/
+TemplateBaseUrl=$template_base_url/$stack_version/cardinal-lakerunner/
 ClusterArn=$CLUSTER_ARN
 ClusterName=$CLUSTER_NAME
 VpcId=$VPC_ID
@@ -206,14 +238,14 @@ ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
 
-[ -n "${LAKERUNNER_IMAGE:-}" ] && params="$params
-LakerunnerImage=$LAKERUNNER_IMAGE"
-[ -n "${MAESTRO_IMAGE:-}" ] && params="$params
-MaestroImage=$MAESTRO_IMAGE"
-[ -n "${OTEL_IMAGE:-}" ] && params="$params
-OtelImage=$OTEL_IMAGE"
-[ -n "${DEX_IMAGE:-}" ] && params="$params
-DexImage=$DEX_IMAGE"
+# First-party public-ECR images: composed from IMAGE_REGISTRY + the baked,
+# locked suffixes, always passed as literal params.
+params="$params
+LakerunnerImage=$lakerunner_image
+MaestroImage=$maestro_image
+DexImage=$dex_image"
+# External/utility images: full-URI overrides, not driven by IMAGE_REGISTRY.
+# Unset -> the template default governs.
 [ -n "${DEX_INIT_IMAGE:-}" ] && params="$params
 DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -18,6 +18,8 @@ set -eu
 
 DEFAULT_TEMPLATE_BASE_URL="https://cardinal-cfn-us-east-1.s3.us-east-1.amazonaws.com/lakerunner"
 TEMPLATE_KEY="cardinal-satellite-infra-base.yaml"
+# Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
+DEFAULT_STACK_VERSION="dev"
 
 usage() {
     cat <<EOF
@@ -28,12 +30,14 @@ All inputs come from environment variables (no flags).
 Required:
   STACK_NAME          Stack to create/update.
   REGION              AWS region (never defaulted; must be set explicitly).
-  VERSION             Published template tag.
   LAKERUNNER_PRINCIPAL  ARN of the central lakerunner process role (its
                       ProcessRoleArn output) allowed to assume the satellite
                       access role.  Read once out of band; works cross-account.
 
 Optional (template defaults preserved when unset):
+  STACK_VERSION              Published template version to deploy. Default: the
+                             version baked into this driver ($DEFAULT_STACK_VERSION).
+                             (VERSION is accepted as a legacy alias.)
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
   RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
   RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
@@ -55,7 +59,6 @@ esac
 missing=""
 [ -z "${STACK_NAME:-}" ] && missing="$missing STACK_NAME"
 [ -z "${REGION:-}" ] && missing="$missing REGION"
-[ -z "${VERSION:-}" ] && missing="$missing VERSION"
 [ -z "${LAKERUNNER_PRINCIPAL:-}" ] && missing="$missing LAKERUNNER_PRINCIPAL"
 if [ -n "$missing" ]; then
     usage >&2
@@ -64,8 +67,10 @@ if [ -n "$missing" ]; then
 fi
 
 template_base_url="${TEMPLATE_BASE_URL:-$DEFAULT_TEMPLATE_BASE_URL}"
+# STACK_VERSION (preferred) or the legacy VERSION alias, else the baked default.
+stack_version="${STACK_VERSION:-${VERSION:-$DEFAULT_STACK_VERSION}}"
 
-TEMPLATE_URL="$template_base_url/$VERSION/$TEMPLATE_KEY"
+TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 # No upstream-stack pull (cross-account safe): the central principal arrives
 # directly, never mapped from a stack output.
 FROM_STACKS=""

--- a/src/cardinal_cfn/image_manifest.py
+++ b/src/cardinal_cfn/image_manifest.py
@@ -12,10 +12,12 @@ import sys
 
 from cardinal_cfn.defaults import load_defaults
 
-# Which cardinal-defaults.yaml images.* keys each stack runs.
-# Phase 1: satellite only. Phase 2 adds the lakerunner stack's keys.
+# Which cardinal-defaults.yaml images.* keys each stack runs. The list is the
+# full scan/mirror surface for the stack, including external/utility images that
+# the drivers handle via per-image overrides (busybox, the ghcr db-init).
 STACK_IMAGE_KEYS = {
     "satellite": ["otel"],
+    "lakerunner": ["lakerunner", "maestro", "dex", "dex_init", "db_init"],
 }
 
 

--- a/tests/unit/test_image_manifest.py
+++ b/tests/unit/test_image_manifest.py
@@ -17,6 +17,14 @@ def test_unknown_stack_raises():
         image_manifest.manifest_lines("nope")
 
 
+def test_lakerunner_manifest_lists_all_stack_images():
+    images = load_defaults()["images"]
+    expected = sorted(
+        {images[k] for k in ("lakerunner", "maestro", "dex", "dex_init", "db_init")}
+    )
+    assert image_manifest.manifest_lines("lakerunner") == expected
+
+
 def test_image_ref_returns_pinned_default():
     assert image_manifest.image_ref("otel") == load_defaults()["images"]["otel"]
 


### PR DESCRIPTION
## Summary

Extends the v0.0.126 satellite pattern to every stack: first-party public-ECR images are locked + digest-pinned in the drivers behind a single `IMAGE_REGISTRY` prefix, external images stay as explicit overrides, and `VERSION` becomes optional `STACK_VERSION` (baked at publish time) on all drivers.

## Changes

- **lakerunner-services driver**: `IMAGE_REGISTRY` (default `public.ecr.aws`) composes literal `LakerunnerImage` / `MaestroImage` / `DexImage` from baked, digest-pinned suffixes. Dropped the per-image `LAKERUNNER_IMAGE`/`MAESTRO_IMAGE`/`DEX_IMAGE`/`OTEL_IMAGE` overrides (the last was dead — the lakerunner root has no `OtelImage`).
- **External/utility images** (not on our public ECR) keep full-URI overrides: `DEX_INIT_IMAGE` (busybox), `DB_INIT_IMAGE` (ghcr `initcontainer-grafana`). Not governed by `IMAGE_REGISTRY`.
- **`STACK_VERSION`** (optional, baked publish-time default; `VERSION` legacy alias) on `infra-base`, `infra-rds`, `services`, `satellite-infra-base` (infra drivers run no images → version change only).
- **Digest-pinned** lakerunner/maestro/dex (multi-arch index digests) in `cardinal-defaults.yaml` → flow into template defaults. New `lakerunner-images.txt` mirror/scan manifest.

## Testing

- `make build` clean (cfn-lint passes; both `*-images.txt` emitted, digest-pinned).
- `make test` — 488 passed, 1 skipped (incl. deploy-driver drift + shellcheck).
- Behavioral: both drivers compose `${IMAGE_REGISTRY}/<pinned-suffix>` and resolve `STACK_VERSION` (baked default; `VERSION` alias honored).

## Upgrade action

Anyone setting `LAKERUNNER_IMAGE`/`MAESTRO_IMAGE`/`DEX_IMAGE`/`OTEL_IMAGE` switches to `IMAGE_REGISTRY` (+ `DEX_INIT_IMAGE`/`DB_INIT_IMAGE` for the externals). `VERSION` automation keeps working. See `docs/air-gapped-images.md` and the updated spec/plan.