### PR TITLE
release: attach version-baked deploy drivers as release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,9 +81,19 @@ jobs:
           if [[ "${PRERELEASE}" == "true" ]]; then
             PRERELEASE_FLAG=(--prerelease)
           fi
+          # Attach the version-baked deploy drivers (same scripts/ that build.sh
+          # regenerated with CARDINAL_VERSION and that were synced to S3 above)
+          # as release assets, so a script downloaded from the GitHub release has
+          # this version baked in (STACK_VERSION="$VERSION"), not "dev". The repo
+          # copies under scripts/ stay "dev" by design (they pre-date the tag).
           gh release create "$VERSION" \
+            scripts/*.sh \
             --title "$VERSION" \
             "${PRERELEASE_FLAG[@]}" \
             --notes "**Lakerunner root template:** $ROOT_URL
 
-          Paste the root URL into the CloudFormation console to deploy."
+          Paste the root URL into the CloudFormation console to deploy.
+
+          The attached \`deploy-*.sh\` drivers have this version baked in
+          (\`STACK_VERSION=$VERSION\`); the same set is published under
+          \`s3://${CARDINAL_BUCKET_NAME}/lakerunner/${VERSION}/scripts/\`."


### PR DESCRIPTION
## Problem
A `scripts/*.sh` driver downloaded "from GitHub" has `STACK_VERSION="dev"`, not a real version. The repo copies are intentionally `dev` (the `test_committed_drivers_match_fresh_build` test enforces repo == plain `make scripts`, and a commit can't know its own future tag). Only the **S3** copies under `lakerunner/<version>/scripts/` are version-baked.

## Fix
`release.yml` already runs `./build.sh` with `CARDINAL_VERSION=<tag>` (baking the version into `scripts/`) and `aws s3 sync`s them. This change also **attaches that same baked `scripts/*.sh` set as GitHub Release assets**, so the drivers are published to GitHub **and** S3 as a unit and a release download has the version baked in (`STACK_VERSION=<tag>`).

Repo `scripts/` stay `dev` by design (unchanged). CI-only change; takes effect on the next `v*` tag.

## Note
No untrusted input in the workflow — only `$VERSION` (the tag ref, env-provided) and a `scripts/*.sh` glob.