### PR TITLE
cleanup: pin aws-cli image via cardinal-defaults, sha-locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.135
+
+- **cleanup task aws-cli image pinned + plumbed through defaults.** The
+  `cardinal-cleanup` teardown task used a hardcoded
+  `public.ecr.aws/aws-cli/aws-cli:latest`. It is now sourced from
+  `cardinal-defaults.yaml` (`images.aws_cli`), pinned by digest
+  (`2.34.63@sha256:c95a…`), and exposed as an `AwsCliImage` parameter on the
+  cleanup stack (like the other image overrides). `dev-scripts/sweep-stranded-
+  resources.sh` default and a new `cleanup-images.txt` manifest track the same
+  pin. No upgrade action — affects only teardown, never a running install. Every
+  image the project references is now a digest-pinned `public.ecr.aws` image.
+
 ## v0.0.134
 
 - **Deploy driver now always sets `DbInitImage` from the baked, pinned default**

--- a/build.sh
+++ b/build.sh
@@ -27,6 +27,9 @@ python3 -m cardinal_cfn.lrdev_baseinfra > generated-templates/lrdev-baseinfra.ya
 echo "Generating cardinal-cleanup.yaml..."
 python3 -m cardinal_cfn.cardinal_cleanup > generated-templates/cardinal-cleanup.yaml
 
+echo "Generating cleanup-images.txt..."
+python3 -m cardinal_cfn.image_manifest manifest cleanup > generated-templates/cleanup-images.txt
+
 echo "Generating cardinal-satellite-infra-base.yaml..."
 python3 -m cardinal_cfn.satellite_infra_base > generated-templates/cardinal-satellite-infra-base.yaml
 

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -38,6 +38,9 @@ images:
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
+  # aws-cli: used only by the cardinal-cleanup teardown task (sh + aws + jq);
+  # never part of a running install. Official AWS image on public ECR.
+  aws_cli:    "public.ecr.aws/aws-cli/aws-cli:2.34.63@sha256:c95ab0642137f55a12b95b6956dd03cefdbd73e760e0e7b870afc9b47f9c8150"
 
 # ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is

--- a/dev-scripts/sweep-stranded-resources.sh
+++ b/dev-scripts/sweep-stranded-resources.sh
@@ -19,7 +19,8 @@
 
 set -eu
 
-DEFAULT_IMAGE="public.ecr.aws/aws-cli/aws-cli:latest"
+# Pinned to match cardinal-defaults.yaml images.aws_cli (digest-locked).
+DEFAULT_IMAGE="public.ecr.aws/aws-cli/aws-cli:2.34.63@sha256:c95ab0642137f55a12b95b6956dd03cefdbd73e760e0e7b870afc9b47f9c8150"
 DEFAULT_FAMILY="cardinal-sweep-stranded"
 
 # --- required ---
@@ -68,7 +69,8 @@ Optional:
   --execution-role-arn ARN     Fargate execution role (ECR pull + logs +
                                logs:CreateLogGroup). Default: same as
                                --task-role-arn.
-  --image URI                  Default: public.ecr.aws/aws-cli/aws-cli:latest.
+  --image URI                  Default: the digest-pinned aws-cli from
+                               cardinal-defaults.yaml (images.aws_cli).
   --family NAME                 Task-definition family. Default: cardinal-sweep-stranded.
   --retry-stack-delete         After a successful sweep, re-issue delete-stack
                                on --stack-name and wait for it to complete.

--- a/src/cardinal_cfn/cardinal_cleanup.py
+++ b/src/cardinal_cfn/cardinal_cleanup.py
@@ -28,6 +28,8 @@ from troposphere.ecs import (
 from troposphere.logs import LogGroup
 
 from cardinal_cfn.cleanup_script import SCRIPT
+from cardinal_cfn.defaults import load_defaults
+from cardinal_cfn.images import add_image_override
 
 
 def build() -> Template:
@@ -98,6 +100,13 @@ def build() -> Template:
         ),
     ))
 
+    aws_cli_image = add_image_override(
+        t,
+        name="AwsCliImage",
+        default=load_defaults()["images"]["aws_cli"],
+        description="Image for the cleanup task (sh + aws CLI). Official AWS image.",
+    )
+
     log_group = t.add_resource(LogGroup(
         "CleanupLogGroup",
         LogGroupName=Sub("/aws/ecs/cardinal-cleanup/${AWS::StackName}"),
@@ -121,7 +130,7 @@ def build() -> Template:
         ExecutionRoleArn=Ref(p_exec_role),
         ContainerDefinitions=[ContainerDefinition(
             Name="cleanup",
-            Image="public.ecr.aws/aws-cli/aws-cli:latest",
+            Image=aws_cli_image,
             Essential=True,
             # Script is in EntryPoint so ecs:RunTask containerOverrides.command
             # cannot bypass it (containerOverrides has no entryPoint override).

--- a/src/cardinal_cfn/cleanup_script.py
+++ b/src/cardinal_cfn/cleanup_script.py
@@ -6,10 +6,10 @@ embedded verbatim into the AWS::ECS::TaskDefinition's EntryPoint by
 ``cardinal_cleanup.py``. Keep this module dependency-free (no
 troposphere) so tests can import and lint the shell directly.
 
-The script is POSIX (``sh``), not bash. The container image
-(``public.ecr.aws/aws-cli/aws-cli:latest``) provides ``sh``, ``aws``,
-and ``python3`` -- and crucially NOT ``jq`` -- so JSON parsing uses
-inline ``python3 -c`` snippets.
+The script is POSIX (``sh``), not bash. The container image (the official
+aws-cli image, pinned via ``images.aws_cli`` in cardinal-defaults.yaml and
+the ``AwsCliImage`` parameter) provides ``sh``, ``aws``, and ``python3`` --
+and crucially NOT ``jq`` -- so JSON parsing uses inline ``python3 -c`` snippets.
 
 The script implements the four-step teardown ordered as:
 

--- a/src/cardinal_cfn/image_manifest.py
+++ b/src/cardinal_cfn/image_manifest.py
@@ -18,6 +18,7 @@ from cardinal_cfn.defaults import load_defaults
 STACK_IMAGE_KEYS = {
     "satellite": ["otel"],
     "lakerunner": ["lakerunner", "maestro", "dex", "db_init"],
+    "cleanup": ["aws_cli"],
 }
 
 

--- a/tests/templates/test_cardinal_cleanup.py
+++ b/tests/templates/test_cardinal_cleanup.py
@@ -70,8 +70,17 @@ def test_single_container(td):
     assert len(containers) == 1
     c = containers[0]
     assert c["Name"] == "cleanup"
-    assert c["Image"] == "public.ecr.aws/aws-cli/aws-cli:latest"
+    assert c["Image"] == {"Ref": "AwsCliImage"}
     assert c["Essential"] is True
+
+
+def test_aws_cli_image_param_defaults_to_pinned_default(td):
+    from cardinal_cfn.defaults import load_defaults
+
+    p = td["Parameters"]["AwsCliImage"]
+    assert p["Default"] == load_defaults()["images"]["aws_cli"]
+    # Pinned by digest, like the rest.
+    assert "@sha256:" in p["Default"]
 
 
 def test_script_in_entrypoint_not_command(td):


### PR DESCRIPTION
## What
The `cardinal-cleanup` teardown task used a hardcoded `public.ecr.aws/aws-cli/aws-cli:latest` (the last unpinned image, and the only one outside the defaults/manifest machinery). Now:
- Added `images.aws_cli` to `cardinal-defaults.yaml`, digest-pinned to the latest (`2.34.63@sha256:c95a…`, multi-arch incl. arm64 — the cleanup task is ARM64).
- `cardinal_cleanup.py` exposes an `AwsCliImage` override parameter defaulting to that pin (same `add_image_override` pattern as the rest); container uses `!Ref AwsCliImage`.
- `image_manifest` gains a `cleanup` stack; `build.sh` emits `cleanup-images.txt`.
- `dev-scripts/sweep-stranded-resources.sh` default pinned to match.

## Why
Consistency + supply-chain hygiene: every image the project references is now a digest-pinned `public.ecr.aws` ref. Cleanup is teardown-only (never part of a running install), so no upgrade action and no deploy.

## Validation
`make build` (cfn-lint clean) + `make test` -> 493 passed, 1 skipped. Verified `AwsCliImage` default + `Image: !Ref AwsCliImage` in the generated template.