### PR TITLE
deploy driver: always set DbInitImage from baked default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.134
+
+- **Deploy driver now always sets `DbInitImage` from the baked, pinned default**
+  (like `LakerunnerImage`/`MaestroImage`/`DexImage`), composed from
+  `IMAGE_REGISTRY` + the locked `db_init` suffix. Previously `DbInitImage` was
+  only passed when `DB_INIT_IMAGE` was set, so on a stack **update** it carried
+  `UsePreviousValue` — meaning the v0.0.133 db-init image change (and any future
+  bump) did **not** take effect on a plain redeploy. **Upgrade action:** redeploy
+  `lakerunner-services` with the v0.0.134 driver; db-init moves to the pinned
+  `postgres:18-alpine` automatically (no `DB_INIT_IMAGE` needed). `DB_INIT_IMAGE`
+  remains a full-URI escape hatch. This stack is always on `public.ecr.aws`, so
+  db-init follows `IMAGE_REGISTRY` like the other images.
+
 ## v0.0.133
 
 - **db-init image: `ghcr.io/cardinalhq/initcontainer-grafana:latest` ->

--- a/scripts-src/build.sh
+++ b/scripts-src/build.sh
@@ -31,9 +31,10 @@ base="$parts_dir/base.sh"
 stack_version="${CARDINAL_VERSION:-dev}"
 py="python3"
 [ -x "$repo_root/.venv/bin/python3" ] && py="$repo_root/.venv/bin/python3"
-# Registry-relative suffixes for the first-party public-ECR images that respect
-# the IMAGE_REGISTRY prefix.  The external db-init image (the official postgres
-# psql client) is not baked here -- the driver keeps a full-URI override for it.
+# Registry-relative suffixes for the public-ECR images that respect the
+# IMAGE_REGISTRY prefix.  db_init (the official postgres psql client) is baked
+# here too -- this stack is always on public.ecr.aws -- so a redeploy always
+# carries the pinned default; DB_INIT_IMAGE remains a full-URI escape hatch.
 image_suffix() {
     s=$(PYTHONPATH="$repo_root/src" "$py" -m cardinal_cfn.image_manifest suffix "$1")
     [ -n "$s" ] || { echo "build.sh: failed to resolve $1 image suffix" >&2; exit 1; }
@@ -43,6 +44,7 @@ otel_image_suffix=$(image_suffix otel)
 lakerunner_image_suffix=$(image_suffix lakerunner)
 maestro_image_suffix=$(image_suffix maestro)
 dex_image_suffix=$(image_suffix dex)
+db_init_image_suffix=$(image_suffix db_init)
 
 for fragment in "$parts_dir"/*.sh; do
     name=$(basename "$fragment")
@@ -60,6 +62,7 @@ for fragment in "$parts_dir"/*.sh; do
         -e "s|@@LAKERUNNER_IMAGE_SUFFIX@@|$lakerunner_image_suffix|g" \
         -e "s|@@MAESTRO_IMAGE_SUFFIX@@|$maestro_image_suffix|g" \
         -e "s|@@DEX_IMAGE_SUFFIX@@|$dex_image_suffix|g" \
+        -e "s|@@DB_INIT_IMAGE_SUFFIX@@|$db_init_image_suffix|g" \
         >"$out"
     chmod +x "$out"
     echo "wrote $out"

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -26,11 +26,14 @@ TEMPLATE_KEY="cardinal-lakerunner-services.yaml"
 DEFAULT_STACK_VERSION="@@STACK_VERSION@@"
 DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # Baked, locked registry-relative paths (repo + pinned tag/digest) for the
-# first-party public-ECR images.  Only the registry prefix is operator-supplied;
-# the external db-init image (official postgres) keeps its own full-URI override.
+# public-ECR images.  Only the registry prefix is operator-supplied.  db-init
+# (official postgres psql client) is baked too -- this stack is always on
+# public.ecr.aws -- so a redeploy always carries the pinned default;
+# DB_INIT_IMAGE remains a full-URI escape hatch.
 LAKERUNNER_IMAGE_SUFFIX="@@LAKERUNNER_IMAGE_SUFFIX@@"
 MAESTRO_IMAGE_SUFFIX="@@MAESTRO_IMAGE_SUFFIX@@"
 DEX_IMAGE_SUFFIX="@@DEX_IMAGE_SUFFIX@@"
+DB_INIT_IMAGE_SUFFIX="@@DB_INIT_IMAGE_SUFFIX@@"
 
 usage() {
     cat <<EOF
@@ -102,8 +105,9 @@ Optional (template defaults preserved when unset):
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
   DB_INIT_IMAGE               Full image URI override for the db-init image
-                              (official postgres psql client, not covered by
-                              IMAGE_REGISTRY). Default: the template default.
+                              (official postgres psql client). Bypasses
+                              IMAGE_REGISTRY. Default: the baked, pinned suffix
+                              under IMAGE_REGISTRY (always passed to the stack).
   PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
                               (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are
@@ -164,10 +168,14 @@ image_registry="${IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
 lakerunner_image="$image_registry/$LAKERUNNER_IMAGE_SUFFIX"
 maestro_image="$image_registry/$MAESTRO_IMAGE_SUFFIX"
 dex_image="$image_registry/$DEX_IMAGE_SUFFIX"
+# db-init: the baked default tracks the registry prefix like the others; a
+# full-URI DB_INIT_IMAGE wins when set (e.g. an unusual mirror layout).
+db_init_image="${DB_INIT_IMAGE:-$image_registry/$DB_INIT_IMAGE_SUFFIX}"
 echo "[deploy-lakerunner-services] resolved STACK_VERSION = $stack_version" >&2
 echo "[deploy-lakerunner-services] resolved LakerunnerImage = $lakerunner_image" >&2
 echo "[deploy-lakerunner-services] resolved MaestroImage    = $maestro_image" >&2
 echo "[deploy-lakerunner-services] resolved DexImage        = $dex_image" >&2
+echo "[deploy-lakerunner-services] resolved DbInitImage     = $db_init_image" >&2
 
 TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 
@@ -234,16 +242,14 @@ ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
 
-# First-party public-ECR images: composed from IMAGE_REGISTRY + the baked,
-# locked suffixes, always passed as literal params.
+# Public-ECR images: composed from IMAGE_REGISTRY + the baked, locked suffixes,
+# always passed as literal params so a redeploy carries the pinned defaults
+# (a stuck UsePreviousValue would never pick up a bumped default otherwise).
 params="$params
 LakerunnerImage=$lakerunner_image
 MaestroImage=$maestro_image
-DexImage=$dex_image"
-# External/utility images: full-URI overrides, not driven by IMAGE_REGISTRY.
-# Unset -> the template default governs.
-[ -n "${DB_INIT_IMAGE:-}" ] && params="$params
-DbInitImage=$DB_INIT_IMAGE"
+DexImage=$dex_image
+DbInitImage=$db_init_image"
 
 # --- Additional satellite queues (groups 1..10). -----------------------------
 # pubsub-sqs consumes extra satellite queues from numbered env groups.  For each

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -27,11 +27,14 @@ TEMPLATE_KEY="cardinal-lakerunner-services.yaml"
 DEFAULT_STACK_VERSION="dev"
 DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # Baked, locked registry-relative paths (repo + pinned tag/digest) for the
-# first-party public-ECR images.  Only the registry prefix is operator-supplied;
-# the external db-init image (official postgres) keeps its own full-URI override.
+# public-ECR images.  Only the registry prefix is operator-supplied.  db-init
+# (official postgres psql client) is baked too -- this stack is always on
+# public.ecr.aws -- so a redeploy always carries the pinned default;
+# DB_INIT_IMAGE remains a full-URI escape hatch.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
+DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 
 usage() {
     cat <<EOF
@@ -103,8 +106,9 @@ Optional (template defaults preserved when unset):
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
   DB_INIT_IMAGE               Full image URI override for the db-init image
-                              (official postgres psql client, not covered by
-                              IMAGE_REGISTRY). Default: the template default.
+                              (official postgres psql client). Bypasses
+                              IMAGE_REGISTRY. Default: the baked, pinned suffix
+                              under IMAGE_REGISTRY (always passed to the stack).
   PUBSUB_AUTOREGISTER         pubsub-sqs auto-registration of satellite buckets
                               (template default "true").  Set "false" to disable.
                               When true, unseen satellite raw-bucket orgs are
@@ -165,10 +169,14 @@ image_registry="${IMAGE_REGISTRY:-$DEFAULT_IMAGE_REGISTRY}"
 lakerunner_image="$image_registry/$LAKERUNNER_IMAGE_SUFFIX"
 maestro_image="$image_registry/$MAESTRO_IMAGE_SUFFIX"
 dex_image="$image_registry/$DEX_IMAGE_SUFFIX"
+# db-init: the baked default tracks the registry prefix like the others; a
+# full-URI DB_INIT_IMAGE wins when set (e.g. an unusual mirror layout).
+db_init_image="${DB_INIT_IMAGE:-$image_registry/$DB_INIT_IMAGE_SUFFIX}"
 echo "[deploy-lakerunner-services] resolved STACK_VERSION = $stack_version" >&2
 echo "[deploy-lakerunner-services] resolved LakerunnerImage = $lakerunner_image" >&2
 echo "[deploy-lakerunner-services] resolved MaestroImage    = $maestro_image" >&2
 echo "[deploy-lakerunner-services] resolved DexImage        = $dex_image" >&2
+echo "[deploy-lakerunner-services] resolved DbInitImage     = $db_init_image" >&2
 
 TEMPLATE_URL="$template_base_url/$stack_version/$TEMPLATE_KEY"
 
@@ -235,16 +243,14 @@ ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
 
-# First-party public-ECR images: composed from IMAGE_REGISTRY + the baked,
-# locked suffixes, always passed as literal params.
+# Public-ECR images: composed from IMAGE_REGISTRY + the baked, locked suffixes,
+# always passed as literal params so a redeploy carries the pinned defaults
+# (a stuck UsePreviousValue would never pick up a bumped default otherwise).
 params="$params
 LakerunnerImage=$lakerunner_image
 MaestroImage=$maestro_image
-DexImage=$dex_image"
-# External/utility images: full-URI overrides, not driven by IMAGE_REGISTRY.
-# Unset -> the template default governs.
-[ -n "${DB_INIT_IMAGE:-}" ] && params="$params
-DbInitImage=$DB_INIT_IMAGE"
+DexImage=$dex_image
+DbInitImage=$db_init_image"
 
 # --- Additional satellite queues (groups 1..10). -----------------------------
 # pubsub-sqs consumes extra satellite queues from numbered env groups.  For each


### PR DESCRIPTION
## Problem
`DbInitImage` was only added to the stack params when `DB_INIT_IMAGE` was set. On a stack **update**, an unset param carries `UsePreviousValue`, so the v0.0.133 db-init default change (ghcr grafana -> postgres:18-alpine) did **not** take effect on a plain redeploy — db-init stayed on the old image until `DB_INIT_IMAGE` was passed explicitly.

## Fix
Bake the `db_init` registry-relative suffix into the driver and always pass `DbInitImage` (composed from `IMAGE_REGISTRY` + suffix) like `LakerunnerImage`/`MaestroImage`/`DexImage`. A plain redeploy now keeps db-init on the pinned default. `DB_INIT_IMAGE` remains a full-URI escape hatch.

This stack is always on `public.ecr.aws`, so db-init follows `IMAGE_REGISTRY` like the other images (the reason it was special-cased no longer applies).

## Notes
- `CHANGELOG.md`: `v0.0.134`.
- `make build` clean + `make test` -> 492 passed, 1 skipped.
- Generated driver verified: `DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d5..."`, `DbInitImage=$db_init_image` always passed.