### PR TITLE
satellite-services: collector ALB allows 0.0.0.0/0 when internet-facing

### DIFF
--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -39,7 +39,7 @@ from troposphere import (
     Tags,
     Template,
 )
-from troposphere.ec2 import SecurityGroup, SecurityGroupRule
+from troposphere.ec2 import SecurityGroup, SecurityGroupIngress, SecurityGroupRule
 from troposphere.ecs import (
     AwsvpcConfiguration,
     CapacityProviderStrategyItem,
@@ -412,6 +412,30 @@ def build() -> Template:
             # RevokeSecurityGroupEgress the default first, an action some
             # customer SCPs explicitly deny (VPC-destructive guard).
             Tags=_tags(component="satellite-alb-sg"),
+        )
+    )
+
+    # When AlbScheme=internet-facing the collector ALB lives in public subnets,
+    # so its intended senders -- including the lakerunner tier's own
+    # self-telemetry -- reach it from outside the VPC. In-VPC senders egress via
+    # the VPC's NAT gateway and so arrive with a *public* source IP that the
+    # RFC1918 IngestSourceCidr default does not cover, which silently blackholes
+    # OTLP and leaves the pipeline empty. Layer a 0.0.0.0/0 ingress on the OTLP
+    # port when internet-facing, matching the app ALB in lakerunner-infra-base.
+    # Internal ALBs are unaffected: their only ingress remains IngestSourceCidr.
+    t.add_condition(
+        "AlbIsInternetFacing", Equals(Ref("AlbScheme"), "internet-facing")
+    )
+    t.add_resource(
+        SecurityGroupIngress(
+            "AlbIngressInternetFacing",
+            Condition="AlbIsInternetFacing",
+            GroupId=Ref(alb_sg),
+            IpProtocol="tcp",
+            FromPort=_OTLP_HTTP_PORT,
+            ToPort=_OTLP_HTTP_PORT,
+            CidrIp="0.0.0.0/0",
+            Description="OTLP/HTTP from 0.0.0.0/0 (internet-facing)",
         )
     )
 


### PR DESCRIPTION
## Problem

The satellite collector ALB security group only ever allowed `IngestSourceCidr` (default `10.0.0.0/8`) on 4318, regardless of `AlbScheme`. So an `internet-facing` collector got public subnets but an SG that still rejected anything outside RFC1918 — not actually reachable as intended.

This silently broke the whole ingest/process pipeline on the standard internet-facing spin-up: the lakerunner tier ships its **self-telemetry** to this collector (`SelfTelemetryEndpoint` = the satellite `CollectorEndpoint`). Those tasks run in private subnets, so they egress via the VPC **NAT gateway** and reach the internet-facing ALB with a *public* source IP that `10.0.0.0/8` doesn't cover. OTLP POSTs timed out (`context deadline exceeded`), nothing landed in the raw bucket/queue, `process-*` had zero input, and the UI showed no data — even though every ECS service was healthy.

## Fix

When `AlbScheme=internet-facing`, layer a `0.0.0.0/0` ingress on the OTLP port (4318), mirroring the app ALB in `lakerunner-infra-base`. **Internal ALBs are unchanged** — their only ingress remains `IngestSourceCidr` (default `10.0.0.0/8`).

## Validation

Applied to a live internet-facing install: removed a manual interim SG rule, updated the stack with this template, and confirmed self-telemetry then flowed end-to-end via the template rule alone — raw bucket ingesting, `pubsub-sqs` processing logs/metrics/traces with 0 failed/0 skipped, cooked bucket growing (200+ objects). `make build` (cfn-lint) clean; `make test` 491 passed.