### PR TITLE
satellite stacks: optional NameSuffix for multi-install accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.1.2
+
+- **New optional parameter `NameSuffix`** (default empty) on the
+  satellite-infra-base and satellite-services stacks, so multiple satellite
+  stacks (e.g. one collector for prod and one for dev) can coexist in a single
+  AWS account. When set, it is appended to the stacks' fixed physical names:
+  the `cardinal-satellite-access` IAM role (account-global, the previous hard
+  collision), the default raw bucket name
+  `cardinal-otel-raw-<account>-<region>`, and the `/cardinal/otel-grpc` log
+  group. Max 16 chars (lowercase alphanumeric and hyphens) to keep the default
+  bucket name within S3's 63-char limit. The suffixed role still matches the
+  central install's existing `cardinal-satellite-access*` assume-role grant,
+  so no change is needed on the lakerunner side. The deploy drivers accept it
+  as `NAME_SUFFIX`. Leave it unset on existing stacks: all names resolve to
+  exactly their previous values — no upgrade action, no resource replacement.
+
 ## v1.1.1
 
 - **Deploy-driver fix: inline `DEX_EXTRA_USERS` works and accepts multi-line

--- a/scripts-src/parts/deploy-satellite-infra-base.sh
+++ b/scripts-src/parts/deploy-satellite-infra-base.sh
@@ -38,6 +38,12 @@ Optional (template defaults preserved when unset):
                              version baked into this driver ($DEFAULT_STACK_VERSION).
                              (VERSION is accepted as a legacy alias.)
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
+  NAME_SUFFIX                Optional suffix appended to the stack's fixed
+                             physical names (access role, default bucket name)
+                             so a second satellite stack (e.g. dev + prod) can
+                             share an account.  Max 16 chars, lowercase
+                             alphanumeric and hyphens.  Leave unset on existing
+                             stacks: their names stay exactly as deployed.
   RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
   RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
   CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
@@ -78,6 +84,8 @@ MAPS=""
 params="LakerunnerPrincipal=$LAKERUNNER_PRINCIPAL
 "
 [ -n "${EXTERNAL_ID:-}" ] && params="${params}ExternalId=$EXTERNAL_ID
+"
+[ -n "${NAME_SUFFIX:-}" ] && params="${params}NameSuffix=$NAME_SUFFIX
 "
 [ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME
 "

--- a/scripts-src/parts/deploy-satellite-services.sh
+++ b/scripts-src/parts/deploy-satellite-services.sh
@@ -108,6 +108,11 @@ Optional (template defaults preserved when unset):
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
+  NAME_SUFFIX          Optional suffix appended to the stack's fixed physical
+                       names (the /cardinal/otel-grpc log group) so a
+                       second collector stack (e.g. dev + prod) can share an
+                       account/region.  Max 16 chars, lowercase alphanumeric
+                       and hyphens.  Leave unset on existing stacks.
   EXECUTION_ROLE_POLICY_ARNS   Comma-separated managed-policy ARNs to attach to
                        the collector execution role (e.g. ECR pull-through
                        import, cross-account ECR, KMS decrypt).
@@ -141,8 +146,8 @@ otel_image="$image_registry/$OTEL_IMAGE_SUFFIX"
 echo "[deploy-satellite-services] inputs visible to this process:" >&2
 for _v in STACK_NAME REGION STACK_VERSION VERSION SATELLITE_INFRA_BASE_STACK \
           ORGANIZATION_ID VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
-          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS IMAGE_REGISTRY \
-          TEMPLATE_BASE_URL DEPLOYER_ROLE_ARN NO_EXECUTE; do
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS NAME_SUFFIX \
+          IMAGE_REGISTRY TEMPLATE_BASE_URL DEPLOYER_ROLE_ARN NO_EXECUTE; do
     eval "_val=\${$_v:-}"
     printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
 done
@@ -186,6 +191,8 @@ OtelImage=$otel_image"
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
+[ -n "${NAME_SUFFIX:-}" ] && params="$params
+NameSuffix=$NAME_SUFFIX"
 
 # Optional execution-role extra managed policies (pasted JSON and/or ARNs).
 EXEC_EXTRA_ARNS=""

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -39,6 +39,12 @@ Optional (template defaults preserved when unset):
                              version baked into this driver ($DEFAULT_STACK_VERSION).
                              (VERSION is accepted as a legacy alias.)
   EXTERNAL_ID                Optional STS ExternalId for the assume-role trust.
+  NAME_SUFFIX                Optional suffix appended to the stack's fixed
+                             physical names (access role, default bucket name)
+                             so a second satellite stack (e.g. dev + prod) can
+                             share an account.  Max 16 chars, lowercase
+                             alphanumeric and hyphens.  Leave unset on existing
+                             stacks: their names stay exactly as deployed.
   RAW_BUCKET_NAME            Optional explicit raw ingest bucket name.
   RAW_BUCKET_LIFECYCLE_DAYS  (template default 7).
   CONFIGURE_BUCKET_PUBLIC_ACCESS_BLOCK
@@ -79,6 +85,8 @@ MAPS=""
 params="LakerunnerPrincipal=$LAKERUNNER_PRINCIPAL
 "
 [ -n "${EXTERNAL_ID:-}" ] && params="${params}ExternalId=$EXTERNAL_ID
+"
+[ -n "${NAME_SUFFIX:-}" ] && params="${params}NameSuffix=$NAME_SUFFIX
 "
 [ -n "${RAW_BUCKET_NAME:-}" ] && params="${params}RawBucketName=$RAW_BUCKET_NAME
 "

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -109,6 +109,11 @@ Optional (template defaults preserved when unset):
   INGEST_SOURCE_CIDR   Allowed source CIDR for the collector ALB (template default 10.0.0.0/8).
   OTEL_REPLICAS        Collector replica count (default 1; >1 requires a
                        collector config change first).
+  NAME_SUFFIX          Optional suffix appended to the stack's fixed physical
+                       names (the /cardinal/otel-grpc log group) so a
+                       second collector stack (e.g. dev + prod) can share an
+                       account/region.  Max 16 chars, lowercase alphanumeric
+                       and hyphens.  Leave unset on existing stacks.
   EXECUTION_ROLE_POLICY_ARNS   Comma-separated managed-policy ARNs to attach to
                        the collector execution role (e.g. ECR pull-through
                        import, cross-account ECR, KMS decrypt).
@@ -142,8 +147,8 @@ otel_image="$image_registry/$OTEL_IMAGE_SUFFIX"
 echo "[deploy-satellite-services] inputs visible to this process:" >&2
 for _v in STACK_NAME REGION STACK_VERSION VERSION SATELLITE_INFRA_BASE_STACK \
           ORGANIZATION_ID VPC_ID ALB_SUBNETS TASK_SUBNETS ECS_CLUSTER_ARN \
-          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS IMAGE_REGISTRY \
-          TEMPLATE_BASE_URL DEPLOYER_ROLE_ARN NO_EXECUTE; do
+          ALB_SCHEME INGEST_SOURCE_CIDR OTEL_REPLICAS NAME_SUFFIX \
+          IMAGE_REGISTRY TEMPLATE_BASE_URL DEPLOYER_ROLE_ARN NO_EXECUTE; do
     eval "_val=\${$_v:-}"
     printf '[deploy-satellite-services]   %-27s = %s\n' "$_v" "${_val:-<unset>}" >&2
 done
@@ -187,6 +192,8 @@ OtelImage=$otel_image"
 AlbScheme=$ALB_SCHEME"
 [ -n "${INGEST_SOURCE_CIDR:-}" ] && params="$params
 IngestSourceCidr=$INGEST_SOURCE_CIDR"
+[ -n "${NAME_SUFFIX:-}" ] && params="$params
+NameSuffix=$NAME_SUFFIX"
 
 # Optional execution-role extra managed policies (pasted JSON and/or ARNs).
 EXEC_EXTRA_ARNS=""

--- a/src/cardinal_cfn/satellite_infra_base.py
+++ b/src/cardinal_cfn/satellite_infra_base.py
@@ -98,7 +98,8 @@ def build() -> Template:
             Default="",
             Description=(
                 "Name for the raw ingest bucket. Blank uses the default "
-                "cardinal-otel-raw-<account>-<region>."
+                "cardinal-otel-raw-<account>-<region>, with -<NameSuffix> "
+                "appended when NameSuffix is set."
             ),
             AllowedPattern=r"^$|^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$",
         )
@@ -133,7 +134,26 @@ def build() -> Template:
         )
     )
 
+    t.add_parameter(
+        Parameter(
+            "NameSuffix",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional suffix appended to this stack's fixed physical "
+                "names (the cardinal-satellite-access role and the default "
+                "raw bucket name) so multiple satellite stacks can coexist "
+                "in one account. Blank (the default) keeps the original "
+                "names, so existing stacks are unaffected. Max 16 chars "
+                "(lowercase alphanumeric and hyphens) to keep the default "
+                "bucket name within S3's 63-char limit."
+            ),
+            AllowedPattern=r"^$|^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$",
+        )
+    )
+
     t.add_condition("UseDefaultBucketName", Equals(Ref("RawBucketName"), ""))
+    t.add_condition("HasNameSuffix", Not(Equals(Ref("NameSuffix"), "")))
     t.add_condition("HasExternalId", Not(Equals(Ref("ExternalId"), "")))
     t.add_condition(
         "AddRawBucketPublicAccessBlock",
@@ -142,7 +162,11 @@ def build() -> Template:
 
     bucket_name_value = If(
         "UseDefaultBucketName",
-        Sub("cardinal-otel-raw-${AWS::AccountId}-${AWS::Region}"),
+        If(
+            "HasNameSuffix",
+            Sub("cardinal-otel-raw-${AWS::AccountId}-${AWS::Region}-${NameSuffix}"),
+            Sub("cardinal-otel-raw-${AWS::AccountId}-${AWS::Region}"),
+        ),
         Ref("RawBucketName"),
     )
 
@@ -246,8 +270,14 @@ def build() -> Template:
             "LakerunnerAccessRole",
             # Fixed name so the lakerunner process tier can grant
             # sts:AssumeRole on the cardinal-satellite-access* pattern across
-            # accounts. One install per account makes a fixed name safe.
-            RoleName="cardinal-satellite-access",
+            # accounts. NameSuffix keeps additional satellite stacks in the
+            # same account collision-free while still matching that pattern
+            # (IAM role names are account-global; 64-char cap).
+            RoleName=If(
+                "HasNameSuffix",
+                Sub("cardinal-satellite-access-${NameSuffix}"),
+                "cardinal-satellite-access",
+            ),
             AssumeRolePolicyDocument={
                 "Version": "2012-10-17",
                 "Statement": [

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -228,6 +228,22 @@ def build() -> Template:
     )
     t.add_parameter(
         Parameter(
+            "NameSuffix",
+            Type="String",
+            Default="",
+            Description=(
+                "Optional suffix appended to this stack's fixed physical "
+                "names (the /cardinal/otel-grpc log group) so multiple "
+                "satellite collector stacks can coexist in one account and "
+                "region. Blank (the default) keeps the original names, so "
+                "existing stacks are unaffected. Max 16 chars (lowercase "
+                "alphanumeric and hyphens), matching satellite-infra-base."
+            ),
+            AllowedPattern=r"^$|^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$",
+        )
+    )
+    t.add_parameter(
+        Parameter(
             "OtelConfigYaml",
             Type="String",
             Default="",
@@ -252,6 +268,7 @@ def build() -> Template:
     t.add_condition(
         "HasOtelConfigOverride", Not(Equals(Ref("OtelConfigYaml"), ""))
     )
+    t.add_condition("HasNameSuffix", Not(Equals(Ref("NameSuffix"), "")))
 
     # ------------------------------------------------------------------
     # Console parameter grouping
@@ -284,6 +301,7 @@ def build() -> Template:
                     "OtelCpu",
                     "OtelMemory",
                     "OtelConfigYaml",
+                    "NameSuffix",
                 ],
             },
             {
@@ -550,7 +568,14 @@ def build() -> Template:
     log_group = t.add_resource(
         LogGroup(
             "OtelGrpcLogGroup",
-            LogGroupName=f"/cardinal/{_SERVICE_KEY}",
+            # Fixed name collides when a second collector stack lands in the
+            # same account/region; NameSuffix disambiguates without touching
+            # existing (suffix-less) stacks.
+            LogGroupName=If(
+                "HasNameSuffix",
+                Sub(f"/cardinal/{_SERVICE_KEY}-${{NameSuffix}}"),
+                f"/cardinal/{_SERVICE_KEY}",
+            ),
             RetentionInDays=14,
             Tags=_tags(component="satellite-otel-log"),
         )

--- a/tests/templates/test_satellite_infra_base.py
+++ b/tests/templates/test_satellite_infra_base.py
@@ -99,11 +99,44 @@ def test_bucket_lifecycle_uses_parameter(td):
 
 def test_role_named_cardinal_satellite_access(td):
     """Fixed name lets the lakerunner process tier scope cross-account
-    sts:AssumeRole to the cardinal-satellite-access* pattern."""
-    assert (
-        td["Resources"]["LakerunnerAccessRole"]["Properties"]["RoleName"]
-        == "cardinal-satellite-access"
-    )
+    sts:AssumeRole to the cardinal-satellite-access* pattern. NameSuffix
+    (blank default) appends -<suffix> while still matching that pattern;
+    blank resolves to the original name so existing stacks never change."""
+    assert td["Resources"]["LakerunnerAccessRole"]["Properties"]["RoleName"] == {
+        "Fn::If": [
+            "HasNameSuffix",
+            {"Fn::Sub": "cardinal-satellite-access-${NameSuffix}"},
+            "cardinal-satellite-access",
+        ]
+    }
+
+
+def test_name_suffix_blank_default_and_bounded(td):
+    p = td["Parameters"]["NameSuffix"]
+    assert p["Default"] == ""
+    # Max 16 chars so the default bucket name stays within S3's 63-char cap
+    # (18 prefix + 12 account + 1 + 14 longest region + 1 + 16 = 62).
+    assert p["AllowedPattern"] == r"^$|^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$"
+
+
+def test_default_bucket_name_gets_suffix(td):
+    name = td["Resources"]["RawIngestBucket"]["Properties"]["BucketName"]
+    assert name == {
+        "Fn::If": [
+            "UseDefaultBucketName",
+            {
+                "Fn::If": [
+                    "HasNameSuffix",
+                    {
+                        "Fn::Sub": "cardinal-otel-raw-${AWS::AccountId}"
+                        "-${AWS::Region}-${NameSuffix}"
+                    },
+                    {"Fn::Sub": "cardinal-otel-raw-${AWS::AccountId}-${AWS::Region}"},
+                ]
+            },
+            {"Ref": "RawBucketName"},
+        ]
+    }
 
 
 def test_role_trusts_lakerunner_principal(td):

--- a/tests/templates/test_satellite_services.py
+++ b/tests/templates/test_satellite_services.py
@@ -284,3 +284,28 @@ def test_exec_role_managed_policy_arns_conditional(td):
     blob = json.dumps(arns)
     assert "AmazonECSTaskExecutionRolePolicy" in blob
     assert "ExecutionRoleExtraPolicyArns" in blob
+
+
+# ---------------------------------------------------------------------------
+# NameSuffix (multiple collector stacks per account/region)
+# ---------------------------------------------------------------------------
+
+
+def test_name_suffix_blank_default_and_bounded(td):
+    p = td["Parameters"]["NameSuffix"]
+    assert p["Default"] == ""
+    assert p["AllowedPattern"] == r"^$|^[a-z0-9]([a-z0-9-]{0,14}[a-z0-9])?$"
+
+
+def test_log_group_name_gets_suffix(td):
+    """The fixed log group name collides on a second same-account/region
+    collector stack; NameSuffix disambiguates, blank keeps the original
+    name so existing stacks never change."""
+    name = td["Resources"]["OtelGrpcLogGroup"]["Properties"]["LogGroupName"]
+    assert name == {
+        "Fn::If": [
+            "HasNameSuffix",
+            {"Fn::Sub": "/cardinal/otel-grpc-${NameSuffix}"},
+            "/cardinal/otel-grpc",
+        ]
+    }


### PR DESCRIPTION
## Summary

- Add an optional `NameSuffix` parameter (default empty) to the satellite-infra-base and satellite-services stacks so multiple satellite stacks (e.g. one collector for prod and one for dev) can coexist in a single AWS account.
- When set, the suffix is appended to the stacks' fixed physical names: the account-global `cardinal-satellite-access` IAM role (the hard collision that fails `AWS::EarlyValidation::ResourceExistenceCheck`), the default raw bucket name `cardinal-otel-raw-<account>-<region>`, and the `/cardinal/otel-grpc` log group.
- Max 16 chars (lowercase alphanumeric and hyphens) so the default bucket name stays within S3's 63-char limit; the IAM role stays well under its 64-char cap.
- The suffixed role still matches the central install's existing `cardinal-satellite-access*` assume-role grant, so no lakerunner-side change is needed.
- Deploy drivers accept it as `NAME_SUFFIX`, forwarded only when set.
- Blank (the default) resolves every name to exactly its previous value: existing stacks see no diff and no resource replacement.

## Test plan

- [x] `make build` (cfn-lint clean)
- [x] `make test` (503 passed) including new template assertions for the suffixed and suffix-less name forms