### PR TITLE
teardown-cardinal: empty each bucket right before deleting its stack

### DIFF
--- a/dev-scripts/teardown-cardinal.sh
+++ b/dev-scripts/teardown-cardinal.sh
@@ -116,14 +116,19 @@ delete_stack() {
     log "$s deleted"
 }
 
-# Empty the data buckets first so their owning stacks (which may use a Delete
-# policy) don't fail deletion on a non-empty bucket.
-if [ "${KEEP_BUCKETS:-}" != "true" ]; then
-    empty_bucket "$RAW_BUCKET"
-    empty_bucket "$COOKED_BUCKET"
-fi
-
 for s in $STACKS; do
+    # Empty an owning stack's bucket immediately BEFORE deleting that stack —
+    # not all upfront. By delete time the writer stack ahead of it is already
+    # gone (collector before its raw bucket; app tier before the cooked bucket),
+    # so a Delete-policy bucket isn't re-filled mid-teardown and blocked from
+    # deletion. The raw bucket is owned by the satellite-infra-base stack; the
+    # cooked bucket by the lakerunner-infra-base stack.
+    if [ "${KEEP_BUCKETS:-}" != "true" ]; then
+        case "$s" in
+            "$SAT_INFRA_STACK")  empty_bucket "$RAW_BUCKET" ;;
+            "$INFRA_BASE_STACK") empty_bucket "$COOKED_BUCKET" ;;
+        esac
+    fi
     delete_stack "$s"
 done
 


### PR DESCRIPTION
## Bug
`teardown-cardinal.sh` emptied `otel-raw` + `cooked` **once upfront**, then deleted the five stacks. But the collector (`satellite-services`) keeps writing to `otel-raw` for the ~20 min the earlier stacks take to delete, so by the time `satellite-infra-base` (which owns that Delete-policy bucket) is deleted, the bucket has refilled → `DELETE_FAILED`. Observed twice during the real burn; a re-run (after the collector was gone) succeeded.

## Fix
Empty each owning stack's bucket immediately **before** deleting that stack, inside the delete loop:
- `otel-raw` right before `satellite-infra-base` (collector already deleted),
- `cooked` right before `lakerunner-infra-base` (app tier already deleted).

By then the writer is gone, so the bucket stays empty and the stack deletes in one pass.

Behavior otherwise unchanged: `CONFIRM=DELETE` gate, idempotent, survivor wipe. shellcheck-clean; lint test passes. Dev tooling only — no release/changelog.