### PR TITLE
services driver: auto-generate cert on rollback/review recreate, not just when absent

### DIFF
--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -335,26 +335,41 @@ CertificatePrivateKey=$cert_key_path"
 CertificateChain=$cert_chain_path"
         fi
     else
-        # No ARN, no PEM.  Generate only on first create (stack absent).
-        if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
-            echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
-        else
-            if ! command -v openssl >/dev/null 2>&1; then
-                echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_BODY+CERTIFICATE_PRIVATE_KEY (or their *_FILE variants)" >&2
-                exit 2
-            fi
-            echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
-            cert_dir=$(mktemp -d)
-            if ! openssl req -x509 -newkey rsa:2048 -nodes \
-                    -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
-                    -days 825 -subj "/CN=cardinal.test" \
-                    -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
-                echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
-                exit 1
-            fi
-            file_params="CertificateBody=$cert_dir/cert.pem
+        # No ARN, no PEM.  Generate a self-signed cert whenever the engine will
+        # do a fresh CREATE: when the stack is absent, or when it is in a state
+        # the engine deletes and recreates (REVIEW_IN_PROGRESS / ROLLBACK_COMPLETE
+        # -- kept in sync with the recreate states in base.sh).  On an in-place
+        # UPDATE the existing cert is left untouched (the engine resolves it to
+        # UsePreviousValue) so the ALB HTTPS listener does not churn.
+        #
+        # A bare "does the stack exist?" check is wrong here: it skips generation
+        # for a ROLLBACK_COMPLETE stack that the engine then recreates, leaving
+        # CertificateArn empty and failing the listener with
+        # "Certificate ARN '' is not valid".
+        cert_stack_status=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+            --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "")
+        case "$cert_stack_status" in
+            ""|REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE)
+                if ! command -v openssl >/dev/null 2>&1; then
+                    echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_BODY+CERTIFICATE_PRIVATE_KEY (or their *_FILE variants)" >&2
+                    exit 2
+                fi
+                echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and stack will be created (${cert_stack_status:-absent}); generating a self-signed internal cert" >&2
+                cert_dir=$(mktemp -d)
+                if ! openssl req -x509 -newkey rsa:2048 -nodes \
+                        -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
+                        -days 825 -subj "/CN=cardinal.test" \
+                        -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
+                    echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
+                    exit 1
+                fi
+                file_params="CertificateBody=$cert_dir/cert.pem
 CertificatePrivateKey=$cert_dir/key.pem"
-        fi
+                ;;
+            *)
+                echo "[deploy-lakerunner-services] stack is $cert_stack_status (in-place update); keeping the existing self-signed cert (no regeneration)" >&2
+                ;;
+        esac
     fi
 fi
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -336,26 +336,41 @@ CertificatePrivateKey=$cert_key_path"
 CertificateChain=$cert_chain_path"
         fi
     else
-        # No ARN, no PEM.  Generate only on first create (stack absent).
-        if aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" >/dev/null 2>&1; then
-            echo "[deploy-lakerunner-services] stack exists; keeping the existing self-signed cert (no regeneration)" >&2
-        else
-            if ! command -v openssl >/dev/null 2>&1; then
-                echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_BODY+CERTIFICATE_PRIVATE_KEY (or their *_FILE variants)" >&2
-                exit 2
-            fi
-            echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and first create; generating a self-signed internal cert" >&2
-            cert_dir=$(mktemp -d)
-            if ! openssl req -x509 -newkey rsa:2048 -nodes \
-                    -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
-                    -days 825 -subj "/CN=cardinal.test" \
-                    -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
-                echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
-                exit 1
-            fi
-            file_params="CertificateBody=$cert_dir/cert.pem
+        # No ARN, no PEM.  Generate a self-signed cert whenever the engine will
+        # do a fresh CREATE: when the stack is absent, or when it is in a state
+        # the engine deletes and recreates (REVIEW_IN_PROGRESS / ROLLBACK_COMPLETE
+        # -- kept in sync with the recreate states in base.sh).  On an in-place
+        # UPDATE the existing cert is left untouched (the engine resolves it to
+        # UsePreviousValue) so the ALB HTTPS listener does not churn.
+        #
+        # A bare "does the stack exist?" check is wrong here: it skips generation
+        # for a ROLLBACK_COMPLETE stack that the engine then recreates, leaving
+        # CertificateArn empty and failing the listener with
+        # "Certificate ARN '' is not valid".
+        cert_stack_status=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" --region "$REGION" \
+            --query 'Stacks[0].StackStatus' --output text 2>/dev/null || echo "")
+        case "$cert_stack_status" in
+            ""|REVIEW_IN_PROGRESS|ROLLBACK_COMPLETE)
+                if ! command -v openssl >/dev/null 2>&1; then
+                    echo "[deploy-lakerunner-services] ERROR: openssl is required to auto-generate a self-signed cert; install openssl or set CERTIFICATE_ARN / CERTIFICATE_BODY+CERTIFICATE_PRIVATE_KEY (or their *_FILE variants)" >&2
+                    exit 2
+                fi
+                echo "[deploy-lakerunner-services] no CERTIFICATE_ARN and stack will be created (${cert_stack_status:-absent}); generating a self-signed internal cert" >&2
+                cert_dir=$(mktemp -d)
+                if ! openssl req -x509 -newkey rsa:2048 -nodes \
+                        -keyout "$cert_dir/key.pem" -out "$cert_dir/cert.pem" \
+                        -days 825 -subj "/CN=cardinal.test" \
+                        -addext "subjectAltName=DNS:cardinal.test,DNS:*.cardinal.internal" 2>/dev/null; then
+                    echo "[deploy-lakerunner-services] ERROR: openssl failed to generate the self-signed cert" >&2
+                    exit 1
+                fi
+                file_params="CertificateBody=$cert_dir/cert.pem
 CertificatePrivateKey=$cert_dir/key.pem"
-        fi
+                ;;
+            *)
+                echo "[deploy-lakerunner-services] stack is $cert_stack_status (in-place update); keeping the existing self-signed cert (no regeneration)" >&2
+                ;;
+        esac
     fi
 fi
 


### PR DESCRIPTION
## Problem

The `cardinal-lakerunner-services` driver auto-generates a self-signed cert (when no `CERTIFICATE_ARN`/PEM is supplied) only on a fresh create. It detected "fresh create" with a bare existence check — if `describe-stacks` succeeded at all, it skipped generation and relied on `UsePreviousValue`.

But the embedded engine (`base.sh`) **deletes and recreates** a stack found in `REVIEW_IN_PROGRESS` or `ROLLBACK_COMPLETE`. In those states the bare check skipped generation, yet the engine then did a CREATE with no previous value — so `CertificateArn` resolved empty and the ALB HTTPS listeners failed:

```
Certificate ARN '' is not valid (Service: ElasticLoadBalancingV2, Status Code: 400)
```

A customer whose first deploy rolled back is wedged: re-running never regenerates the cert.

## Fix

Decide by **stack status**, mirroring the engine's recreate states:
- absent / `REVIEW_IN_PROGRESS` / `ROLLBACK_COMPLETE` → generate the self-signed cert (the engine will CREATE).
- any other (true in-place UPDATE) → keep the existing cert (no regeneration, no ALB listener churn).

Edited `scripts-src/parts/deploy-lakerunner-services.sh`; `scripts/deploy-lakerunner-services.sh` regenerated via `make scripts`. `make test` green (491 passed).

## How found

Hit during a from-scratch test-account install: a Maestro failure rolled back `lakerunner-services`, and every re-run then failed on the empty cert until the stack was manually deleted.