### PR TITLE
db-init: official postgres:18-alpine for psql; drop ghcr grafana image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.133
+
+- **db-init image: `ghcr.io/cardinalhq/initcontainer-grafana:latest` ->
+  `public.ecr.aws/docker/library/postgres:18-alpine` (digest-pinned).** The
+  maestro `db-init` container only ever used the image to run a one-line
+  `psql ... CREATE DATABASE maestro`; it overrode the entrypoint and used none
+  of the grafana tooling. Switch it to the official Postgres image (Docker
+  Official Images, AWS-mirrored on public ECR; psql 18 matches the RDS major
+  version), which is leaner, from a trusted publisher, digest-pinned (no more
+  mutable `:latest`), and removes the only `ghcr.io` pull. **Upgrade action:**
+  redeploy `lakerunner-services`. The `DbInitImage` default changes; if you
+  pinned `DB_INIT_IMAGE` in a saved config, update it. No DB/data change
+  (db-init is idempotent: `CREATE DATABASE ... || true`).
+
 ## v0.0.132
 
 - **Image bumps: maestro `v1.50.0` -> `v1.53.0`, dex-customization `v0.2.0` ->

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -37,7 +37,7 @@ images:
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
-  db_init:    "ghcr.io/cardinalhq/initcontainer-grafana:latest"
+  db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 
 # ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is

--- a/scripts-src/build.sh
+++ b/scripts-src/build.sh
@@ -32,8 +32,8 @@ stack_version="${CARDINAL_VERSION:-dev}"
 py="python3"
 [ -x "$repo_root/.venv/bin/python3" ] && py="$repo_root/.venv/bin/python3"
 # Registry-relative suffixes for the first-party public-ECR images that respect
-# the IMAGE_REGISTRY prefix.  External images (busybox, the ghcr db-init) are
-# not baked here -- the drivers keep full-URI overrides for those.
+# the IMAGE_REGISTRY prefix.  The external db-init image (the official postgres
+# psql client) is not baked here -- the driver keeps a full-URI override for it.
 image_suffix() {
     s=$(PYTHONPATH="$repo_root/src" "$py" -m cardinal_cfn.image_manifest suffix "$1")
     [ -n "$s" ] || { echo "build.sh: failed to resolve $1 image suffix" >&2; exit 1; }

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -27,7 +27,7 @@ DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # Baked, locked registry-relative paths (repo + pinned tag/digest) for the
 # first-party public-ECR images.  Only the registry prefix is operator-supplied;
-# external images (busybox, the ghcr db-init) keep their own full-URI overrides.
+# the external db-init image (official postgres) keeps its own full-URI override.
 LAKERUNNER_IMAGE_SUFFIX="@@LAKERUNNER_IMAGE_SUFFIX@@"
 MAESTRO_IMAGE_SUFFIX="@@MAESTRO_IMAGE_SUFFIX@@"
 DEX_IMAGE_SUFFIX="@@DEX_IMAGE_SUFFIX@@"
@@ -102,8 +102,8 @@ Optional (template defaults preserved when unset):
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
   DB_INIT_IMAGE               Full image URI override for the db-init image
-                              (ghcr, not covered by IMAGE_REGISTRY). Default:
-                              the template default.
+                              (official postgres psql client, not covered by
+                              IMAGE_REGISTRY). Default: the template default.
   PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
                               (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -28,7 +28,7 @@ DEFAULT_STACK_VERSION="dev"
 DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # Baked, locked registry-relative paths (repo + pinned tag/digest) for the
 # first-party public-ECR images.  Only the registry prefix is operator-supplied;
-# external images (busybox, the ghcr db-init) keep their own full-URI overrides.
+# the external db-init image (official postgres) keeps its own full-URI override.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
@@ -103,8 +103,8 @@ Optional (template defaults preserved when unset):
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
   DB_INIT_IMAGE               Full image URI override for the db-init image
-                              (ghcr, not covered by IMAGE_REGISTRY). Default:
-                              the template default.
+                              (official postgres psql client, not covered by
+                              IMAGE_REGISTRY). Default: the template default.
   PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
                               (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are


### PR DESCRIPTION
## What
Swap the maestro `db-init` image from `ghcr.io/cardinalhq/initcontainer-grafana:latest` to **`public.ecr.aws/docker/library/postgres:18-alpine`** (digest-pinned).

## Why
`db-init` overrides the image entrypoint and runs a single `psql -d postgres -c "CREATE DATABASE maestro" || true` — it uses **none** of the grafana tooling (baked datasource plugin, init scripts). It just needs a `psql` client. The official Postgres image is:
- a trusted publisher (Docker Official Images, AWS-mirrored on public ECR — same namespace the repo already used for busybox),
- multi-arch (amd64 + arm64; the maestro task is ARM64),
- `psql 18`, matching the RDS major version,
- digest-pinned (no more mutable `:latest`),
- and it removes the only `ghcr.io` pull in the product.

## Notes
- `CHANGELOG.md`: `v0.0.133` (operator action: redeploy `lakerunner-services`; update any pinned `DB_INIT_IMAGE`).
- No DB/data change — db-init is idempotent.
- `make build` (cfn-lint clean) + `make test` -> 492 passed, 1 skipped.