### PR TITLE
dev-scripts: per-stack teardown-cardinal.sh

### DIFF
--- a/dev-scripts/README.md
+++ b/dev-scripts/README.md
@@ -42,6 +42,23 @@ Outputs: `VpcId`, `PublicSubnetsCsv`, `PrivateSubnetsCsv`.
 
 Outputs: `ClusterArn`, `ClusterName`.
 
+## teardown-cardinal.sh (current)
+
+Tears down a per-stack install: deletes the five `cardinal-*` stacks in
+reverse-dependency order, then wipes the retained fixed-name survivors (the
+`cardinal-license` / `cardinal-admin-key` / `cardinal-db-master` secrets and the
+cooked / otel-raw buckets) so a fresh install can re-create them. Leaves the VPC
+and ECS cluster intact. Idempotent; gated behind `CONFIRM=DELETE`.
+
+```sh
+REGION=us-east-1 dev-scripts/teardown-cardinal.sh                 # plan only
+REGION=us-east-1 CONFIRM=DELETE dev-scripts/teardown-cardinal.sh  # execute
+```
+
+Env: `KEEP_SECRETS` / `KEEP_BUCKETS` / `DELETE_SNAPSHOTS`, stack-name overrides,
+`DEPLOYER_ROLE_ARN`. See `--help` and
+[`dev-environment.md`](../docs/operations/dev-environment.md).
+
 ## sweep-stranded-resources.sh (current)
 
 When a stack delete fails part-way and leaves `DELETE_FAILED` /
@@ -57,7 +74,4 @@ parameters, S3 buckets), then deregisters itself. Runs under a caller-supplied
 `run-cleanup.sh`, `cleanup-lakerunner.sh`, and `teardown-lakerunner.sh` target
 the retired **monolithic** `cardinal-infrastructure` + `cardinal-lakerunner`
 stacks and do **not** match the current per-stack model. For the per-stack
-teardown, use the manual sequence in
-[`dev-environment.md`](../docs/operations/dev-environment.md) (delete the five
-stacks in reverse order, then wipe the retained `cardinal-*` survivors). A
-per-stack teardown script is a future follow-up.
+teardown, use `teardown-cardinal.sh` (above).

--- a/dev-scripts/teardown-cardinal.sh
+++ b/dev-scripts/teardown-cardinal.sh
@@ -86,7 +86,9 @@ command -v aws >/dev/null 2>&1 || fail 1 "aws CLI v2 is required"
 command -v jq  >/dev/null 2>&1 || fail 1 "jq is required"
 
 ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
-[ -n "$ACCOUNT" ] && [ "$ACCOUNT" != "None" ] || fail 1 "could not resolve AWS account id"
+if [ -z "$ACCOUNT" ] || [ "$ACCOUNT" = "None" ]; then
+    fail 1 "could not resolve AWS account id"
+fi
 COOKED_BUCKET="${COOKED_BUCKET:-cardinal-cooked-$ACCOUNT-$REGION}"
 RAW_BUCKET="${RAW_BUCKET:-cardinal-otel-raw-$ACCOUNT-$REGION}"
 

--- a/dev-scripts/teardown-cardinal.sh
+++ b/dev-scripts/teardown-cardinal.sh
@@ -1,0 +1,155 @@
+#!/bin/sh
+# Tear down a per-stack Cardinal Lakerunner install: delete the five cardinal-*
+# stacks in reverse-dependency order, then remove the retained, fixed-name
+# resources that would otherwise block a fresh re-create. The customer-supplied
+# (or lrdev-*) VPC and ECS cluster are left untouched.
+#
+# Self-contained: POSIX sh + AWS CLI v2 + jq. Environment-variable driven.
+# Destructive: requires CONFIRM=DELETE. Without it, prints the plan and exits 0.
+#
+# Replaces the legacy dev-scripts/teardown-lakerunner.sh / cleanup-lakerunner.sh,
+# which target the retired monolithic cardinal-lakerunner / cardinal-infrastructure
+# stacks. See docs/operations/dev-environment.md.
+
+set -eu
+
+TAG="teardown-cardinal"
+log()  { printf '[%s] [%s] %s\n' "$(date -u +%H:%M:%SZ)" "$TAG" "$*" >&2; }
+fail() { code="$1"; shift; printf '[%s] ERROR: %s\n' "$TAG" "$*" >&2; exit "$code"; }
+
+usage() {
+    cat <<'EOF'
+Usage: teardown-cardinal.sh   (environment-variable driven)
+
+Deletes the per-stack Cardinal Lakerunner install (five cardinal-* stacks) and
+wipes the retained survivors. Leaves the VPC and ECS cluster alone.
+
+Required:
+  REGION                      AWS region of the install.
+  CONFIRM=DELETE              Required to actually destroy. Without it the
+                              script prints the plan and exits 0.
+
+Optional (stack name overrides; defaults shown):
+  SERVICES_STACK              cardinal-lakerunner-services
+  SAT_SERVICES_STACK          cardinal-satellite-services
+  SAT_INFRA_STACK             cardinal-satellite-infra-base
+  RDS_STACK                   cardinal-lakerunner-infra-rds
+  INFRA_BASE_STACK            cardinal-lakerunner-infra-base
+
+Optional (survivor handling):
+  KEEP_SECRETS=true           Skip force-delete of cardinal-license /
+                              cardinal-admin-key / cardinal-db-master.
+  KEEP_BUCKETS=true           Skip empty+delete of the cooked / otel-raw buckets.
+  DELETE_SNAPSHOTS=true       Also delete RDS snapshots whose id starts with the
+                              RDS stack name (default: keep them; they cost only
+                              storage and never block a re-create).
+  COOKED_BUCKET / RAW_BUCKET  Override the derived bucket names
+                              (cardinal-cooked-<acct>-<region> /
+                              cardinal-otel-raw-<acct>-<region>).
+  DEPLOYER_ROLE_ARN           Passed only to delete-stack (--role-arn).
+
+Exit codes: 0 success / 1 failure / 2 input validation.
+EOF
+}
+
+case "${1:-}" in
+    -h|--help) usage; exit 0 ;;
+    "") : ;;
+    *) fail 2 "this script takes no arguments; configure it via environment variables" ;;
+esac
+
+[ -n "${REGION:-}" ] || { usage >&2; fail 2 "REGION is required"; }
+
+SERVICES_STACK="${SERVICES_STACK:-cardinal-lakerunner-services}"
+SAT_SERVICES_STACK="${SAT_SERVICES_STACK:-cardinal-satellite-services}"
+SAT_INFRA_STACK="${SAT_INFRA_STACK:-cardinal-satellite-infra-base}"
+RDS_STACK="${RDS_STACK:-cardinal-lakerunner-infra-rds}"
+INFRA_BASE_STACK="${INFRA_BASE_STACK:-cardinal-lakerunner-infra-base}"
+SECRETS="cardinal-license cardinal-admin-key cardinal-db-master"
+
+# Reverse-dependency delete order.
+STACKS="$SERVICES_STACK $SAT_SERVICES_STACK $SAT_INFRA_STACK $RDS_STACK $INFRA_BASE_STACK"
+
+if [ "${CONFIRM:-}" != "DELETE" ]; then
+    cat >&2 <<EOF
+PLAN (set CONFIRM=DELETE to execute) — region $REGION:
+  Delete stacks, in order: $STACKS
+  Empty + delete buckets: $([ "${KEEP_BUCKETS:-}" = "true" ] && echo "(skipped: KEEP_BUCKETS)" || echo "${COOKED_BUCKET:-cardinal-cooked-<acct>-$REGION} ${RAW_BUCKET:-cardinal-otel-raw-<acct>-$REGION}")
+  Force-delete secrets: $([ "${KEEP_SECRETS:-}" = "true" ] && echo "(skipped: KEEP_SECRETS)" || echo "$SECRETS")
+  RDS snapshots: $([ "${DELETE_SNAPSHOTS:-}" = "true" ] && echo "delete (prefix $RDS_STACK)" || echo "kept")
+  VPC + ECS cluster: left untouched.
+EOF
+    exit 0
+fi
+
+command -v aws >/dev/null 2>&1 || fail 1 "aws CLI v2 is required"
+command -v jq  >/dev/null 2>&1 || fail 1 "jq is required"
+
+ACCOUNT="$(aws sts get-caller-identity --query Account --output text)"
+[ -n "$ACCOUNT" ] && [ "$ACCOUNT" != "None" ] || fail 1 "could not resolve AWS account id"
+COOKED_BUCKET="${COOKED_BUCKET:-cardinal-cooked-$ACCOUNT-$REGION}"
+RAW_BUCKET="${RAW_BUCKET:-cardinal-otel-raw-$ACCOUNT-$REGION}"
+
+empty_bucket() {
+    b="$1"
+    if aws s3 ls "s3://$b" --region "$REGION" >/dev/null 2>&1; then
+        log "emptying s3://$b"
+        aws s3 rm "s3://$b" --recursive --region "$REGION" >/dev/null 2>&1 || true
+    fi
+}
+
+delete_stack() {
+    s="$1"
+    if ! aws cloudformation describe-stacks --stack-name "$s" --region "$REGION" >/dev/null 2>&1; then
+        log "$s already gone"; return 0
+    fi
+    log "deleting $s"
+    if [ -n "${DEPLOYER_ROLE_ARN:-}" ]; then
+        aws cloudformation delete-stack --stack-name "$s" --region "$REGION" --role-arn "$DEPLOYER_ROLE_ARN"
+    else
+        aws cloudformation delete-stack --stack-name "$s" --region "$REGION"
+    fi
+    aws cloudformation wait stack-delete-complete --stack-name "$s" --region "$REGION" \
+        || fail 1 "$s did not reach DELETE_COMPLETE (check DELETE_FAILED events)"
+    log "$s deleted"
+}
+
+# Empty the data buckets first so their owning stacks (which may use a Delete
+# policy) don't fail deletion on a non-empty bucket.
+if [ "${KEEP_BUCKETS:-}" != "true" ]; then
+    empty_bucket "$RAW_BUCKET"
+    empty_bucket "$COOKED_BUCKET"
+fi
+
+for s in $STACKS; do
+    delete_stack "$s"
+done
+
+if [ "${KEEP_SECRETS:-}" != "true" ]; then
+    for sec in $SECRETS; do
+        if aws secretsmanager describe-secret --secret-id "$sec" --region "$REGION" >/dev/null 2>&1; then
+            aws secretsmanager delete-secret --secret-id "$sec" --force-delete-without-recovery --region "$REGION" >/dev/null \
+                && log "deleted secret $sec"
+        fi
+    done
+fi
+
+if [ "${KEEP_BUCKETS:-}" != "true" ]; then
+    for b in "$COOKED_BUCKET" "$RAW_BUCKET"; do
+        if aws s3 ls "s3://$b" --region "$REGION" >/dev/null 2>&1; then
+            aws s3 rb "s3://$b" --force --region "$REGION" >/dev/null 2>&1 && log "removed bucket $b"
+        fi
+    done
+fi
+
+if [ "${DELETE_SNAPSHOTS:-}" = "true" ]; then
+    snaps="$(aws rds describe-db-snapshots --region "$REGION" --snapshot-type manual \
+        --query "DBSnapshots[?starts_with(DBSnapshotIdentifier, '$RDS_STACK')].DBSnapshotIdentifier" \
+        --output text 2>/dev/null || true)"
+    for snap in $snaps; do
+        aws rds delete-db-snapshot --db-snapshot-identifier "$snap" --region "$REGION" >/dev/null 2>&1 \
+            && log "deleted snapshot $snap"
+    done
+fi
+
+log "teardown complete (VPC + ECS cluster left intact)"

--- a/docs/operations/dev-environment.md
+++ b/docs/operations/dev-environment.md
@@ -121,34 +121,25 @@ shows `... 0 failed`, the cooked bucket is non-empty, and logging into Maestro
 
 ## 5. Burn it down
 
-Delete the five stacks in **reverse** dependency order, then remove the
-retained/fixed-name survivors that would block a future re-create. (The legacy
-`dev-scripts/cleanup-lakerunner.sh` / `teardown-lakerunner.sh` target the old
-monolithic stack names and do **not** fit the per-stack model — use this manual
-sequence; a per-stack teardown script is a future follow-up.)
+Use `dev-scripts/teardown-cardinal.sh`. It deletes the five stacks in
+**reverse** dependency order, empties + removes the data buckets, and
+force-deletes the retained fixed-name secrets (`cardinal-license` /
+`cardinal-admin-key` / `cardinal-db-master`) that would otherwise block a fresh
+re-create. The VPC and ECS cluster are left untouched. It is idempotent (safe to
+re-run if interrupted) and gated behind `CONFIRM=DELETE`.
 
 ```sh
-for s in cardinal-lakerunner-services cardinal-satellite-services \
-         cardinal-satellite-infra-base cardinal-lakerunner-infra-rds \
-         cardinal-lakerunner-infra-base; do
-  aws cloudformation delete-stack --stack-name "$s" --region "$REGION"
-  aws cloudformation wait stack-delete-complete --stack-name "$s" --region "$REGION"
-done
+# Plan only (prints what would be deleted; no changes):
+REGION=us-east-1 dev-scripts/teardown-cardinal.sh
 
-ACCT=$(aws sts get-caller-identity --query Account --output text)
-# A non-empty bucket blocks its stack delete — empty first if a delete failed:
-#   aws s3 rm s3://cardinal-otel-raw-$ACCT-$REGION --recursive
-#   aws s3 rm s3://cardinal-cooked-$ACCT-$REGION  --recursive  (then retry the delete)
-
-# Wipe survivors (fixed cardinal-* names) so a fresh install can re-create them:
-for sec in cardinal-license cardinal-admin-key cardinal-db-master; do
-  aws secretsmanager delete-secret --secret-id "$sec" --force-delete-without-recovery --region "$REGION"
-done
-for b in cardinal-cooked-$ACCT-$REGION cardinal-otel-raw-$ACCT-$REGION; do
-  aws s3 rb s3://$b --force
-done
-# Optional (cost only; no re-create collision): delete the RDS final snapshot.
+# Execute:
+REGION=us-east-1 CONFIRM=DELETE dev-scripts/teardown-cardinal.sh
 ```
+
+Useful env: `KEEP_SECRETS=true` / `KEEP_BUCKETS=true` to preserve those;
+`DELETE_SNAPSHOTS=true` to also delete the RDS final snapshot (kept by default —
+cost only, never blocks a re-create); `DEPLOYER_ROLE_ARN` if a CloudFormation
+service role is in use. See `--help`.
 
 `lrdev-vpc` and `lrdev-baseinfra` are intentionally left standing (BYO
 scaffolding) for the next iteration.

--- a/tests/unit/test_teardown_cardinal_lint.py
+++ b/tests/unit/test_teardown_cardinal_lint.py
@@ -1,0 +1,73 @@
+"""Lint tests for the per-stack teardown-cardinal.sh script.
+
+Mirrors test_teardown_lakerunner_lint.py: shellcheck-clean, parses, fails
+loudly without REGION, and gates destruction behind CONFIRM=DELETE.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "dev-scripts" / "teardown-cardinal.sh"
+
+
+def test_script_is_executable():
+    assert SCRIPT.exists(), f"missing {SCRIPT}"
+    assert SCRIPT.stat().st_mode & 0o111, "script should be executable"
+
+
+def test_shellcheck_clean():
+    if shutil.which("shellcheck") is None:
+        pytest.skip("shellcheck not installed on this runner")
+    result = subprocess.run(
+        ["shellcheck", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (
+        f"shellcheck reported issues:\n{result.stdout}\n{result.stderr}"
+    )
+
+
+def test_no_region_fails_loudly():
+    """Bare invocation (no REGION) hits validation and exits 2, not a crash."""
+    result = subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin"},
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2, got {result.returncode}: {result.stderr}"
+    )
+
+
+def test_help_prints_usage_and_exits_zero():
+    result = subprocess.run(
+        ["sh", str(SCRIPT), "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Usage:" in result.stdout
+    assert "CONFIRM=DELETE" in result.stdout
+
+
+def test_confirm_required_for_destruction():
+    """With REGION set but CONFIRM unset, the script prints the plan and exits
+    0 WITHOUT touching AWS (the plan branch precedes any AWS call) — proving the
+    destruction gate. A minimal PATH ensures it cannot reach a real `aws`."""
+    result = subprocess.run(
+        ["sh", str(SCRIPT)],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "REGION": "us-east-1"},
+    )
+    assert result.returncode == 0, (
+        f"expected exit 0 (plan mode), got {result.returncode}: {result.stderr}"
+    )
+    assert "PLAN" in result.stderr
+    assert "CONFIRM=DELETE" in result.stderr


### PR DESCRIPTION
Adds `dev-scripts/teardown-cardinal.sh` — the per-stack teardown the dev flow needed (the legacy `cleanup-lakerunner.sh`/`teardown-lakerunner.sh` target the retired monolithic stack names).

## What it does
Deletes the five `cardinal-*` stacks in reverse-dependency order, empties + removes the cooked/otel-raw buckets, and force-deletes the retained `cardinal-license`/`cardinal-admin-key`/`cardinal-db-master` secrets — so a fresh install can re-create them. **Leaves the VPC and ECS cluster intact.** Self-contained POSIX `sh` + AWS CLI v2 + `jq`, env-driven, idempotent, gated behind `CONFIRM=DELETE` (plan-only without it).

```sh
REGION=us-east-1 dev-scripts/teardown-cardinal.sh                 # plan only
REGION=us-east-1 CONFIRM=DELETE dev-scripts/teardown-cardinal.sh  # execute
```
Env: `KEEP_SECRETS`/`KEEP_BUCKETS`/`DELETE_SNAPSHOTS`, stack-name overrides, `DEPLOYER_ROLE_ARN`.

## Validation
Run for real against the live test env (full teardown-all-but-VPC-and-cluster): emptied buckets, deleted all 5 stacks, wiped survivors, clean slate, `lrdev-vpc`/`lrdev-baseinfra` preserved. The run also survived an AWS SSO token expiry mid-teardown — it failed loudly (exit 1) rather than silently continuing, and a re-run idempotently skipped the already-deleted stacks and finished. shellcheck-clean.

## Also
- Lint test `tests/unit/test_teardown_cardinal_lint.py` (executable, shellcheck, no-REGION→exit 2, `--help`, CONFIRM gate). `make test` 498 passed.
- Wired `docs/operations/dev-environment.md` and `dev-scripts/README.md` to the script (replaces the manual sequence; removes the "future follow-up" note).