### PR TITLE
maestro v1.53.1 (provisioning cold-start retry fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v0.0.136
+
+- **maestro `v1.53.0` -> `v1.53.1`.** Picks up the fix for the fresh-install
+  provisioning cold-start race (conductor #998): the Lakerunner provisioning
+  worker now retries transient admin-api failures for ~29 min (capped backoff)
+  instead of giving up after ~31s, so on a fresh install the org reliably lands
+  in configdb without a manual maestro restart. **Upgrade action:** redeploy
+  `lakerunner-services`.
+
 ## v0.0.135
 
 - **cleanup task aws-cli image pinned + plumbed through defaults.** The

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,7 +34,7 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.53.1@sha256:ac533a492623b5df7c4176f8fc887145a2de3662417388e5fc0fb678c49ba698"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -32,7 +32,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.40.4@sha256:532abeafcd7fb3ad7be49704239f6147a9a6ac19ed5a71976005542d72066b89"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.53.0@sha256:9cd5267640aced6dbfa794f940bba356ae71b8404768ebcbbbdc27bef0d9b1d2"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.53.1@sha256:ac533a492623b5df7c4176f8fc887145a2de3662417388e5fc0fb678c49ba698"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
Bump maestro `v1.53.0` -> `v1.53.1`, which contains conductor #998 — the Lakerunner provisioning worker now retries transient admin-api failures for ~29 min (capped backoff) instead of giving up after ~31s. Fixes the fresh-install race where the org never landed in configdb until a manual maestro restart. CHANGELOG: v0.0.136. `make build` clean + `make test` 493 passed.