### PR TITLE
bump(dex): v0.1.0 -> v0.2.0 (embedded theme, drop frontend.dir)

### DIFF
--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -36,7 +36,7 @@ images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0@sha256:642e93afbbf846535923fc4ad59ea790fd0aff85cc6889355e866ab883da5001"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
-  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.1.0@sha256:a1d0af5a99068516df067af803312c03b62b1bd07eefb16e914bd1d55deacf9c"
+  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.2.0@sha256:4a3aed43c7c800a19d840c2cf5a483d614c11aea6dcbff6661df9cf28aa4c707"
   dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # external images (busybox, the ghcr db-init) keep their own full-URI overrides.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.50.0@sha256:642e93afbbf846535923fc4ad59ea790fd0aff85cc6889355e866ab883da5001"
-DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.1.0@sha256:a1d0af5a99068516df067af803312c03b62b1bd07eefb16e914bd1d55deacf9c"
+DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.2.0@sha256:4a3aed43c7c800a19d840c2cf5a483d614c11aea6dcbff6661df9cf28aa4c707"
 
 usage() {
     cat <<EOF

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -597,8 +597,10 @@ def build() -> Template:
         "  type: memory\n"
         "web:\n"
         "  http: 0.0.0.0:${DEX_PORT}\n"
+        # The Cardinal theme is embedded in the dex binary as of
+        # dex-customization v0.2.0 — no frontend.dir needed. (issuer names the
+        # login page; it is unrelated to asset loading.)
         "frontend:\n"
-        "  dir: /srv/dex-cardinal/web\n"
         "  issuer: Cardinal\n"
         "oauth2:\n"
         "  skipApprovalScreen: true\n"


### PR DESCRIPTION
## What
Bump the bundled Dex image to **dex-customization v0.2.0**, which embeds the Cardinal theme directly in the dex binary. The dex-init config no longer sets `frontend.dir`.

## Why
v0.2.0 is a drop-in for `ghcr.io/dexidp/dex`: the themed login is the embedded default, so no `frontend.dir` is needed. v0.2.0 also **removes** the old `/srv/dex-cardinal/web` disk path — a stale `frontend.dir: /srv/dex-cardinal/web` now points at a missing directory and **dex fails to boot**, so the line must go in the same change as the image bump.

## Changes
- `src/cardinal_cfn/children/maestro.py` — drop `  dir: /srv/dex-cardinal/web` from the dex-init config heredoc. Keep `frontend.issuer: Cardinal` (names the login page; unrelated to asset loading).
- `cardinal-defaults.yaml` — `dex` image → `v0.2.0@sha256:4a3aed43…` (multi-arch index digest of the published image).

## Verification
- `pytest tests/templates/test_maestro.py` → 34 passed.
- v0.2.0 image published to public ECR (amd64 + arm64); digest pinned above.
- Upstream context: cardinalhq/dex-customization#2 (embed) + tag `v0.2.0`.