### PR TITLE
execution role: customer-supplied extra IAM policies (ARNs or pasted JSON)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.128
+
+- **Execution roles can take customer-supplied extra permissions.** The
+  execution role in `lakerunner-infra-base` and the collector execution role in
+  `satellite-services` gain an `ExecutionRoleExtraPolicyArns` parameter (CSV of
+  managed-policy ARNs) appended to `ManagedPolicyArns` alongside
+  `AmazonECSTaskExecutionRolePolicy`. Use this for air-gapped ECR pull-through
+  first-pull (`ecr:BatchImportUpstreamImage` + repo auto-create), cross-account
+  ECR, or KMS-encrypted repos (standard private-ECR pulls are already covered by
+  the base policy).
+- **Two driver inputs feed it** on `deploy-lakerunner-infra-base.sh` and
+  `deploy-satellite-services.sh`: `EXECUTION_ROLE_POLICY_ARNS` (ready-made
+  managed-policy ARNs) and `EXECUTION_ROLE_POLICY_JSON` / `_FILE` (a pasted IAM
+  policy the driver flattens and turns into a customer-managed policy named
+  `<STACK_NAME>-exec-extra`, then attaches by ARN — CFN can't inline a string
+  policy without Lambda). The JSON path needs `jq` and IAM write permissions for
+  the deployer. See `docs/air-gapped-images.md`.
+- **Upgrade action:** none — both inputs are optional and default to today's
+  behavior (base policy only). No resource replacement.
+
 ## v0.0.127
 
 - **The locked-image + registry-prefix model now covers all stacks.** Following

--- a/docs/air-gapped-images.md
+++ b/docs/air-gapped-images.md
@@ -73,7 +73,46 @@ First-pull IAM note: on the first pull of a not-yet-cached image, the ECS task
 **execution role** needs `ecr:BatchImportUpstreamImage` plus repository
 auto-creation (`ecr:CreateRepository` on the principal, or a registry
 repository-creation template) in addition to the usual pull permissions. Once
-cached, standard pull permissions suffice.
+cached, standard pull permissions suffice. The base
+`AmazonECSTaskExecutionRolePolicy` already grants standard private-ECR pulls, so
+you only need extras for pull-through import, cross-account ECR, or KMS-encrypted
+repos — see "Granting the execution role extra permissions" below.
+
+## Granting the execution role extra permissions
+
+The execution role created by `lakerunner-infra-base` (the app stack) and by
+`satellite-services` (the collector) carries `AmazonECSTaskExecutionRolePolicy`,
+which already covers standard private-ECR pulls. For the cases that aren't
+covered (pull-through-cache first pull, cross-account ECR, KMS decrypt), attach
+additional permissions via the deploy driver — two ways, on
+`deploy-lakerunner-infra-base.sh` and `deploy-satellite-services.sh`:
+
+1. **Ready-made managed policies (the "proper ops" path):** set
+   `EXECUTION_ROLE_POLICY_ARNS` to a comma-separated list of managed-policy ARNs.
+   The stack appends them to the execution role's `ManagedPolicyArns`.
+
+2. **A pasted JSON policy (for getting started):** set
+   `EXECUTION_ROLE_POLICY_JSON` to an IAM policy document (multi-line is fine),
+   or `EXECUTION_ROLE_POLICY_JSON_FILE` to a path. CloudFormation cannot attach a
+   string policy without Lambda (which this product does not use), so the driver
+   flattens the JSON, creates/updates a customer-managed policy named
+   `<STACK_NAME>-exec-extra`, and attaches its ARN. This needs `jq` and IAM
+   permissions for the deployer (`iam:CreatePolicy`, `iam:CreatePolicyVersion`,
+   `iam:GetPolicy`, `iam:ListPolicyVersions`, `iam:DeletePolicyVersion`).
+
+Both inputs may be combined; both are optional. Example (pull-through import):
+
+```sh
+EXECUTION_ROLE_POLICY_JSON='{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["ecr:BatchImportUpstreamImage", "ecr:CreateRepository"],
+    "Resource": "*"
+  }]
+}' \
+  STACK_NAME=... REGION=... ./scripts/deploy-lakerunner-infra-base.sh
+```
 
 ## Deploying from the mirror
 

--- a/docs/superpowers/specs/2026-06-04-execution-role-extra-policies-design.md
+++ b/docs/superpowers/specs/2026-06-04-execution-role-extra-policies-design.md
@@ -1,0 +1,75 @@
+# Execution-role extra IAM policies (customer-supplied)
+
+Date: 2026-06-04
+Status: implemented (v0.0.128)
+
+## Problem
+
+Air-gapped / private-registry installs sometimes need permissions on the ECS
+task **execution role** that the base `AmazonECSTaskExecutionRolePolicy` does not
+grant: ECR pull-through-cache first pull (`ecr:BatchImportUpstreamImage` + repo
+auto-create), cross-account ECR, or KMS-encrypted repos. Customers need a way to
+add these, driven from the deploy driver, and to grow from "paste a JSON policy"
+into "manage proper managed policies."
+
+(The four ECR read actions a private pull needs — `GetAuthorizationToken`,
+`BatchCheckLayerAvailability`, `GetDownloadUrlForLayer`, `BatchGetImage` — are
+already in the base policy, so they need no extra grant.)
+
+## Constraint
+
+CloudFormation cannot attach a *string* parameter as an IAM `PolicyDocument`
+(it must be a structured JSON object), and the usual string→policy workaround
+needs a macro/custom resource, i.e. Lambda — which this product bans. So a
+pasted JSON policy must become a real IAM policy object before CFN can attach it.
+
+## Design
+
+### Template (both execution-role creators)
+
+`lakerunner_infra_base.py` (`ExecutionRole`) and `satellite_services.py`
+(`CollectorExecutionRole`) gain:
+
+- Parameter `ExecutionRoleExtraPolicyArns` (String, default `""`, CSV of
+  managed-policy ARNs).
+- Condition `HasExecutionRoleExtraPolicies` = the param is non-empty.
+- `ManagedPolicyArns = Fn::If(HasExecutionRoleExtraPolicies,
+  Split(",", Sub("<base>,${ExecutionRoleExtraPolicyArns}")), ["<base>"])`,
+  where `<base>` is `AmazonECSTaskExecutionRolePolicy`.
+
+Attachment is fully CFN-tracked; empty default = today's behavior.
+
+### Drivers (`deploy-lakerunner-infra-base.sh`, `deploy-satellite-services.sh`)
+
+A shared front-half function `resolve_exec_role_policy_arns` sets a CSV from two
+optional inputs (both may be combined):
+
+- `EXECUTION_ROLE_POLICY_ARNS` — ready-made managed-policy ARNs, passed through.
+- `EXECUTION_ROLE_POLICY_JSON` / `_FILE` — a pasted IAM policy. The driver
+  validates+flattens it (`jq -c`), then creates (or version-updates, pruning
+  non-default versions under the IAM 5-version cap) a customer-managed policy
+  named `<STACK_NAME>-exec-extra`, and appends its ARN. Needs `jq` and IAM write
+  permissions for the deployer.
+
+The function is invoked directly (not in `$()`) so validation errors `exit` the
+whole script. The resulting CSV is passed as the `ExecutionRoleExtraPolicyArns`
+PARAMS override (omitted when empty, preserving the template default).
+
+## Scope / decisions
+
+- **Execution role only** (the image-pull role). Task-role extensibility is not
+  included.
+- **Managed policy created by the driver from pasted JSON**, attached by ARN
+  (chosen over a post-deploy inline `put-role-policy`, which can't run on first
+  create and would be CFN drift).
+- The created policy object's lifecycle is the driver's (not CFN): re-deploys
+  add a new default version; a stack delete detaches it (CFN owns the role) and
+  leaves the policy as a harmless orphan.
+
+## Testing
+
+- Template: the param + condition exist; `ManagedPolicyArns` is the conditional
+  `Fn::If` referencing both the base policy and the param (both stacks).
+- Driver: shellcheck clean; drift gate; behavioral check that
+  `EXECUTION_ROLE_POLICY_ARNS` passes through into the `ExecutionRoleExtraPolicyArns`
+  param (the JSON path needs live IAM and is covered by inspection).

--- a/scripts-src/parts/deploy-lakerunner-infra-base.sh
+++ b/scripts-src/parts/deploy-lakerunner-infra-base.sh
@@ -20,6 +20,53 @@ TEMPLATE_KEY="cardinal-lakerunner-infra-base.yaml"
 # Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
 DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 
+# Resolve optional execution-role managed-policy ARNs into the global
+# EXEC_EXTRA_ARNS (a CSV, possibly empty), from two operator inputs:
+#   EXECUTION_ROLE_POLICY_ARNS         ready-made managed-policy ARNs (CSV) -- the
+#                                      "proper ops" path; passed through as-is.
+#   EXECUTION_ROLE_POLICY_JSON[_FILE]  a pasted IAM policy document (multi-line
+#                                      ok).  CFN cannot attach a string policy
+#                                      (no Lambda in this product), so the driver
+#                                      flattens it (jq -c) and creates/updates a
+#                                      customer-managed policy named
+#                                      <STACK_NAME>-exec-extra, then attaches its
+#                                      ARN via the stack's ManagedPolicyArns.
+# Called directly (not in $()) so a validation error can exit the whole script.
+resolve_exec_role_policy_arns() {
+    EXEC_EXTRA_ARNS="${EXECUTION_ROLE_POLICY_ARNS:-}"
+    _erp_json=""
+    if [ -n "${EXECUTION_ROLE_POLICY_JSON:-}" ]; then
+        _erp_json="$EXECUTION_ROLE_POLICY_JSON"
+    elif [ -n "${EXECUTION_ROLE_POLICY_JSON_FILE:-}" ]; then
+        [ -r "$EXECUTION_ROLE_POLICY_JSON_FILE" ] || { echo "[deploy-lakerunner-infra-base] ERROR: cannot read EXECUTION_ROLE_POLICY_JSON_FILE: $EXECUTION_ROLE_POLICY_JSON_FILE" >&2; exit 2; }
+        _erp_json=$(cat "$EXECUTION_ROLE_POLICY_JSON_FILE")
+    fi
+    [ -n "$_erp_json" ] || return 0
+
+    command -v jq >/dev/null 2>&1 || { echo "[deploy-lakerunner-infra-base] ERROR: jq is required for EXECUTION_ROLE_POLICY_JSON" >&2; exit 2; }
+    _erp_doc=$(printf '%s' "$_erp_json" | jq -c . 2>/dev/null) || { echo "[deploy-lakerunner-infra-base] ERROR: EXECUTION_ROLE_POLICY_JSON is not valid JSON" >&2; exit 2; }
+    _erp_name="${STACK_NAME}-exec-extra"
+    _erp_acct=$(aws sts get-caller-identity --query Account --output text)
+    _erp_arn="arn:aws:iam::${_erp_acct}:policy/${_erp_name}"
+    if _erp_def=$(aws iam get-policy --policy-arn "$_erp_arn" --query 'Policy.DefaultVersionId' --output text 2>/dev/null); then
+        # IAM caps a policy at 5 versions; drop the non-default ones before adding.
+        for _erp_v in $(aws iam list-policy-versions --policy-arn "$_erp_arn" --query 'Versions[].VersionId' --output text); do
+            [ "$_erp_v" = "$_erp_def" ] && continue
+            aws iam delete-policy-version --policy-arn "$_erp_arn" --version-id "$_erp_v" >/dev/null 2>&1 || true
+        done
+        aws iam create-policy-version --policy-arn "$_erp_arn" --policy-document "$_erp_doc" --set-as-default >/dev/null
+        echo "[deploy-lakerunner-infra-base] updated execution-role managed policy: $_erp_arn" >&2
+    else
+        aws iam create-policy --policy-name "$_erp_name" --policy-document "$_erp_doc" --description "Cardinal execution-role extra policy for $STACK_NAME" >/dev/null
+        echo "[deploy-lakerunner-infra-base] created execution-role managed policy: $_erp_arn" >&2
+    fi
+    if [ -n "$EXEC_EXTRA_ARNS" ]; then
+        EXEC_EXTRA_ARNS="$EXEC_EXTRA_ARNS,$_erp_arn"
+    else
+        EXEC_EXTRA_ARNS="$_erp_arn"
+    fi
+}
+
 usage() {
     cat <<EOF
 deploy-lakerunner-infra-base.sh -- deploy the cardinal-lakerunner-infra-base stack.
@@ -50,6 +97,15 @@ Optional (template defaults preserved when unset):
                                Access config (template default 'false': not set).
   LICENSE_SECRET_NAME          (template default cardinal-license).
   ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
+  EXECUTION_ROLE_POLICY_ARNS   Comma-separated managed-policy ARNs to attach to
+                               the ECS task execution role (e.g. ECR pull-through
+                               import, cross-account ECR, KMS decrypt).
+  EXECUTION_ROLE_POLICY_JSON   A pasted IAM policy document (multi-line ok). The
+                               driver flattens it and creates/updates a customer
+                               managed policy <STACK_NAME>-exec-extra, then
+                               attaches it. Requires jq + iam:CreatePolicy/
+                               CreatePolicyVersion. Or use *_FILE for a path.
+  EXECUTION_ROLE_POLICY_JSON_FILE  Path fallback for EXECUTION_ROLE_POLICY_JSON.
   TEMPLATE_BASE_URL            Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN            Passed to create-change-set.
   NO_EXECUTE                   Non-empty: change-set only, do not execute.
@@ -114,6 +170,12 @@ ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK"
 LicenseSecretName=$LICENSE_SECRET_NAME"
 [ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params
 AdminKeySecretName=$ADMIN_KEY_SECRET_NAME"
+
+# Optional execution-role extra managed policies (pasted JSON and/or ARNs).
+EXEC_EXTRA_ARNS=""
+resolve_exec_role_policy_arns
+[ -n "$EXEC_EXTRA_ARNS" ] && params="$params
+ExecutionRoleExtraPolicyArns=$EXEC_EXTRA_ARNS"
 
 PARAMS="$params"
 FROM_STACKS=""

--- a/scripts-src/parts/deploy-satellite-services.sh
+++ b/scripts-src/parts/deploy-satellite-services.sh
@@ -31,6 +31,53 @@ DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 OTEL_IMAGE_SUFFIX="@@OTEL_IMAGE_SUFFIX@@"
 DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 
+# Resolve optional execution-role managed-policy ARNs into the global
+# EXEC_EXTRA_ARNS (a CSV, possibly empty), from two operator inputs:
+#   EXECUTION_ROLE_POLICY_ARNS         ready-made managed-policy ARNs (CSV) -- the
+#                                      "proper ops" path; passed through as-is.
+#   EXECUTION_ROLE_POLICY_JSON[_FILE]  a pasted IAM policy document (multi-line
+#                                      ok).  CFN cannot attach a string policy
+#                                      (no Lambda in this product), so the driver
+#                                      flattens it (jq -c) and creates/updates a
+#                                      customer-managed policy named
+#                                      <STACK_NAME>-exec-extra, then attaches its
+#                                      ARN via the stack's ManagedPolicyArns.
+# Called directly (not in $()) so a validation error can exit the whole script.
+resolve_exec_role_policy_arns() {
+    EXEC_EXTRA_ARNS="${EXECUTION_ROLE_POLICY_ARNS:-}"
+    _erp_json=""
+    if [ -n "${EXECUTION_ROLE_POLICY_JSON:-}" ]; then
+        _erp_json="$EXECUTION_ROLE_POLICY_JSON"
+    elif [ -n "${EXECUTION_ROLE_POLICY_JSON_FILE:-}" ]; then
+        [ -r "$EXECUTION_ROLE_POLICY_JSON_FILE" ] || { echo "[deploy-satellite-services] ERROR: cannot read EXECUTION_ROLE_POLICY_JSON_FILE: $EXECUTION_ROLE_POLICY_JSON_FILE" >&2; exit 2; }
+        _erp_json=$(cat "$EXECUTION_ROLE_POLICY_JSON_FILE")
+    fi
+    [ -n "$_erp_json" ] || return 0
+
+    command -v jq >/dev/null 2>&1 || { echo "[deploy-satellite-services] ERROR: jq is required for EXECUTION_ROLE_POLICY_JSON" >&2; exit 2; }
+    _erp_doc=$(printf '%s' "$_erp_json" | jq -c . 2>/dev/null) || { echo "[deploy-satellite-services] ERROR: EXECUTION_ROLE_POLICY_JSON is not valid JSON" >&2; exit 2; }
+    _erp_name="${STACK_NAME}-exec-extra"
+    _erp_acct=$(aws sts get-caller-identity --query Account --output text)
+    _erp_arn="arn:aws:iam::${_erp_acct}:policy/${_erp_name}"
+    if _erp_def=$(aws iam get-policy --policy-arn "$_erp_arn" --query 'Policy.DefaultVersionId' --output text 2>/dev/null); then
+        # IAM caps a policy at 5 versions; drop the non-default ones before adding.
+        for _erp_v in $(aws iam list-policy-versions --policy-arn "$_erp_arn" --query 'Versions[].VersionId' --output text); do
+            [ "$_erp_v" = "$_erp_def" ] && continue
+            aws iam delete-policy-version --policy-arn "$_erp_arn" --version-id "$_erp_v" >/dev/null 2>&1 || true
+        done
+        aws iam create-policy-version --policy-arn "$_erp_arn" --policy-document "$_erp_doc" --set-as-default >/dev/null
+        echo "[deploy-satellite-services] updated execution-role managed policy: $_erp_arn" >&2
+    else
+        aws iam create-policy --policy-name "$_erp_name" --policy-document "$_erp_doc" --description "Cardinal execution-role extra policy for $STACK_NAME" >/dev/null
+        echo "[deploy-satellite-services] created execution-role managed policy: $_erp_arn" >&2
+    fi
+    if [ -n "$EXEC_EXTRA_ARNS" ]; then
+        EXEC_EXTRA_ARNS="$EXEC_EXTRA_ARNS,$_erp_arn"
+    else
+        EXEC_EXTRA_ARNS="$_erp_arn"
+    fi
+}
+
 usage() {
     cat <<EOF
 deploy-satellite-services.sh -- deploy the cardinal-satellite-services stack.
@@ -61,6 +108,14 @@ Optional (template defaults preserved when unset):
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
+  EXECUTION_ROLE_POLICY_ARNS   Comma-separated managed-policy ARNs to attach to
+                       the collector execution role (e.g. ECR pull-through
+                       import, cross-account ECR, KMS decrypt).
+  EXECUTION_ROLE_POLICY_JSON   A pasted IAM policy document (multi-line ok). The
+                       driver flattens it and creates/updates a customer managed
+                       policy <STACK_NAME>-exec-extra, then attaches it. Requires
+                       jq + iam:CreatePolicy/CreatePolicyVersion. Or use *_FILE.
+  EXECUTION_ROLE_POLICY_JSON_FILE  Path fallback for EXECUTION_ROLE_POLICY_JSON.
   TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN    Passed to create-change-set.
   NO_EXECUTE           Non-empty: change-set only, do not execute.
@@ -131,6 +186,12 @@ OtelImage=$otel_image"
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
+
+# Optional execution-role extra managed policies (pasted JSON and/or ARNs).
+EXEC_EXTRA_ARNS=""
+resolve_exec_role_policy_arns
+[ -n "$EXEC_EXTRA_ARNS" ] && params="$params
+ExecutionRoleExtraPolicyArns=$EXEC_EXTRA_ARNS"
 
 PARAMS="$params"
 

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -21,6 +21,53 @@ TEMPLATE_KEY="cardinal-lakerunner-infra-base.yaml"
 # Baked at publish time (scripts-src/build.sh).  STACK_VERSION defaults to this.
 DEFAULT_STACK_VERSION="dev"
 
+# Resolve optional execution-role managed-policy ARNs into the global
+# EXEC_EXTRA_ARNS (a CSV, possibly empty), from two operator inputs:
+#   EXECUTION_ROLE_POLICY_ARNS         ready-made managed-policy ARNs (CSV) -- the
+#                                      "proper ops" path; passed through as-is.
+#   EXECUTION_ROLE_POLICY_JSON[_FILE]  a pasted IAM policy document (multi-line
+#                                      ok).  CFN cannot attach a string policy
+#                                      (no Lambda in this product), so the driver
+#                                      flattens it (jq -c) and creates/updates a
+#                                      customer-managed policy named
+#                                      <STACK_NAME>-exec-extra, then attaches its
+#                                      ARN via the stack's ManagedPolicyArns.
+# Called directly (not in $()) so a validation error can exit the whole script.
+resolve_exec_role_policy_arns() {
+    EXEC_EXTRA_ARNS="${EXECUTION_ROLE_POLICY_ARNS:-}"
+    _erp_json=""
+    if [ -n "${EXECUTION_ROLE_POLICY_JSON:-}" ]; then
+        _erp_json="$EXECUTION_ROLE_POLICY_JSON"
+    elif [ -n "${EXECUTION_ROLE_POLICY_JSON_FILE:-}" ]; then
+        [ -r "$EXECUTION_ROLE_POLICY_JSON_FILE" ] || { echo "[deploy-lakerunner-infra-base] ERROR: cannot read EXECUTION_ROLE_POLICY_JSON_FILE: $EXECUTION_ROLE_POLICY_JSON_FILE" >&2; exit 2; }
+        _erp_json=$(cat "$EXECUTION_ROLE_POLICY_JSON_FILE")
+    fi
+    [ -n "$_erp_json" ] || return 0
+
+    command -v jq >/dev/null 2>&1 || { echo "[deploy-lakerunner-infra-base] ERROR: jq is required for EXECUTION_ROLE_POLICY_JSON" >&2; exit 2; }
+    _erp_doc=$(printf '%s' "$_erp_json" | jq -c . 2>/dev/null) || { echo "[deploy-lakerunner-infra-base] ERROR: EXECUTION_ROLE_POLICY_JSON is not valid JSON" >&2; exit 2; }
+    _erp_name="${STACK_NAME}-exec-extra"
+    _erp_acct=$(aws sts get-caller-identity --query Account --output text)
+    _erp_arn="arn:aws:iam::${_erp_acct}:policy/${_erp_name}"
+    if _erp_def=$(aws iam get-policy --policy-arn "$_erp_arn" --query 'Policy.DefaultVersionId' --output text 2>/dev/null); then
+        # IAM caps a policy at 5 versions; drop the non-default ones before adding.
+        for _erp_v in $(aws iam list-policy-versions --policy-arn "$_erp_arn" --query 'Versions[].VersionId' --output text); do
+            [ "$_erp_v" = "$_erp_def" ] && continue
+            aws iam delete-policy-version --policy-arn "$_erp_arn" --version-id "$_erp_v" >/dev/null 2>&1 || true
+        done
+        aws iam create-policy-version --policy-arn "$_erp_arn" --policy-document "$_erp_doc" --set-as-default >/dev/null
+        echo "[deploy-lakerunner-infra-base] updated execution-role managed policy: $_erp_arn" >&2
+    else
+        aws iam create-policy --policy-name "$_erp_name" --policy-document "$_erp_doc" --description "Cardinal execution-role extra policy for $STACK_NAME" >/dev/null
+        echo "[deploy-lakerunner-infra-base] created execution-role managed policy: $_erp_arn" >&2
+    fi
+    if [ -n "$EXEC_EXTRA_ARNS" ]; then
+        EXEC_EXTRA_ARNS="$EXEC_EXTRA_ARNS,$_erp_arn"
+    else
+        EXEC_EXTRA_ARNS="$_erp_arn"
+    fi
+}
+
 usage() {
     cat <<EOF
 deploy-lakerunner-infra-base.sh -- deploy the cardinal-lakerunner-infra-base stack.
@@ -51,6 +98,15 @@ Optional (template defaults preserved when unset):
                                Access config (template default 'false': not set).
   LICENSE_SECRET_NAME          (template default cardinal-license).
   ADMIN_KEY_SECRET_NAME        (template default cardinal-admin-key).
+  EXECUTION_ROLE_POLICY_ARNS   Comma-separated managed-policy ARNs to attach to
+                               the ECS task execution role (e.g. ECR pull-through
+                               import, cross-account ECR, KMS decrypt).
+  EXECUTION_ROLE_POLICY_JSON   A pasted IAM policy document (multi-line ok). The
+                               driver flattens it and creates/updates a customer
+                               managed policy <STACK_NAME>-exec-extra, then
+                               attaches it. Requires jq + iam:CreatePolicy/
+                               CreatePolicyVersion. Or use *_FILE for a path.
+  EXECUTION_ROLE_POLICY_JSON_FILE  Path fallback for EXECUTION_ROLE_POLICY_JSON.
   TEMPLATE_BASE_URL            Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN            Passed to create-change-set.
   NO_EXECUTE                   Non-empty: change-set only, do not execute.
@@ -115,6 +171,12 @@ ConfigureBucketPublicAccessBlock=$CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK"
 LicenseSecretName=$LICENSE_SECRET_NAME"
 [ -n "${ADMIN_KEY_SECRET_NAME:-}" ] && params="$params
 AdminKeySecretName=$ADMIN_KEY_SECRET_NAME"
+
+# Optional execution-role extra managed policies (pasted JSON and/or ARNs).
+EXEC_EXTRA_ARNS=""
+resolve_exec_role_policy_arns
+[ -n "$EXEC_EXTRA_ARNS" ] && params="$params
+ExecutionRoleExtraPolicyArns=$EXEC_EXTRA_ARNS"
 
 PARAMS="$params"
 FROM_STACKS=""

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -32,6 +32,53 @@ DEFAULT_STACK_VERSION="dev"
 OTEL_IMAGE_SUFFIX="cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
 DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 
+# Resolve optional execution-role managed-policy ARNs into the global
+# EXEC_EXTRA_ARNS (a CSV, possibly empty), from two operator inputs:
+#   EXECUTION_ROLE_POLICY_ARNS         ready-made managed-policy ARNs (CSV) -- the
+#                                      "proper ops" path; passed through as-is.
+#   EXECUTION_ROLE_POLICY_JSON[_FILE]  a pasted IAM policy document (multi-line
+#                                      ok).  CFN cannot attach a string policy
+#                                      (no Lambda in this product), so the driver
+#                                      flattens it (jq -c) and creates/updates a
+#                                      customer-managed policy named
+#                                      <STACK_NAME>-exec-extra, then attaches its
+#                                      ARN via the stack's ManagedPolicyArns.
+# Called directly (not in $()) so a validation error can exit the whole script.
+resolve_exec_role_policy_arns() {
+    EXEC_EXTRA_ARNS="${EXECUTION_ROLE_POLICY_ARNS:-}"
+    _erp_json=""
+    if [ -n "${EXECUTION_ROLE_POLICY_JSON:-}" ]; then
+        _erp_json="$EXECUTION_ROLE_POLICY_JSON"
+    elif [ -n "${EXECUTION_ROLE_POLICY_JSON_FILE:-}" ]; then
+        [ -r "$EXECUTION_ROLE_POLICY_JSON_FILE" ] || { echo "[deploy-satellite-services] ERROR: cannot read EXECUTION_ROLE_POLICY_JSON_FILE: $EXECUTION_ROLE_POLICY_JSON_FILE" >&2; exit 2; }
+        _erp_json=$(cat "$EXECUTION_ROLE_POLICY_JSON_FILE")
+    fi
+    [ -n "$_erp_json" ] || return 0
+
+    command -v jq >/dev/null 2>&1 || { echo "[deploy-satellite-services] ERROR: jq is required for EXECUTION_ROLE_POLICY_JSON" >&2; exit 2; }
+    _erp_doc=$(printf '%s' "$_erp_json" | jq -c . 2>/dev/null) || { echo "[deploy-satellite-services] ERROR: EXECUTION_ROLE_POLICY_JSON is not valid JSON" >&2; exit 2; }
+    _erp_name="${STACK_NAME}-exec-extra"
+    _erp_acct=$(aws sts get-caller-identity --query Account --output text)
+    _erp_arn="arn:aws:iam::${_erp_acct}:policy/${_erp_name}"
+    if _erp_def=$(aws iam get-policy --policy-arn "$_erp_arn" --query 'Policy.DefaultVersionId' --output text 2>/dev/null); then
+        # IAM caps a policy at 5 versions; drop the non-default ones before adding.
+        for _erp_v in $(aws iam list-policy-versions --policy-arn "$_erp_arn" --query 'Versions[].VersionId' --output text); do
+            [ "$_erp_v" = "$_erp_def" ] && continue
+            aws iam delete-policy-version --policy-arn "$_erp_arn" --version-id "$_erp_v" >/dev/null 2>&1 || true
+        done
+        aws iam create-policy-version --policy-arn "$_erp_arn" --policy-document "$_erp_doc" --set-as-default >/dev/null
+        echo "[deploy-satellite-services] updated execution-role managed policy: $_erp_arn" >&2
+    else
+        aws iam create-policy --policy-name "$_erp_name" --policy-document "$_erp_doc" --description "Cardinal execution-role extra policy for $STACK_NAME" >/dev/null
+        echo "[deploy-satellite-services] created execution-role managed policy: $_erp_arn" >&2
+    fi
+    if [ -n "$EXEC_EXTRA_ARNS" ]; then
+        EXEC_EXTRA_ARNS="$EXEC_EXTRA_ARNS,$_erp_arn"
+    else
+        EXEC_EXTRA_ARNS="$_erp_arn"
+    fi
+}
+
 usage() {
     cat <<EOF
 deploy-satellite-services.sh -- deploy the cardinal-satellite-services stack.
@@ -62,6 +109,14 @@ Optional (template defaults preserved when unset):
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
+  EXECUTION_ROLE_POLICY_ARNS   Comma-separated managed-policy ARNs to attach to
+                       the collector execution role (e.g. ECR pull-through
+                       import, cross-account ECR, KMS decrypt).
+  EXECUTION_ROLE_POLICY_JSON   A pasted IAM policy document (multi-line ok). The
+                       driver flattens it and creates/updates a customer managed
+                       policy <STACK_NAME>-exec-extra, then attaches it. Requires
+                       jq + iam:CreatePolicy/CreatePolicyVersion. Or use *_FILE.
+  EXECUTION_ROLE_POLICY_JSON_FILE  Path fallback for EXECUTION_ROLE_POLICY_JSON.
   TEMPLATE_BASE_URL    Default: $DEFAULT_TEMPLATE_BASE_URL
   DEPLOYER_ROLE_ARN    Passed to create-change-set.
   NO_EXECUTE           Non-empty: change-set only, do not execute.
@@ -132,6 +187,12 @@ OtelImage=$otel_image"
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
+
+# Optional execution-role extra managed policies (pasted JSON and/or ARNs).
+EXEC_EXTRA_ARNS=""
+resolve_exec_role_policy_arns
+[ -n "$EXEC_EXTRA_ARNS" ] && params="$params
+ExecutionRoleExtraPolicyArns=$EXEC_EXTRA_ARNS"
 
 PARAMS="$params"
 

--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -46,6 +46,7 @@ from troposphere import (
     Output,
     Parameter,
     Ref,
+    Split,
     Sub,
     Tags,
     Template,
@@ -483,12 +484,34 @@ def build() -> Template:
     # ----------------------------------------------------------------------
     # Shared ECS execution role
     # ----------------------------------------------------------------------
+    # Optional customer-supplied managed policies appended to the execution role
+    # (e.g. ECR pull-through-cache import, cross-account ECR, KMS decrypt). The
+    # deploy driver can build one from a pasted JSON policy, or the operator can
+    # pass ready-made managed-policy ARNs directly (CSV) as they grow into ops.
+    t.add_parameter(Parameter(
+        "ExecutionRoleExtraPolicyArns",
+        Type="String",
+        Default="",
+        Description=(
+            "Optional comma-separated managed-policy ARNs to attach to the ECS "
+            "task execution role, in addition to AmazonECSTaskExecutionRolePolicy."
+        ),
+    ))
+    t.add_condition(
+        "HasExecutionRoleExtraPolicies",
+        Not(Equals(Ref("ExecutionRoleExtraPolicyArns"), "")),
+    )
     exec_role = t.add_resource(Role(
         "ExecutionRole",
         AssumeRolePolicyDocument=_ecs_tasks_trust(),
-        ManagedPolicyArns=[
-            "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
-        ],
+        ManagedPolicyArns=If(
+            "HasExecutionRoleExtraPolicies",
+            Split(",", Sub(
+                "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy,"
+                "${ExecutionRoleExtraPolicyArns}"
+            )),
+            ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"],
+        ),
         Policies=[
             Policy(
                 PolicyName="cardinal-task-exec-extras",

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -296,13 +296,35 @@ def build() -> Template:
     # ------------------------------------------------------------------
     # IAM: execution role
     # ------------------------------------------------------------------
+    # Optional customer-supplied managed policies appended to the execution role
+    # (e.g. ECR pull-through-cache import, cross-account ECR, KMS decrypt). The
+    # deploy driver can build one from a pasted JSON policy, or the operator can
+    # pass ready-made managed-policy ARNs directly (CSV) as they grow into ops.
+    t.add_parameter(Parameter(
+        "ExecutionRoleExtraPolicyArns",
+        Type="String",
+        Default="",
+        Description=(
+            "Optional comma-separated managed-policy ARNs to attach to the ECS "
+            "task execution role, in addition to AmazonECSTaskExecutionRolePolicy."
+        ),
+    ))
+    t.add_condition(
+        "HasExecutionRoleExtraPolicies",
+        Not(Equals(Ref("ExecutionRoleExtraPolicyArns"), "")),
+    )
     exec_role = t.add_resource(
         Role(
             "CollectorExecutionRole",
             AssumeRolePolicyDocument=_ecs_tasks_trust(),
-            ManagedPolicyArns=[
-                "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy",
-            ],
+            ManagedPolicyArns=If(
+                "HasExecutionRoleExtraPolicies",
+                Split(",", Sub(
+                    "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy,"
+                    "${ExecutionRoleExtraPolicyArns}"
+                )),
+                ["arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"],
+            ),
             Policies=[
                 Policy(
                     PolicyName="cardinal-collector-exec-extras",

--- a/tests/templates/test_lakerunner_infra_base.py
+++ b/tests/templates/test_lakerunner_infra_base.py
@@ -248,8 +248,19 @@ def test_process_role_s3_readwrite_targets_cooked_bucket(td):
 
 
 def test_exec_role_has_managed_execution_policy(td):
+    # ManagedPolicyArns is an Fn::If: base-only when no extras are supplied,
+    # base + the operator CSV (split) when ExecutionRoleExtraPolicyArns is set.
     arns = td["Resources"]["ExecutionRole"]["Properties"]["ManagedPolicyArns"]
-    assert any("AmazonECSTaskExecutionRolePolicy" in a for a in arns)
+    blob = json.dumps(arns)
+    assert "AmazonECSTaskExecutionRolePolicy" in blob
+    assert "ExecutionRoleExtraPolicyArns" in blob
+
+
+def test_exec_role_extra_policy_param_and_condition(td):
+    p = td["Parameters"]["ExecutionRoleExtraPolicyArns"]
+    assert p["Type"] == "String"
+    assert p["Default"] == ""
+    assert "HasExecutionRoleExtraPolicies" in td["Conditions"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/templates/test_satellite_services.py
+++ b/tests/templates/test_satellite_services.py
@@ -265,3 +265,22 @@ def test_outputs_present(td):
         "CollectorTaskRoleArn",
     ):
         assert o in td["Outputs"], f"missing output: {o}"
+
+
+# ---------------------------------------------------------------------------
+# Execution-role extra managed policies (air-gapped ECR / pull-through)
+# ---------------------------------------------------------------------------
+
+
+def test_exec_role_extra_policy_param_and_condition(td):
+    p = td["Parameters"]["ExecutionRoleExtraPolicyArns"]
+    assert p["Type"] == "String"
+    assert p["Default"] == ""
+    assert "HasExecutionRoleExtraPolicies" in td["Conditions"]
+
+
+def test_exec_role_managed_policy_arns_conditional(td):
+    arns = td["Resources"]["CollectorExecutionRole"]["Properties"]["ManagedPolicyArns"]
+    blob = json.dumps(arns)
+    assert "AmazonECSTaskExecutionRolePolicy" in blob
+    assert "ExecutionRoleExtraPolicyArns" in blob


### PR DESCRIPTION
## Summary

Lets customers attach extra permissions to the ECS task **execution role** (the image-pull role), driven from the deploy driver — for air-gapped ECR pull-through first-pull, cross-account ECR, or KMS-encrypted repos. Two paths so they can grow from pasted JSON into proper managed-policy ops.

(Standard private-ECR pulls already work — `AmazonECSTaskExecutionRolePolicy` grants the four ECR read actions. This is for the cases it doesn't cover.)

## Constraint

CFN can't attach a string parameter as an IAM `PolicyDocument` (must be structured), and the string→policy workaround needs Lambda, which this product bans. So a pasted JSON policy must become a real IAM policy object first.

## Changes

- **Templates** (`lakerunner-infra-base` `ExecutionRole`, `satellite-services` `CollectorExecutionRole`): new `ExecutionRoleExtraPolicyArns` param (CSV) → appended to `ManagedPolicyArns` via `Fn::If`/`Split`/`Sub` alongside the base policy. Empty default = unchanged behavior.
- **Drivers** (`deploy-lakerunner-infra-base.sh`, `deploy-satellite-services.sh`):
  - `EXECUTION_ROLE_POLICY_ARNS` — ready-made managed-policy ARNs, passed through ("proper ops").
  - `EXECUTION_ROLE_POLICY_JSON` / `_FILE` — a pasted IAM policy (multi-line ok); the driver flattens it (`jq -c`) and creates/updates a managed policy `<STACK_NAME>-exec-extra` (version-pruned under the IAM 5-version cap), then attaches by ARN. Needs `jq` + IAM write perms for the deployer.
  - Both optional and combinable.

## Testing

- `make build` clean (cfn-lint passes the new `Fn::If`/`Split`/`Sub`).
- `make test` — 491 passed, 1 skipped (incl. deploy-driver drift + shellcheck; new template tests for the param/condition/ManagedPolicyArns on both stacks).
- Behavioral: `EXECUTION_ROLE_POLICY_ARNS` passes through into the param (JSON path needs live IAM, covered by inspection).

## Upgrade action

None — both inputs are optional and default to today's behavior. No resource replacement.

See `docs/air-gapped-images.md` and the spec under `docs/superpowers/`.