### PR TITLE
Multiple DEX login accounts via DexExtraUsers

### DIFF
--- a/.cardinal-initiative
+++ b/.cardinal-initiative
@@ -1,0 +1,5 @@
+{
+  "name": "multiple-dex-accounts",
+  "description": "Let operators configure more than one bundled-Dex login account (each with its own username/password), so non-admin org members can be invited and sign in without an external IdP. Spans the dex-customization image template and the lakerunner CloudFormation parameter surface.",
+  "type": "feature"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
-## Unreleased
+## v1.1.0
 
 - **New optional parameter `DexExtraUsers`** (NoEcho, default empty) on the
   lakerunner-services stack. Adds bundled-DEX login accounts beyond the admin:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## Unreleased
+
+- **New optional parameter `DexExtraUsers`** (NoEcho, default empty) on the
+  lakerunner-services stack. Adds bundled-DEX login accounts beyond the admin:
+  a JSON array of `{"email":...,"hash":"$2y$..."}` objects (optional
+  `username`/`userID`). The deploy driver accepts it as `DEX_EXTRA_USERS`
+  (inline, single-line JSON) or `DEX_EXTRA_USERS_FILE` (path to a JSON file).
+  Leave it empty for the existing admin-only behavior — no upgrade action.
+  Make any of the extra users a superadmin by also adding their email to
+  `OIDC_SUPERADMIN_EMAILS`; otherwise an admin invites them to an org in the
+  Maestro UI after their first login. Requires the bundled DEX image that
+  supports `DEX_EXTRA_USERS` (shipped with this release's `DexImage` default);
+  an empty value works on any prior image. No resource replacement.
+
 ## v1.0.1
 
 - **lakerunner `v1.40.4` -> `v1.41.6`.** Default `LakerunnerImage` bump. On

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -36,7 +36,7 @@ images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.41.6@sha256:b19a07106bd21658e7e1f833e4fa79e633418f810126c710907f436beab964a9"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.53.1@sha256:ac533a492623b5df7c4176f8fc887145a2de3662417388e5fc0fb678c49ba698"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
-  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
+  dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
   # aws-cli: used only by the cardinal-cleanup teardown task (sh + aws + jq);
   # never part of a running install. Official AWS image on public ECR.

--- a/docs/superpowers/specs/2026-06-09-multiple-dex-accounts-design.md
+++ b/docs/superpowers/specs/2026-06-09-multiple-dex-accounts-design.md
@@ -1,0 +1,146 @@
+# Multiple Dex Login Accounts
+
+Status: approved (2026-06-09)
+
+## Goal
+
+Let an operator configure more than one bundled-Dex login account, each with
+its own username and password, so non-admin users can be invited as org
+members and sign in to Maestro without an external IdP. Today the bundled Dex
+renders exactly one `staticPasswords` entry from `DEX_ADMIN_EMAIL` +
+`DEX_ADMIN_HASH`; this adds an additive list of further accounts.
+
+## Background: why this needs two repos
+
+Two mechanisms were conflated in the original request:
+
+1. `OidcSuperadminEmails` (Maestro env, CSV) is an **authorization allowlist**:
+   "if someone with this email authenticates, grant them superadmin." It does
+   not create login accounts.
+2. Dex `staticPasswords` are the actual **credentials**. The live config is
+   rendered inside the `dex-customization` image by gomplate from env vars
+   (`config/config.docker.yaml`), and emits a single entry. Dex uses in-memory
+   storage with no runtime user management, so every account must be baked into
+   config at task start.
+
+A user cannot log in unless Dex has a `staticPasswords` record for them, so the
+real enabler lives in the `dex-customization` image. The CloudFormation repo
+only threads env vars into the Dex container. Therefore the feature is a
+coordinated change across:
+
+- `dex-customization` — render N `staticPasswords` from a new env var.
+- `lakerunner-cloudformation` — add the parameter and wire it through the
+  shell driver, root stack, and Maestro child to the Dex container env.
+
+Maestro needs no change: it provisions a user on first OIDC login and keys org
+membership by email. "Inviting a member" is a runtime in-app admin action.
+
+## Repo 1: dex-customization
+
+Extend `config/config.docker.yaml`. The admin stays as entry 0, unchanged; a
+new `DEX_EXTRA_USERS` env var (JSON array) renders additional entries:
+
+```gotemplate
+staticPasswords:
+  - email: "{{ getenv "DEX_ADMIN_EMAIL" | required "DEX_ADMIN_EMAIL is required" }}"
+    hash: "{{ getenv "DEX_ADMIN_HASH" | required "DEX_ADMIN_HASH is required" }}"
+    username: "admin"
+    userID: "00000000-0000-0000-0000-000000000001"
+{{- $extra := getenv "DEX_EXTRA_USERS" "[]" | data.JSON }}
+{{- range $u := $extra }}
+{{-   $email := $u.email | required "each DEX_EXTRA_USERS entry needs an email" }}
+  - email: "{{ $email }}"
+    hash: "{{ $u.hash | required "each DEX_EXTRA_USERS entry needs a hash" }}"
+    username: "{{ if $u.username }}{{ $u.username }}{{ else }}{{ index (strings.Split "@" $email) 0 }}{{ end }}"
+    userID: "{{ if $u.userID }}{{ $u.userID }}{{ else }}{{ uuid.V5 "1b671a64-40d5-491e-99b0-da01ff1f3341" $email }}{{ end }}"
+{{- end }}
+```
+
+Properties:
+
+- Unset/empty `DEX_EXTRA_USERS` defaults to `"[]"` -> zero extra entries ->
+  byte-identical render to today (back-compat).
+- The operator supplies only `email` + `hash` per entry. `username` defaults to
+  the email local part; `userID` defaults to a stable `uuid.V5` of the email
+  (fixed Cardinal namespace UUID). Both may be overridden explicitly.
+- bcrypt `$` survives: JSON does not escape `$`, and gomplate renders in a
+  single pass without re-scanning its output (the same property the admin hash
+  already relies on).
+- Malformed JSON, or an entry missing `email`/`hash`, fails the render loudly
+  via `required` -> Dex will not start -> ECS deployment circuit breaker rolls
+  back. Consistent with the existing fail-loud config contract.
+
+Testing: extend `test/config_render_smoke.sh` with a 2-user `DEX_EXTRA_USERS`
+case asserting two extra `staticPasswords` entries render with derived username
+and userID, and that an empty/unset value renders exactly the single admin
+entry. Release as `v0.4.0`.
+
+## Repo 2: lakerunner-cloudformation
+
+1. `src/cardinal_cfn/children/maestro.py`: add one `NoEcho` parameter
+   `DexExtraUsers` (default `""`), set it on the Dex container as
+   `Environment(Name="DEX_EXTRA_USERS", Value=Ref("DexExtraUsers"))`, and add it
+   to the "DEX configuration" parameter group. Hashes stay in env (one-way,
+   matching `DEX_ADMIN_HASH` today; no Secrets Manager indirection).
+2. `src/cardinal_cfn/root.py`: declare `DexExtraUsers` and forward it to the
+   Maestro child stack.
+3. `scripts/deploy-lakerunner-services.sh`: mirror the cert string-or-file
+   duality.
+   - `DEX_EXTRA_USERS` (inline, single-line JSON) -> appended to `PARAMS` as
+     `DexExtraUsers=...`. Safe because `scripts-src/parts/base.sh` assembles the
+     parameter list as JSON via `jq`, not the AWS CLI `--parameter-overrides`
+     shorthand, so commas / quotes / `$` in the value survive. The only
+     restriction is no embedded newlines (newlines delimit `PARAMS` entries).
+   - `DEX_EXTRA_USERS_FILE` (path to a pretty-printed JSON file) -> routed via
+     `FILE_PARAMS` (multi-line safe), exactly like `CERTIFICATE_BODY_FILE`. The
+     inline form wins when both are set.
+4. Image pin: bump `cardinal-defaults.yaml` `images.dex` and the driver's
+   `DEX_IMAGE_SUFFIX` to the published `v0.4.0` digest. **Ordering: publish the
+   dex image first, then bump the pin** -- the old image ignores the new env
+   var, so a premature pin bump would ship a silently-inert parameter.
+5. Tests under `tests/templates/`: assert `DexExtraUsers` exists, is `NoEcho`,
+   defaults empty, sits in the DEX parameter group, and renders the
+   `DEX_EXTRA_USERS` env var on the Dex container; root forwards it to the
+   Maestro child.
+
+## Operator story (documentation, no code)
+
+Supply accounts as JSON, e.g.:
+
+```json
+[{"email":"alice@acme.com","hash":"$2y$10$..."},
+ {"email":"bob@acme.com","hash":"$2y$10$..."}]
+```
+
+via `DEX_EXTRA_USERS` (inline) or `DEX_EXTRA_USERS_FILE` (file). Generate each
+hash the same way as the admin hash
+(`htpasswd -bnBC 10 "" 'password' | tr -d ':\n' | sed 's/^/$/' | sed 's/2y/2a/'`).
+
+- To make one of them a **superadmin**, also add their email to
+  `OIDC_SUPERADMIN_EMAILS`.
+- For a **plain org member**, leave them out of superadmin; an admin invites
+  them to the org in-app after their first login (Maestro keys membership by
+  email -- no stack change).
+- Do not repeat the admin's email in the list (duplicate `staticPasswords`
+  email is undefined; first match wins on login).
+
+## Non-goals / YAGNI
+
+- No runtime user management: Dex is in-memory and static-config by design;
+  every account is a config entry applied at task start. Add/remove is a stack
+  update.
+- No plaintext-password hashing in the stack: operators supply pre-bcrypted
+  hashes, as today.
+- No HA for Dex: inherits upstream's single-replica, in-memory, POC-grade
+  posture. Login state is lost on task restart.
+- Large lists (~30+) approach the 4 KB CloudFormation parameter-value limit;
+  that is the documented signal to move to an external IdP rather than the
+  bundled Dex.
+
+## Upgrade / operational notes
+
+- Existing installs that set nothing new render identically -- no upgrade action
+  for operators who do not want extra accounts.
+- Changing `DEX_EXTRA_USERS` replaces the Maestro task (Dex re-renders config on
+  the next task), and rotates Dex's in-memory signing keys, so existing browser
+  sessions must re-authenticate -- the same churn any Dex config change causes.

--- a/docs/superpowers/specs/2026-06-09-multiple-dex-accounts-design.md
+++ b/docs/superpowers/specs/2026-06-09-multiple-dex-accounts-design.md
@@ -46,23 +46,31 @@ staticPasswords:
     hash: "{{ getenv "DEX_ADMIN_HASH" | required "DEX_ADMIN_HASH is required" }}"
     username: "admin"
     userID: "00000000-0000-0000-0000-000000000001"
-{{- $extra := getenv "DEX_EXTRA_USERS" "[]" | data.JSON }}
+{{- $extra := getenv "DEX_EXTRA_USERS" "[]" | data.JSONArray }}
 {{- range $u := $extra }}
 {{-   $email := $u.email | required "each DEX_EXTRA_USERS entry needs an email" }}
+{{-   $un := index $u "username" }}
+{{-   $uid := index $u "userID" }}
+{{-   $h := crypto.SHA256 $email }}
   - email: "{{ $email }}"
     hash: "{{ $u.hash | required "each DEX_EXTRA_USERS entry needs a hash" }}"
-    username: "{{ if $u.username }}{{ $u.username }}{{ else }}{{ index (strings.Split "@" $email) 0 }}{{ end }}"
-    userID: "{{ if $u.userID }}{{ $u.userID }}{{ else }}{{ uuid.V5 "1b671a64-40d5-491e-99b0-da01ff1f3341" $email }}{{ end }}"
+    username: "{{ if $un }}{{ $un }}{{ else }}{{ index (strings.Split "@" $email) 0 }}{{ end }}"
+    userID: "{{ if $uid }}{{ $uid }}{{ else }}{{ printf "%s-%s-%s-%s-%s" (slice $h 0 8) (slice $h 8 12) (slice $h 12 16) (slice $h 16 20) (slice $h 20 32) }}{{ end }}"
 {{- end }}
 ```
 
 Properties:
 
-- Unset/empty `DEX_EXTRA_USERS` defaults to `"[]"` -> zero extra entries ->
-  byte-identical render to today (back-compat).
-- The operator supplies only `email` + `hash` per entry. `username` defaults to
-  the email local part; `userID` defaults to a stable `uuid.V5` of the email
-  (fixed Cardinal namespace UUID). Both may be overridden explicitly.
+- Uses `data.JSONArray` (gomplate's `data.JSON` parses only a top-level object,
+  not an array). Unset/empty `DEX_EXTRA_USERS` defaults to `"[]"` -> zero extra
+  entries -> byte-identical render to today (back-compat).
+- The operator supplies only `email` + `hash` per entry. Optional `username`/
+  `userID` are read with `index` (a missing map key under gomplate's strict mode
+  errors via `.field` access but returns nil via `index`). `username` defaults
+  to the email local part; `userID` defaults to a stable UUID-shaped digest of
+  the email -- gomplate has no `uuid.V5`, so the id is built from the first 32
+  hex chars of `crypto.SHA256(email)`. Dex only needs a stable, unique, non-empty
+  id; both fields may be overridden explicitly.
 - bcrypt `$` survives: JSON does not escape `$`, and gomplate renders in a
   single pass without re-scanning its output (the same property the admin hash
   already relies on).

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -85,6 +85,13 @@ Optional (template defaults preserved when unset):
   CERTIFICATE_CHAIN_FILE      PEM chain (path) -- fallback for CERTIFICATE_CHAIN.
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
   DEX_CLIENT_ID               (template default maestro-ui).
+  DEX_EXTRA_USERS             JSON array of additional DEX login accounts, each
+                              with an "email" and a bcrypt "hash" (optional
+                              "username"/"userID").  Single-line; passed as the
+                              DexExtraUsers stack param.  Add a user's email to
+                              OIDC_SUPERADMIN_EMAILS to make them a superadmin.
+  DEX_EXTRA_USERS_FILE        Path to a JSON file with the same content (multi-
+                              line ok) -- fallback for DEX_EXTRA_USERS.
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
   SATELLITE_SERVICES_STACK    Source of CollectorEndpoint for lakerunner self-
                               telemetry (default cardinal-satellite-services).
@@ -382,6 +389,29 @@ DexAdminPasswordHash=$DEX_ADMIN_PASSWORD_HASH"
 DexClientId=$DEX_CLIENT_ID"
 [ -n "${OIDC_SUPERADMIN_EMAILS:-}" ] && params="$params
 OidcSuperadminEmails=$OIDC_SUPERADMIN_EMAILS"
+
+# Additional DEX login accounts.  Inline DEX_EXTRA_USERS rides PARAMS (single-
+# line: PARAMS is newline-delimited, so a multi-line blob must use the _FILE
+# form, routed through FILE_PARAMS like the cert PEMs).  Inline wins when both
+# are set.
+if [ -n "${DEX_EXTRA_USERS:-}" ]; then
+    case "$DEX_EXTRA_USERS" in
+        *"$(printf '\n')"*)
+            echo "[deploy-lakerunner-services] ERROR: DEX_EXTRA_USERS contains a newline; pass a single-line value or use DEX_EXTRA_USERS_FILE" >&2
+            exit 2
+            ;;
+    esac
+    params="$params
+DexExtraUsers=$DEX_EXTRA_USERS"
+elif [ -n "${DEX_EXTRA_USERS_FILE:-}" ]; then
+    [ -r "$DEX_EXTRA_USERS_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read DEX_EXTRA_USERS_FILE: $DEX_EXTRA_USERS_FILE" >&2; exit 2; }
+    if [ -n "$file_params" ]; then
+        file_params="$file_params
+DexExtraUsers=$DEX_EXTRA_USERS_FILE"
+    else
+        file_params="DexExtraUsers=$DEX_EXTRA_USERS_FILE"
+    fi
+fi
 
 [ -n "${PUBSUB_AUTOREGISTER:-}" ] && params="$params
 PubsubAutoRegister=$PUBSUB_AUTOREGISTER"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -86,6 +86,13 @@ Optional (template defaults preserved when unset):
   CERTIFICATE_CHAIN_FILE      PEM chain (path) -- fallback for CERTIFICATE_CHAIN.
   DEX_ADMIN_EMAIL             (template default admin@cardinal.local).
   DEX_CLIENT_ID               (template default maestro-ui).
+  DEX_EXTRA_USERS             JSON array of additional DEX login accounts, each
+                              with an "email" and a bcrypt "hash" (optional
+                              "username"/"userID").  Single-line; passed as the
+                              DexExtraUsers stack param.  Add a user's email to
+                              OIDC_SUPERADMIN_EMAILS to make them a superadmin.
+  DEX_EXTRA_USERS_FILE        Path to a JSON file with the same content (multi-
+                              line ok) -- fallback for DEX_EXTRA_USERS.
   OIDC_SUPERADMIN_EMAILS      (template default admin@cardinal.local).
   SATELLITE_SERVICES_STACK    Source of CollectorEndpoint for lakerunner self-
                               telemetry (default cardinal-satellite-services).
@@ -383,6 +390,29 @@ DexAdminPasswordHash=$DEX_ADMIN_PASSWORD_HASH"
 DexClientId=$DEX_CLIENT_ID"
 [ -n "${OIDC_SUPERADMIN_EMAILS:-}" ] && params="$params
 OidcSuperadminEmails=$OIDC_SUPERADMIN_EMAILS"
+
+# Additional DEX login accounts.  Inline DEX_EXTRA_USERS rides PARAMS (single-
+# line: PARAMS is newline-delimited, so a multi-line blob must use the _FILE
+# form, routed through FILE_PARAMS like the cert PEMs).  Inline wins when both
+# are set.
+if [ -n "${DEX_EXTRA_USERS:-}" ]; then
+    case "$DEX_EXTRA_USERS" in
+        *"$(printf '\n')"*)
+            echo "[deploy-lakerunner-services] ERROR: DEX_EXTRA_USERS contains a newline; pass a single-line value or use DEX_EXTRA_USERS_FILE" >&2
+            exit 2
+            ;;
+    esac
+    params="$params
+DexExtraUsers=$DEX_EXTRA_USERS"
+elif [ -n "${DEX_EXTRA_USERS_FILE:-}" ]; then
+    [ -r "$DEX_EXTRA_USERS_FILE" ] || { echo "[deploy-lakerunner-services] ERROR: cannot read DEX_EXTRA_USERS_FILE: $DEX_EXTRA_USERS_FILE" >&2; exit 2; }
+    if [ -n "$file_params" ]; then
+        file_params="$file_params
+DexExtraUsers=$DEX_EXTRA_USERS_FILE"
+    else
+        file_params="DexExtraUsers=$DEX_EXTRA_USERS_FILE"
+    fi
+fi
 
 [ -n "${PUBSUB_AUTOREGISTER:-}" ] && params="$params
 PubsubAutoRegister=$PUBSUB_AUTOREGISTER"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -33,7 +33,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # DB_INIT_IMAGE remains a full-URI escape hatch.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.41.6@sha256:b19a07106bd21658e7e1f833e4fa79e633418f810126c710907f436beab964a9"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.53.1@sha256:ac533a492623b5df7c4176f8fc887145a2de3662417388e5fc0fb678c49ba698"
-DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.3.0@sha256:7d5504390f799577d31c3bde21c816e1c3674de30f31bf755e0633886b4bbf77"
+DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 
 usage() {

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -309,6 +309,21 @@ def build() -> Template:
             "(or any bcrypt $2a$/$2b$/$2y$ hash). Required."
         ),
     )
+    add_no_echo_parameter(
+        t,
+        "DexExtraUsers",
+        default="",
+        description=(
+            "Optional additional DEX login accounts, beyond the admin above. "
+            "JSON array of objects, each with a required \"email\" and bcrypt "
+            "\"hash\" (same form as DexAdminPasswordHash) plus optional "
+            "\"username\"/\"userID\": "
+            "[{\"email\":\"a@b.com\",\"hash\":\"$2y$...\"}]. Leave empty for "
+            "admin-only. Make any of them a superadmin by also adding their "
+            "email to OidcSuperadminEmails; otherwise an admin invites them to "
+            "an org in the Maestro UI after their first login."
+        ),
+    )
 
     # ---------------------------------------------------------------------
     # Console parameter grouping
@@ -359,6 +374,7 @@ def build() -> Template:
                     "DexClientId",
                     "DexAdminEmail",
                     "DexAdminPasswordHash",
+                    "DexExtraUsers",
                     "OidcSuperadminEmails",
                 ],
             },
@@ -593,6 +609,8 @@ def build() -> Template:
             Environment(Name="DEX_PORT", Value=str(dex_port)),
             Environment(Name="DEX_ADMIN_EMAIL", Value=Ref("DexAdminEmail")),
             Environment(Name="DEX_ADMIN_HASH", Value=Ref("DexAdminPasswordHash")),
+            # Additive non-admin accounts; empty -> the image renders admin only.
+            Environment(Name="DEX_EXTRA_USERS", Value=Ref("DexExtraUsers")),
         ],
         LogConfiguration=LogConfiguration(
             LogDriver="awslogs",

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -353,6 +353,15 @@ def build() -> Template:
             "Bcrypt hash ($2a$/$2b$/$2y$) of the DEX admin password. Required."
         ),
     )
+    add_no_echo_parameter(
+        t, "DexExtraUsers", default="",
+        description=(
+            "Optional JSON array of additional DEX login accounts, each "
+            "{\"email\":...,\"hash\":\"$2y$...\"} (optional \"username\"/"
+            "\"userID\"). Empty for admin-only. Add an email to "
+            "OidcSuperadminEmails to make that user a superadmin."
+        ),
+    )
     t.add_parameter(Parameter(
         "OidcSuperadminEmails",
         Type="String",
@@ -478,6 +487,7 @@ def build() -> Template:
             {"label": "Advanced",
              "parameters": ["DeployMaestro",
                             "DexAdminEmail", "DexAdminPasswordHash",
+                            "DexExtraUsers",
                             "OidcSuperadminEmails",
                             "OrganizationId", "OrgName",
                             "TemplateBaseUrl"]},
@@ -701,6 +711,7 @@ def build() -> Template:
         "DexClientId": Ref("DexClientId"),
         "DexAdminEmail": Ref("DexAdminEmail"),
         "DexAdminPasswordHash": Ref("DexAdminPasswordHash"),
+        "DexExtraUsers": Ref("DexExtraUsers"),
         "OidcSuperadminEmails": Ref("OidcSuperadminEmails"),
         "AdminApiKeySecretArn": Ref("AdminKeySecretArn"),
         "OrganizationId": Ref("OrganizationId"),

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -154,6 +154,17 @@ def test_migration_child_gets_no_org_content_params(td):
         assert gone not in migration, f"Migration child still gets {gone}"
 
 
+def test_dex_extra_users_param_and_forwarded_to_maestro(td):
+    """Additional DEX accounts: NoEcho param on the root, forwarded verbatim to
+    the Maestro child (which sets it as the dex DEX_EXTRA_USERS env var)."""
+    p = td["Parameters"]["DexExtraUsers"]
+    assert p["Type"] == "String"
+    assert p["NoEcho"] is True
+    assert p["Default"] == ""
+    maestro = td["Resources"]["Maestro"]["Properties"]["Parameters"]
+    assert maestro["DexExtraUsers"] == {"Ref": "DexExtraUsers"}
+
+
 def test_self_telemetry_endpoint_param(td):
     """The locked SelfTelemetry=[No] toggle is gone; a real configurable
     SelfTelemetryEndpoint (String, default "") takes its place."""

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -60,6 +60,22 @@ def test_dex_client_id_default(td):
     assert td["Parameters"]["DexClientId"]["Default"] == "maestro-ui"
 
 
+def test_dex_extra_users_parameter(td):
+    p = td["Parameters"]["DexExtraUsers"]
+    assert p["Type"] == "String"
+    # Holds bcrypt hashes -> NoEcho. Empty default -> admin-only, back-compat.
+    assert p["NoEcho"] is True
+    assert p["Default"] == ""
+
+
+def test_dex_extra_users_in_dex_parameter_group(td):
+    groups = td["Metadata"]["AWS::CloudFormation::Interface"]["ParameterGroups"]
+    dex_group = next(
+        g for g in groups if g["Label"]["default"] == "DEX configuration"
+    )
+    assert "DexExtraUsers" in dex_group["Parameters"]
+
+
 # ---------------------------------------------------------------------------
 # Core resources
 # ---------------------------------------------------------------------------
@@ -325,6 +341,14 @@ def test_dex_container_env_has_oidc_inputs(td):
         "DEX_ADMIN_EMAIL",
         "DEX_ADMIN_HASH",
     } <= env_names
+
+
+def test_dex_container_extra_users_env(td):
+    # The additive multi-account list is threaded to the dex gomplate template
+    # via DEX_EXTRA_USERS; the image renders zero entries when it is empty.
+    dex_c = _container(td, "dex")
+    env = {e["Name"]: e["Value"] for e in dex_c.get("Environment", [])}
+    assert env["DEX_EXTRA_USERS"] == {"Ref": "DexExtraUsers"}
 
 
 def test_dex_renders_config_in_image(td):

--- a/tests/unit/test_deploy_lakerunner.py
+++ b/tests/unit/test_deploy_lakerunner.py
@@ -442,6 +442,7 @@ def test_create_full_install_mix(tmp_path):
             "ParameterType": "String",
         },
         {"ParameterKey": "DexAdminPasswordHash", "ParameterType": "String"},
+        {"ParameterKey": "DexExtraUsers", "ParameterType": "String"},
         {"ParameterKey": "LicenseData", "ParameterType": "String"},
         {
             "ParameterKey": "TemplateBaseUrl",
@@ -454,6 +455,9 @@ def test_create_full_install_mix(tmp_path):
         "PrivateSubnets": "subnet-1,subnet-2",
         "DexAdminEmail": "ops@example.com",
         "DexAdminPasswordHash": "$2b$12$abcdef",
+        # Commas, quotes, and '$' in one PARAMS value: the engine JSON-encodes it
+        # (not CLI --parameter-overrides shorthand), so it must survive verbatim.
+        "DexExtraUsers": '[{"email":"a@b.com","hash":"$2y$10$abc.DEF/ghi"}]',
         "LicenseData": '{"customer":"acme"}',
         "TemplateBaseUrl": "https://my-mirror.example.com/v9.9.9/cardinal-lakerunner/",
     }
@@ -466,5 +470,9 @@ def test_create_full_install_mix(tmp_path):
     assert out["LakerunnerImage"]["ParameterValue"].endswith("1.20.0")
     assert out["DexAdminEmail"]["ParameterValue"] == "ops@example.com"  # CLI overrides default
     assert out["DexAdminPasswordHash"]["ParameterValue"].startswith("$2b$12$")
+    assert (
+        out["DexExtraUsers"]["ParameterValue"]
+        == '[{"email":"a@b.com","hash":"$2y$10$abc.DEF/ghi"}]'
+    )
     assert out["LicenseData"]["ParameterValue"] == '{"customer":"acme"}'
     assert out["TemplateBaseUrl"]["ParameterValue"].startswith("https://my-mirror.example.com")


### PR DESCRIPTION
Adds an optional `DexExtraUsers` parameter so operators can configure bundled-DEX login accounts beyond the admin (non-admin members invited to an org, each with their own username/password) without an external IdP.

- `DexExtraUsers` (NoEcho, default empty) on the lakerunner-services root, forwarded to the Maestro child, set as the dex container's `DEX_EXTRA_USERS` env var (the dex image renders it into `staticPasswords`).
- Deploy driver accepts `DEX_EXTRA_USERS` (inline single-line JSON via PARAMS) or `DEX_EXTRA_USERS_FILE` (file via FILE_PARAMS, like the cert PEMs). Commas/quotes/`$` survive because the engine JSON-encodes params (not CLI shorthand).
- Empty value = existing admin-only behavior, no upgrade action. Superadmin via `OidcSuperadminEmails`; plain members invited in the Maestro UI after first login.

Tests: maestro param/NoEcho/group/env assertions, root forwarding, and an engine round-trip proving a JSON value with commas+`$` survives. `make build` + cfn-lint clean; full suite green.

Depends on the dex image that supports `DEX_EXTRA_USERS` (dex-customization v0.4.0). The `DexImage` pin bump to that digest lands as a follow-up commit on this branch before release. Spec: `docs/superpowers/specs/2026-06-09-multiple-dex-accounts-design.md`.