### PR TITLE
README: per-stack descriptions + base/satellite apply orders

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,53 @@ SQS, secrets, ALBs, ECS services).
 - **Dev/test environment (reproduce, validate an upgrade, burn it down):** [`docs/operations/dev-environment.md`](docs/operations/dev-environment.md)
 - **The drivers themselves:** [`scripts/README.md`](scripts/README.md)
 
-## Stacks (install order)
+## Stacks
+
+**You provide:** a VPC with subnets, and an ECS Fargate cluster. The stacks
+create everything else. Each driver reads upstream stacks' outputs by name, so
+order matters.
+
+### Base lakerunner install
+
+The central application: API/query/process/control services, the database, and
+the Maestro UI.
 
 ```
-1. cardinal-lakerunner-infra-base   IAM roles, security groups, cooked S3 bucket, license/admin secrets
-2. cardinal-lakerunner-infra-rds    RDS Postgres
-3. cardinal-satellite-infra-base    raw ingest bucket + SQS + cross-account access role
-4. cardinal-satellite-services      OTLP collector (its own ALB)
-5. cardinal-lakerunner-services     app ALB + query/process/control + maestro/dex (root + nested children)
+1. cardinal-lakerunner-infra-base   deploy-lakerunner-infra-base.sh   creates IAM roles, security groups, cooked S3 bucket, license/admin-key secrets
+2. cardinal-lakerunner-infra-rds    deploy-lakerunner-infra-rds.sh    creates the RDS Postgres database
+3. cardinal-lakerunner-services     deploy-lakerunner-services.sh     creates the app ALB, query/process/control services, and maestro+dex
 ```
 
-Each driver reads upstream stacks' outputs by name, so order matters.
 `cardinal-lakerunner-services` is a root template with nested children: `alb`,
 `cert`, `migration`, `services-query`, `services-process`, `services-control`,
 `otel`, `maestro`.
+
+### Satellite install
+
+The OTLP ingest edge — a raw bucket/queue plus the collector that fills them.
+May live in a different account from the base install; it only needs the base
+install's process-role ARN as its trusted principal.
+
+```
+1. cardinal-satellite-infra-base    deploy-satellite-infra-base.sh    creates the raw ingest S3 bucket, its SQS queue, and the cross-account access role the base install assumes
+2. cardinal-satellite-services      deploy-satellite-services.sh      creates the OTLP collector and its own ALB
+```
+
+### Single-account order
+
+When the base and a satellite share one account, the dependencies interleave:
+`satellite-infra-base` needs the base `ProcessRoleArn`, and
+`lakerunner-services` needs the satellite's queue/role and collector endpoint.
+Deploy in this order (see
+[`docs/operations/production-deploy.md`](docs/operations/production-deploy.md)):
+
+```
+1. cardinal-lakerunner-infra-base
+2. cardinal-lakerunner-infra-rds
+3. cardinal-satellite-infra-base
+4. cardinal-satellite-services
+5. cardinal-lakerunner-services
+```
 
 ## Published artifacts & versioning
 


### PR DESCRIPTION
Restructures the README Stacks section to describe each stack alongside its driver script, split into a base lakerunner install order and a satellite install order, plus the interleaved single-account order. Adds a 'you provide: VPC with subnets, ECS cluster' prerequisite note.

No release needed (docs only).