### PR TITLE
dex v0.3.0: drop dex-init sidecar; bump maestro v1.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.131
+
+- **Image bumps: maestro `v1.50.0` -> `v1.53.0`, dex-customization `v0.2.0` ->
+  `v0.3.0`.** Redeploy `lakerunner-services` to pick them up. The maestro task
+  redeploys (brief blip on the singleton maestro/dex service); no data-bearing
+  resource is replaced.
+- **`dex-init` sidecar removed; `DexInitImage` parameter removed.** dex
+  v0.3.0 renders its own `/etc/dex/config.yaml` at startup (gomplate over a
+  baked template, from the same `DexClientId` / `DexAdminEmail` /
+  `DexAdminPasswordHash` inputs as before), so the busybox `dex-init` init
+  container is gone. The maestro task drops from six containers to five, and
+  the `busybox` image is no longer pulled. **Upgrade action:** redeploy
+  `lakerunner-services`. If you set the `DexInitImage` stack parameter or the
+  `DEX_INIT_IMAGE` deploy-driver env var in a saved config, remove it — both
+  no longer exist. No change to the DEX admin login or OIDC behavior.
+- **dex container now runs with a writable root filesystem (was read-only),
+  still as nonroot.** dex v0.3.0's entrypoint writes the rendered config to
+  `/tmp`; on Fargate a read-only rootfs would require a writable `/tmp` volume,
+  but empty Fargate volumes mount `0755 root:root` and the nonroot dex user
+  can't write them. Rather than run dex as root or add an init container, the
+  dex container leaves `ReadOnlyRootFilesystem` unset and uses the image's
+  `1777` `/tmp` on the task's ephemeral storage. No upgrade action.
+
 ## v0.0.130
 
 - **Internet-facing collector ALB is now actually reachable (ingest pipeline

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,10 +34,9 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.50.0@sha256:642e93afbbf846535923fc4ad59ea790fd0aff85cc6889355e866ab883da5001"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
-  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.2.0@sha256:4a3aed43c7c800a19d840c2cf5a483d614c11aea6dcbff6661df9cf28aa4c707"
-  dex_init:   "public.ecr.aws/docker/library/busybox:1.37"
+  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
   db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
 
 # ---------------------------------------------------------------------------

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -101,9 +101,6 @@ Optional (template defaults preserved when unset):
                               PUBLIC_SUBNETS, and the ALB SG internet ingress is
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
-  DEX_INIT_IMAGE              Full image URI override for the dex-init busybox
-                              (a non-public-ECR/utility image, not covered by
-                              IMAGE_REGISTRY). Default: the template default.
   DB_INIT_IMAGE               Full image URI override for the db-init image
                               (ghcr, not covered by IMAGE_REGISTRY). Default:
                               the template default.
@@ -245,8 +242,6 @@ MaestroImage=$maestro_image
 DexImage=$dex_image"
 # External/utility images: full-URI overrides, not driven by IMAGE_REGISTRY.
 # Unset -> the template default governs.
-[ -n "${DEX_INIT_IMAGE:-}" ] && params="$params
-DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params
 DbInitImage=$DB_INIT_IMAGE"
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -30,8 +30,8 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # first-party public-ECR images.  Only the registry prefix is operator-supplied;
 # external images (busybox, the ghcr db-init) keep their own full-URI overrides.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.50.0@sha256:642e93afbbf846535923fc4ad59ea790fd0aff85cc6889355e866ab883da5001"
-DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.2.0@sha256:4a3aed43c7c800a19d840c2cf5a483d614c11aea6dcbff6661df9cf28aa4c707"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
+DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
 
 usage() {
     cat <<EOF
@@ -102,9 +102,6 @@ Optional (template defaults preserved when unset):
                               PUBLIC_SUBNETS, and the ALB SG internet ingress is
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
-  DEX_INIT_IMAGE              Full image URI override for the dex-init busybox
-                              (a non-public-ECR/utility image, not covered by
-                              IMAGE_REGISTRY). Default: the template default.
   DB_INIT_IMAGE               Full image URI override for the db-init image
                               (ghcr, not covered by IMAGE_REGISTRY). Default:
                               the template default.
@@ -246,8 +243,6 @@ MaestroImage=$maestro_image
 DexImage=$dex_image"
 # External/utility images: full-URI overrides, not driven by IMAGE_REGISTRY.
 # Unset -> the template default governs.
-[ -n "${DEX_INIT_IMAGE:-}" ] && params="$params
-DexInitImage=$DEX_INIT_IMAGE"
 [ -n "${DB_INIT_IMAGE:-}" ] && params="$params
 DbInitImage=$DB_INIT_IMAGE"
 

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -1,6 +1,6 @@
 """maestro.yaml nested stack: maestro + DEX ECS Fargate service.
 
-Owns a SINGLE ECS Fargate service running a six-container task definition:
+Owns a SINGLE ECS Fargate service running a five-container task definition:
 
   1. db-init       (Essential=False, runs psql to create the maestro database)
   2. mcp-gateway   (Essential=True, runs maestro DB schema migrations on
@@ -9,14 +9,14 @@ Owns a SINGLE ECS Fargate service running a six-container task definition:
   3. wait-for-mcp  (Essential=False, blocks until mcp-gateway has finished
                     its on-startup migrations so maestro doesn't race them)
   4. maestro      (Essential=True, listens on the maestro HTTPS port)
-  5. dex-init      (Essential=False, renders the DEX config from CFN-supplied
-                    OIDC params: DexAdminEmail, DexAdminPasswordHash,
-                    OidcSuperadminEmails)
-  6. dex          (Essential=True, listens on the DEX OIDC port)
+  5. dex          (Essential=True, listens on the DEX OIDC port; renders its
+                    own config from CFN-supplied OIDC params -- DexAdminEmail,
+                    DexAdminPasswordHash, OidcSuperadminEmails -- via the dex
+                    image's gomplate entrypoint, so no dex-init sidecar)
 
-Container dependsOn graph: db-init -> mcp-gateway -> wait-for-mcp -> maestro;
-dex-init -> dex. Both maestro and dex attach to the shared cardinal HTTPS
-listener via two ListenerRules:
+Container dependsOn graph: db-init -> mcp-gateway -> wait-for-mcp -> maestro.
+Both maestro and dex attach to the shared cardinal HTTPS listener via two
+ListenerRules:
 
   /*          -> maestro container, priority 49999 (catch-all default app)
   /dex/*      -> dex container,     priority 210
@@ -41,14 +41,12 @@ from troposphere.ecs import (
     Environment,
     LoadBalancer as EcsLoadBalancer,
     LogConfiguration,
-    MountPoint,
     NetworkConfiguration,
     PortMapping,
     RuntimePlatform,
     Secret,
     Service,
     TaskDefinition,
-    Volume,
 )
 from cardinal_cfn.children import services_common
 from cardinal_cfn.defaults import load_defaults
@@ -68,7 +66,6 @@ _SERVICE_KEY = "maestro"
 _DB_INIT_KEY = "maestro-db-init"
 _MAESTRO_KEY = "maestro"
 _DEX_KEY = "maestro-dex"
-_DEX_INIT_KEY = "maestro-dex-init"
 
 # Listener-rule registration keys (see listener_priorities.py).
 _MAESTRO_LISTENER_KEY = "maestro-https"
@@ -219,12 +216,6 @@ def build() -> Template:
         default=defaults["images"]["db_init"],
         description="Container image for the psql-capable db-init bootstrapper.",
     )
-    dex_init_image_ref = add_image_override(
-        t,
-        name="DexInitImage",
-        default=defaults["images"]["dex_init"],
-        description="BusyBox-style image used by the dex-init container to render config.yaml.",
-    )
 
     # ---------------------------------------------------------------------
     # Customer-tunable parameters
@@ -360,7 +351,7 @@ def build() -> Template:
             },
             {
                 "label": "Image overrides",
-                "parameters": ["MaestroImage", "DexImage", "DbInitImage", "DexInitImage"],
+                "parameters": ["MaestroImage", "DexImage", "DbInitImage"],
             },
             {
                 "label": "DEX configuration",
@@ -380,7 +371,6 @@ def build() -> Template:
     db_init_lg = t.add_resource(services_common.build_log_group(service_key=_DB_INIT_KEY))
     maestro_lg = t.add_resource(services_common.build_log_group(service_key=_MAESTRO_KEY))
     dex_lg = t.add_resource(services_common.build_log_group(service_key=_DEX_KEY))
-    dex_init_lg = t.add_resource(services_common.build_log_group(service_key=_DEX_INIT_KEY))
 
     # ---------------------------------------------------------------------
     # Container definitions (inlined: services_common.build_task_definition
@@ -580,53 +570,22 @@ def build() -> Template:
         ),
     )
 
-    # dex-init renders /etc/dex/config.yaml from env vars (BusyBox sh + heredoc).
-    # The unquoted heredoc expands ${DEX_*} once (no re-scan), so a bcrypt hash
-    # containing '$' survives intact. ALB DNS comes back mixed-case but
-    # browsers lower-case Host before sending; Dex's redirect_uri match is
-    # exact-string, so we register both the original and lowercased URI.
-    # 1777 on /dex-tmp because Fargate mounts empty volumes 0755 root:root and
-    # the nonroot dex container can't otherwise write its config-expansion
-    # tempfile on startup.
-    dex_config_render_script = (
-        "set -eu; "
-        "DEX_REDIRECT_URI_LC=$(echo \"$DEX_REDIRECT_URI\" | tr 'A-Z' 'a-z'); "
-        "cat > /etc/dex/config.yaml <<EOF\n"
-        "issuer: ${DEX_ISSUER_URL}\n"
-        "storage:\n"
-        "  type: memory\n"
-        "web:\n"
-        "  http: 0.0.0.0:${DEX_PORT}\n"
-        # The Cardinal theme is embedded in the dex binary as of
-        # dex-customization v0.2.0 — no frontend.dir needed. (issuer names the
-        # login page; it is unrelated to asset loading.)
-        "frontend:\n"
-        "  issuer: Cardinal\n"
-        "oauth2:\n"
-        "  skipApprovalScreen: true\n"
-        "enablePasswordDB: true\n"
-        "staticClients:\n"
-        "  - id: \"${DEX_CLIENT_ID}\"\n"
-        "    name: \"Maestro UI\"\n"
-        "    public: true\n"
-        "    redirectURIs:\n"
-        "      - \"${DEX_REDIRECT_URI}\"\n"
-        "      - \"${DEX_REDIRECT_URI_LC}\"\n"
-        "staticPasswords:\n"
-        "  - email: \"${DEX_ADMIN_EMAIL}\"\n"
-        "    hash: \"${DEX_ADMIN_HASH}\"\n"
-        "    username: \"admin\"\n"
-        "    userID: \"00000000-0000-0000-0000-000000000001\"\n"
-        "EOF\n"
-        "chmod 1777 /dex-tmp\n"
-    )
-
-    dex_init_container = ContainerDefinition(
-        Name="dex-init",
-        Image=dex_init_image_ref,
-        Essential=False,
-        EntryPoint=["/bin/sh", "-c"],
-        Command=[dex_config_render_script],
+    # dex-customization v0.3.0 renders its own config at startup: the inherited
+    # docker-entrypoint runs gomplate over the baked /etc/dex/config.docker.yaml
+    # (the image's default CMD) from the DEX_* env vars below and writes the
+    # result under /tmp before exec'ing dex -- so there is no dex-init sidecar.
+    # gomplate uses {{ }} delimiters (not '$'), so the bcrypt hash survives, and
+    # the template registers a lowercased copy of the redirect URI itself. We do
+    # NOT mount /etc/dex (a mount there shadows the baked template) and do NOT
+    # set ReadonlyRootFilesystem: the image's /tmp is a 1777 dir on the task's
+    # free ephemeral storage, writable by the nonroot dex user (uid 1001), so no
+    # writable volume or root chmod is needed.
+    dex_container = ContainerDefinition(
+        Name="dex",
+        Image=dex_image_ref,
+        Essential=True,
+        User="1001",
+        PortMappings=[PortMapping(ContainerPort=dex_port, Protocol="tcp")],
         Environment=[
             Environment(Name="DEX_ISSUER_URL", Value=Sub("https://${AlbDnsName}/dex")),
             Environment(Name="DEX_REDIRECT_URI", Value=Sub("https://${AlbDnsName}/")),
@@ -634,33 +593,6 @@ def build() -> Template:
             Environment(Name="DEX_PORT", Value=str(dex_port)),
             Environment(Name="DEX_ADMIN_EMAIL", Value=Ref("DexAdminEmail")),
             Environment(Name="DEX_ADMIN_HASH", Value=Ref("DexAdminPasswordHash")),
-        ],
-        MountPoints=[
-            MountPoint(ContainerPath="/etc/dex", SourceVolume="dex-config", ReadOnly=False),
-            MountPoint(ContainerPath="/dex-tmp", SourceVolume="dex-tmp", ReadOnly=False),
-        ],
-        LogConfiguration=LogConfiguration(
-            LogDriver="awslogs",
-            Options={
-                "awslogs-group": Ref(dex_init_lg),
-                "awslogs-region": Ref("AWS::Region"),
-                "awslogs-stream-prefix": "dex-init",
-            },
-        ),
-    )
-
-    dex_container = ContainerDefinition(
-        Name="dex",
-        Image=dex_image_ref,
-        Essential=True,
-        User="65532",
-        ReadonlyRootFilesystem=True,
-        Command=["dex", "serve", "/etc/dex/config.yaml"],
-        PortMappings=[PortMapping(ContainerPort=dex_port, Protocol="tcp")],
-        DependsOn=[{"ContainerName": "dex-init", "Condition": "SUCCESS"}],
-        MountPoints=[
-            MountPoint(ContainerPath="/etc/dex", SourceVolume="dex-config", ReadOnly=True),
-            MountPoint(ContainerPath="/tmp", SourceVolume="dex-tmp", ReadOnly=False),
         ],
         LogConfiguration=LogConfiguration(
             LogDriver="awslogs",
@@ -690,12 +622,7 @@ def build() -> Template:
                 mcp_gateway_container,
                 wait_for_mcp_container,
                 maestro_container,
-                dex_init_container,
                 dex_container,
-            ],
-            Volumes=[
-                Volume(Name="dex-config"),
-                Volume(Name="dex-tmp"),
             ],
             Tags=cardinal_tags(component="compute", role=_SERVICE_KEY),
         )

--- a/src/cardinal_cfn/image_manifest.py
+++ b/src/cardinal_cfn/image_manifest.py
@@ -17,7 +17,7 @@ from cardinal_cfn.defaults import load_defaults
 # the drivers handle via per-image overrides (busybox, the ghcr db-init).
 STACK_IMAGE_KEYS = {
     "satellite": ["otel"],
-    "lakerunner": ["lakerunner", "maestro", "dex", "dex_init", "db_init"],
+    "lakerunner": ["lakerunner", "maestro", "dex", "db_init"],
 }
 
 

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -447,16 +447,11 @@ def build() -> Template:
         t, name="DbInitImage",
         default=defaults["images"]["db_init"],
         description="psql-capable bootstrapper container image (maestro db-init).")
-    dex_init_image = add_image_override(
-        t, name="DexInitImage",
-        default=defaults["images"]["dex_init"],
-        description="BusyBox-style image used to render the dex config.yaml.")
     image_param_names = [
         "LakerunnerImage",
         "MaestroImage",
         "DexImage",
         "DbInitImage",
-        "DexInitImage",
     ]
 
     # ---------------------------------------------------------------------
@@ -700,7 +695,6 @@ def build() -> Template:
         "MaestroImage": maestro_image,
         "DexImage": dex_image,
         "DbInitImage": db_init_image,
-        "DexInitImage": dex_init_image,
         "MaestroTaskCpu": Ref("MaestroTaskCpu"),
         "MaestroTaskMemory": Ref("MaestroTaskMemory"),
         "McpMigrateRecoverFromDirty": Ref("McpMigrateRecoverFromDirty"),

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -81,7 +81,7 @@ def test_task_definition_has_expected_containers(td):
     )
     containers = task_def["Properties"]["ContainerDefinitions"]
     names = {c["Name"] for c in containers}
-    assert names == {"db-init", "mcp-gateway", "wait-for-mcp", "maestro", "dex-init", "dex"}
+    assert names == {"db-init", "mcp-gateway", "wait-for-mcp", "maestro", "dex"}
 
 
 def test_db_init_is_not_essential(td):
@@ -116,13 +116,13 @@ def test_maestro_depends_on_db_init(td):
     assert {"ContainerName": "db-init", "Condition": "SUCCESS"} in deps
 
 
-def test_four_log_groups(td):
+def test_three_log_groups(td):
     log_groups = [r for r in td["Resources"].values() if r["Type"] == "AWS::Logs::LogGroup"]
-    assert len(log_groups) == 4
+    assert len(log_groups) == 3
     for lg in log_groups:
         assert lg["Properties"]["RetentionInDays"] == 14
     names = {json.dumps(lg["Properties"].get("LogGroupName")) for lg in log_groups}
-    assert len(names) == 4, "log groups must have distinct names"
+    assert len(names) == 3, "log groups must have distinct names"
 
 
 def test_no_internally_managed_iam_task_role(td):
@@ -313,16 +313,34 @@ def test_maestro_container_has_license_data(td):
     assert "LICENSE_DATA" in secret_names
 
 
-def test_dex_init_container_env_has_issuer_url(td):
-    dex_init_c = _container(td, "dex-init")
-    env_names = {e["Name"] for e in dex_init_c.get("Environment", [])}
-    assert "DEX_ISSUER_URL" in env_names
-
-
-def test_dex_depends_on_dex_init(td):
+def test_dex_container_env_has_oidc_inputs(td):
+    # dex v0.3.0 renders its own config from these env vars (no dex-init).
     dex_c = _container(td, "dex")
-    deps = dex_c.get("DependsOn", [])
-    assert {"ContainerName": "dex-init", "Condition": "SUCCESS"} in deps
+    env_names = {e["Name"] for e in dex_c.get("Environment", [])}
+    assert {
+        "DEX_ISSUER_URL",
+        "DEX_REDIRECT_URI",
+        "DEX_CLIENT_ID",
+        "DEX_PORT",
+        "DEX_ADMIN_EMAIL",
+        "DEX_ADMIN_HASH",
+    } <= env_names
+
+
+def test_dex_renders_config_in_image(td):
+    # No dex-init sidecar: nothing mounts /etc/dex (a mount shadows the baked
+    # template) and the dex container keeps the image's gomplate entrypoint/CMD.
+    dex_c = _container(td, "dex")
+    assert "Command" not in dex_c
+    mount_paths = {m["ContainerPath"] for m in dex_c.get("MountPoints", [])}
+    assert "/etc/dex" not in mount_paths
+
+
+def test_task_definition_has_no_volumes(td):
+    task_def = next(
+        r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
+    )
+    assert not task_def["Properties"].get("Volumes")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_image_manifest.py
+++ b/tests/unit/test_image_manifest.py
@@ -20,7 +20,7 @@ def test_unknown_stack_raises():
 def test_lakerunner_manifest_lists_all_stack_images():
     images = load_defaults()["images"]
     expected = sorted(
-        {images[k] for k in ("lakerunner", "maestro", "dex", "dex_init", "db_init")}
+        {images[k] for k in ("lakerunner", "maestro", "dex", "db_init")}
     )
     assert image_manifest.manifest_lines("lakerunner") == expected
 


### PR DESCRIPTION
## What

- **Bump dex-customization `v0.2.0` -> `v0.3.0`** and **maestro `v1.50.0` -> `v1.53.0`** (digest-pinned in `cardinal-defaults.yaml`). lakerunner stays `v1.40.4` (already latest).
- **Drop the busybox `dex-init` sidecar.** dex v0.3.0 renders its own `/etc/dex/config.yaml` at startup (gomplate over a baked template, from the same `DexClientId`/`DexAdminEmail`/`DexAdminPasswordHash` inputs), so the init container, the `DexInitImage` parameter, the `DEX_INIT_IMAGE` deploy-driver env, the `dex-config`/`dex-tmp` volumes, and the `/etc/dex` mount all go away. The maestro task drops from six containers to five and no longer pulls `busybox`.
- **dex container: nonroot (uid 1001), writable rootfs.** The gomplate entrypoint writes to `/tmp`; on Fargate a read-only rootfs would need a writable `/tmp` volume, but empty Fargate volumes mount `0755 root:root` (unwritable by nonroot). Rather than run as root or add an init container, dex leaves `ReadOnlyRootFilesystem` unset and uses the image's `1777` `/tmp` on ephemeral storage.

## Why

`dex-init` was the only place the install pulled a non-`cardinalhq.io` image (`public.ecr.aws/docker/library/busybox`). dex-customization #3/#5 moved config rendering into the image specifically to remove it.

## Notes

- `CHANGELOG.md`: `v0.0.131` entry added (operator action: redeploy `lakerunner-services`; remove any `DexInitImage`/`DEX_INIT_IMAGE` from saved configs).
- Docs in `cardinalhq/dex-customization` (CLAUDE.md/README) need a companion edit to correct the read-only-rootfs guidance — separate PR.
- `make build` (cfn-lint clean) + `make test` → 492 passed, 1 skipped.