### PR TITLE
services stack: optional PublicDnsName for vanity-hostname installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.1.3
+
+- **New optional parameter `PublicDnsName`** (default empty) on the
+  lakerunner-services stack. Sets the DNS name the install is reached at
+  (e.g. `lakerunner.example.com`) — typically a CNAME the operator points at
+  the ALB (the stack's `AlbDnsName` output). When set, the Maestro/Dex OIDC
+  issuer and redirect URLs and the `QueryApiUrl` output are derived from it
+  instead of the raw `*.elb.amazonaws.com` name, so browser logins work
+  through the vanity name; the supplied certificate
+  (`CERTIFICATE_ARN`/`CERTIFICATE_BODY`) must match it. The deploy driver
+  accepts it as `PUBLIC_DNS_NAME`. Leave it unset for the existing
+  ALB-DNS-name behavior — no upgrade action, no resource replacement. Setting
+  it on an existing install redeploys the Maestro service (new issuer env
+  vars) and invalidates sessions issued under the old hostname.
+
+Template changes:
+
+- `cardinal-lakerunner-services.yaml`
+- `cardinal-lakerunner/maestro.yaml` (parameter description only)
+
+Script changes:
+
+- `deploy-lakerunner-services.sh`
+
 ## v1.1.2
 
 - **New optional parameter `NameSuffix`** (default empty) on the

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -112,6 +112,12 @@ Optional (template defaults preserved when unset):
                               PUBLIC_SUBNETS, and the ALB SG internet ingress is
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
+  PUBLIC_DNS_NAME             DNS name the install is reached at (e.g.
+                              lakerunner.example.com), typically a CNAME the
+                              operator points at the ALB (AlbDnsName stack
+                              output).  Maestro/Dex OIDC issuer and redirect
+                              URLs are derived from it, so the certificate must
+                              match it.  Unset: the raw ALB DNS name is used.
   DB_INIT_IMAGE               Full image URI override for the db-init image
                               (official postgres psql client). Bypasses
                               IMAGE_REGISTRY. Default: the baked, pinned suffix
@@ -247,6 +253,8 @@ PublicSubnets=$PUBLIC_SUBNETS"
 AlbScheme=$ALB_SCHEME"
 [ -n "${SERVICE_NAMESPACE_NAME:-}" ] && params="$params
 ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
+[ -n "${PUBLIC_DNS_NAME:-}" ] && params="$params
+PublicDnsName=$PUBLIC_DNS_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -113,6 +113,12 @@ Optional (template defaults preserved when unset):
                               PUBLIC_SUBNETS, and the ALB SG internet ingress is
                               enabled on the infra-base stack (its ALB_SCHEME /
                               ALB_ALLOWED_CIDR* settings).
+  PUBLIC_DNS_NAME             DNS name the install is reached at (e.g.
+                              lakerunner.example.com), typically a CNAME the
+                              operator points at the ALB (AlbDnsName stack
+                              output).  Maestro/Dex OIDC issuer and redirect
+                              URLs are derived from it, so the certificate must
+                              match it.  Unset: the raw ALB DNS name is used.
   DB_INIT_IMAGE               Full image URI override for the db-init image
                               (official postgres psql client). Bypasses
                               IMAGE_REGISTRY. Default: the baked, pinned suffix
@@ -248,6 +254,8 @@ PublicSubnets=$PUBLIC_SUBNETS"
 AlbScheme=$ALB_SCHEME"
 [ -n "${SERVICE_NAMESPACE_NAME:-}" ] && params="$params
 ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
+[ -n "${PUBLIC_DNS_NAME:-}" ] && params="$params
+PublicDnsName=$PUBLIC_DNS_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
 

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -122,7 +122,11 @@ def build() -> Template:
         Parameter(
             "AlbDnsName",
             Type="String",
-            Description="DNS name of the shared ALB (used to derive issuer URLs).",
+            Description=(
+                "Public DNS name the install is reached at (the shared ALB's "
+                "DNS name, or a vanity CNAME pointing at it); used to derive "
+                "issuer URLs."
+            ),
         )
     )
     t.add_parameter(

--- a/src/cardinal_cfn/lakerunner_services.py
+++ b/src/cardinal_cfn/lakerunner_services.py
@@ -272,6 +272,18 @@ def build() -> Template:
             "parameters instead."
         ),
     ))
+    t.add_parameter(Parameter(
+        "PublicDnsName",
+        Type="String",
+        Default="",
+        Description=(
+            "Optional DNS name the install is reached at (e.g. "
+            "lakerunner.example.com), typically a CNAME the customer points "
+            "at the ALB. Used to derive the Maestro/Dex OIDC issuer and "
+            "redirect URLs; the supplied certificate must match it. Empty "
+            "uses the ALB's generated DNS name."
+        ),
+    ))
 
     # ---------------------------------------------------------------------
     # Cloud Map (in-cluster service discovery) namespace name
@@ -473,6 +485,7 @@ def build() -> Template:
              "parameters": ["VpcId", "PrivateSubnets",
                             "AlbScheme", "PublicSubnets",
                             "ServiceNamespaceName",
+                            "PublicDnsName",
                             "CertificateArn",
                             "CertificateBody", "CertificatePrivateKey",
                             "CertificateChain"]},
@@ -506,6 +519,8 @@ def build() -> Template:
         "SelfTelemetryOn", Not(Equals(Ref("SelfTelemetryEndpoint"), "")))
     self_telemetry_endpoint = Ref("SelfTelemetryEndpoint")
     self_telemetry_enabled = If("SelfTelemetryOn", "true", "false")
+
+    t.add_condition("PublicDnsNameSet", Not(Equals(Ref("PublicDnsName"), "")))
 
     # ---------------------------------------------------------------------
     # Install-id derivation (computed inline; not a parameter on root)
@@ -575,6 +590,14 @@ def build() -> Template:
         "AlbSgId": sec_alb_sg,
         "CertificateArn": GetAtt(cert_stack, "Outputs.EffectiveCertificateArn"),
     }, depends_on=["Cert"])
+
+    # Hostname the externally visible URLs are derived from: the customer's
+    # vanity DNS name when supplied, otherwise the ALB's generated DNS name.
+    public_dns_name = If(
+        "PublicDnsNameSet",
+        Ref("PublicDnsName"),
+        GetAtt(alb_stack, "Outputs.AlbDnsName"),
+    )
 
     migration_stack = _add_child(t, "Migration", "migration.yaml", {
         "InstallIdShort": install_short,
@@ -694,7 +717,7 @@ def build() -> Template:
         "PrivateSubnetsCsv": private_subnets_csv,
         "VpcId": Ref("VpcId"),
         "HttpsListenerArn": GetAtt(alb_stack, "Outputs.HttpsListenerArn"),
-        "AlbDnsName": GetAtt(alb_stack, "Outputs.AlbDnsName"),
+        "AlbDnsName": public_dns_name,
         "ServiceNamespaceName": namespace_name,
         "DbEndpoint": Ref("DbEndpoint"),
         "DbPort": Ref("DbPort"),
@@ -727,12 +750,14 @@ def build() -> Template:
                         Description="Long per-install identifier."))
     t.add_output(Output("AlbDnsName",
                         Value=GetAtt(alb_stack, "Outputs.AlbDnsName"),
-                        Description="DNS name of the shared Cardinal ALB."))
+                        Description=(
+                            "DNS name of the shared Cardinal ALB. When "
+                            "PublicDnsName is set, point its CNAME here.")))
     t.add_output(Output(
         "QueryApiUrl",
         Value=Sub(
             "https://${AlbDns}/api/v1/query/",
-            AlbDns=GetAtt(alb_stack, "Outputs.AlbDnsName"),
+            AlbDns=public_dns_name,
         ),
         Description="Base URL for the lakerunner query API.",
     ))

--- a/tests/templates/test_lakerunner_services.py
+++ b/tests/templates/test_lakerunner_services.py
@@ -239,3 +239,28 @@ def test_self_telemetry_wired_to_tiers_only(td):
         p = td["Resources"][other]["Properties"]["Parameters"]
         assert "SelfTelemetryEndpoint" not in p, other
         assert "SelfTelemetryEnabled" not in p, other
+
+
+def test_public_dns_name_overrides_hostname(td):
+    """PublicDnsName (optional, default "") replaces the ALB DNS name in every
+    externally visible URL: the Maestro child's AlbDnsName (issuer/redirect
+    URLs) and the QueryApiUrl output. The AlbDnsName output stays the raw ALB
+    name so the operator knows the CNAME target."""
+    p = td["Parameters"]["PublicDnsName"]
+    assert p["Type"] == "String"
+    assert p["Default"] == ""
+    assert td["Conditions"]["PublicDnsNameSet"] == {
+        "Fn::Not": [{"Fn::Equals": [{"Ref": "PublicDnsName"}, ""]}]
+    }
+    effective = {"Fn::If": [
+        "PublicDnsNameSet",
+        {"Ref": "PublicDnsName"},
+        {"Fn::GetAtt": ["Alb", "Outputs.AlbDnsName"]},
+    ]}
+    maestro = td["Resources"]["Maestro"]["Properties"]["Parameters"]
+    assert maestro["AlbDnsName"] == effective
+    query_url = td["Outputs"]["QueryApiUrl"]["Value"]
+    assert query_url["Fn::Sub"][1]["AlbDns"] == effective
+    assert td["Outputs"]["AlbDnsName"]["Value"] == {
+        "Fn::GetAtt": ["Alb", "Outputs.AlbDnsName"]
+    }


### PR DESCRIPTION
## Summary

- New optional `PublicDnsName` parameter (String, default empty) on the lakerunner-services root, grouped under Networking in the console.
- When set, the Maestro child's `AlbDnsName` (which drives `OIDC_ISSUER_URL`, `DEX_ISSUER_URL`, `DEX_REDIRECT_URI`, and the `MaestroUrl`/`DexUrl` outputs) and the root's `QueryApiUrl` output use it via `Fn::If(PublicDnsNameSet, ...)`; empty falls back to the ALB's generated DNS name (existing behavior).
- The root's `AlbDnsName` output stays the raw ALB name so operators know the CNAME target.
- Deploy driver (`deploy-lakerunner-services.sh`, edited in `scripts-src/`) accepts `PUBLIC_DNS_NAME` and forwards it as the `PublicDnsName` param when non-empty.
- CHANGELOG entry for v1.1.3 including the changed-files list.

## Test plan

- `make build` (cfn-lint clean)
- `make test` (504 passed), including new `test_public_dns_name_overrides_hostname` asserting the parameter, condition, Maestro wiring, `QueryApiUrl` output, and the unchanged raw `AlbDnsName` output.