### PR TITLE
deploy drivers: reject non-ASCII input with a precise error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.1.4
+
+- **Deploy drivers now reject non-ASCII input with a precise error.** Every
+  operator-supplied value — environment variables / flags and the contents of
+  input files (license token, DEX extra users JSON, certificate PEMs, policy
+  JSON) — is validated before any AWS call. A value containing smart quotes,
+  no-break spaces, or other non-ASCII or control characters now fails fast
+  (exit 2) with a message naming the parameter, the offending character (e.g.
+  `left double curly quote (U+201C)`), its line and byte position, and the
+  plain-ASCII replacement to use. Previously such characters — typically
+  introduced by pasting from a word processor, browser, or chat tool —
+  flowed into the stack parameters and surfaced much later as confusing
+  JSON or template errors. No template changes, no upgrade action; if a
+  redeploy now fails the new check, the flagged value was already corrupt —
+  fix it as the message says.
+
+Script changes:
+
+- `deploy-lakerunner-infra-base.sh`, `deploy-lakerunner-infra-rds.sh`,
+  `deploy-lakerunner-services.sh`, `deploy-satellite-infra-base.sh`,
+  `deploy-satellite-services.sh` (shared engine), `deploy-lakerunner.sh`
+
 ## v1.1.3
 
 - **New optional parameter `PublicDnsName`** (default empty) on the

--- a/scripts-src/parts/base.sh
+++ b/scripts-src/parts/base.sh
@@ -106,6 +106,10 @@ Optional:
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
+All PARAMS values and FILE_PARAMS file contents must be plain ASCII; smart
+quotes, no-break spaces, and similar pasted characters are rejected with a
+message naming the offending character and its position.
+
 Exit codes:
   0  success or no-op
   1  generic / AWS / change set failure
@@ -122,6 +126,77 @@ fail() {
     shift
     printf '[deploy-stack] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (PARAMS entries
+# composed from the driver's environment variables, FILE_PARAMS file contents)
+# must be plain ASCII: smart quotes, no-break spaces, and other typographic
+# characters -- usually introduced by pasting from a word processor, browser,
+# or chat tool -- ride silently into the CloudFormation parameter JSON and
+# surface much later as inscrutable template or service errors.  Reject them
+# up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -347,6 +422,7 @@ build_upstream_values() {
         done >"$out_file.fileparams" || exit $?
         while IFS="$(printf '\t')" read -r key path; do
             [ -n "$key" ] || continue
+            ascii_check "FILE_PARAMS parameter '$key' (file $path)" "$(cat "$path")"
             merged=$(
                 jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
                     $m + {($key): $val}
@@ -365,6 +441,8 @@ build_upstream_values() {
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
                 fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
+            ascii_check "PARAMS parameter name '$key'" "$key"
+            ascii_check "value for parameter '$key' (from PARAMS / a driver environment variable)" "$val"
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
         merged=$(
@@ -430,6 +508,11 @@ main() {
         usage >&2
         fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
+
+    ascii_check "STACK_NAME" "$stack_name"
+    ascii_check "TEMPLATE_URL" "$template_url"
+    ascii_check "REGION" "$region"
+    ascii_check "DEPLOYER_ROLE_ARN" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     existing_status=$(aws cloudformation describe-stacks \

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -292,6 +292,10 @@ Optional:
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
+All PARAMS values and FILE_PARAMS file contents must be plain ASCII; smart
+quotes, no-break spaces, and similar pasted characters are rejected with a
+message naming the offending character and its position.
+
 Exit codes:
   0  success or no-op
   1  generic / AWS / change set failure
@@ -308,6 +312,77 @@ fail() {
     shift
     printf '[deploy-stack] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (PARAMS entries
+# composed from the driver's environment variables, FILE_PARAMS file contents)
+# must be plain ASCII: smart quotes, no-break spaces, and other typographic
+# characters -- usually introduced by pasting from a word processor, browser,
+# or chat tool -- ride silently into the CloudFormation parameter JSON and
+# surface much later as inscrutable template or service errors.  Reject them
+# up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -533,6 +608,7 @@ build_upstream_values() {
         done >"$out_file.fileparams" || exit $?
         while IFS="$(printf '\t')" read -r key path; do
             [ -n "$key" ] || continue
+            ascii_check "FILE_PARAMS parameter '$key' (file $path)" "$(cat "$path")"
             merged=$(
                 jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
                     $m + {($key): $val}
@@ -551,6 +627,8 @@ build_upstream_values() {
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
                 fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
+            ascii_check "PARAMS parameter name '$key'" "$key"
+            ascii_check "value for parameter '$key' (from PARAMS / a driver environment variable)" "$val"
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
         merged=$(
@@ -616,6 +694,11 @@ main() {
         usage >&2
         fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
+
+    ascii_check "STACK_NAME" "$stack_name"
+    ascii_check "TEMPLATE_URL" "$template_url"
+    ascii_check "REGION" "$region"
+    ascii_check "DEPLOYER_ROLE_ARN" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     existing_status=$(aws cloudformation describe-stacks \

--- a/scripts/deploy-lakerunner-infra-rds.sh
+++ b/scripts/deploy-lakerunner-infra-rds.sh
@@ -192,6 +192,10 @@ Optional:
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
+All PARAMS values and FILE_PARAMS file contents must be plain ASCII; smart
+quotes, no-break spaces, and similar pasted characters are rejected with a
+message naming the offending character and its position.
+
 Exit codes:
   0  success or no-op
   1  generic / AWS / change set failure
@@ -208,6 +212,77 @@ fail() {
     shift
     printf '[deploy-stack] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (PARAMS entries
+# composed from the driver's environment variables, FILE_PARAMS file contents)
+# must be plain ASCII: smart quotes, no-break spaces, and other typographic
+# characters -- usually introduced by pasting from a word processor, browser,
+# or chat tool -- ride silently into the CloudFormation parameter JSON and
+# surface much later as inscrutable template or service errors.  Reject them
+# up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -433,6 +508,7 @@ build_upstream_values() {
         done >"$out_file.fileparams" || exit $?
         while IFS="$(printf '\t')" read -r key path; do
             [ -n "$key" ] || continue
+            ascii_check "FILE_PARAMS parameter '$key' (file $path)" "$(cat "$path")"
             merged=$(
                 jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
                     $m + {($key): $val}
@@ -451,6 +527,8 @@ build_upstream_values() {
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
                 fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
+            ascii_check "PARAMS parameter name '$key'" "$key"
+            ascii_check "value for parameter '$key' (from PARAMS / a driver environment variable)" "$val"
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
         merged=$(
@@ -516,6 +594,11 @@ main() {
         usage >&2
         fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
+
+    ascii_check "STACK_NAME" "$stack_name"
+    ascii_check "TEMPLATE_URL" "$template_url"
+    ascii_check "REGION" "$region"
+    ascii_check "DEPLOYER_ROLE_ARN" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     existing_status=$(aws cloudformation describe-stacks \

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -535,6 +535,10 @@ Optional:
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
+All PARAMS values and FILE_PARAMS file contents must be plain ASCII; smart
+quotes, no-break spaces, and similar pasted characters are rejected with a
+message naming the offending character and its position.
+
 Exit codes:
   0  success or no-op
   1  generic / AWS / change set failure
@@ -551,6 +555,77 @@ fail() {
     shift
     printf '[deploy-stack] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (PARAMS entries
+# composed from the driver's environment variables, FILE_PARAMS file contents)
+# must be plain ASCII: smart quotes, no-break spaces, and other typographic
+# characters -- usually introduced by pasting from a word processor, browser,
+# or chat tool -- ride silently into the CloudFormation parameter JSON and
+# surface much later as inscrutable template or service errors.  Reject them
+# up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -776,6 +851,7 @@ build_upstream_values() {
         done >"$out_file.fileparams" || exit $?
         while IFS="$(printf '\t')" read -r key path; do
             [ -n "$key" ] || continue
+            ascii_check "FILE_PARAMS parameter '$key' (file $path)" "$(cat "$path")"
             merged=$(
                 jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
                     $m + {($key): $val}
@@ -794,6 +870,8 @@ build_upstream_values() {
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
                 fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
+            ascii_check "PARAMS parameter name '$key'" "$key"
+            ascii_check "value for parameter '$key' (from PARAMS / a driver environment variable)" "$val"
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
         merged=$(
@@ -859,6 +937,11 @@ main() {
         usage >&2
         fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
+
+    ascii_check "STACK_NAME" "$stack_name"
+    ascii_check "TEMPLATE_URL" "$template_url"
+    ascii_check "REGION" "$region"
+    ascii_check "DEPLOYER_ROLE_ARN" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     existing_status=$(aws cloudformation describe-stacks \

--- a/scripts/deploy-lakerunner.sh
+++ b/scripts/deploy-lakerunner.sh
@@ -46,6 +46,8 @@ internal_resolve_create_params=""
 internal_resolve_create_params_arg2=""
 internal_classify_status=""
 internal_classify_reason=""
+internal_ascii_check_label=""
+internal_ascii_check_file=""
 
 # State held across stages so the abort handler can clean up.
 change_set_name=""
@@ -94,6 +96,76 @@ fail() {
     shift
     printf '[deploy-lakerunner] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (flag values and
+# input-file contents) must be plain ASCII: smart quotes, no-break spaces, and
+# other typographic characters -- usually introduced by pasting from a word
+# processor, browser, or chat tool -- ride silently into the CloudFormation
+# parameter JSON and surface much later as inscrutable template or service
+# errors.  Reject them up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -335,6 +407,11 @@ parse_args() {
                 internal_classify_reason="$3"
                 shift 3
                 ;;
+            --internal-ascii-check)
+                internal_ascii_check_label="$2"
+                internal_ascii_check_file="$3"
+                shift 3
+                ;;
             -h|--help) usage; exit 0 ;;
             *) fail 2 "unknown argument: $1" ;;
         esac
@@ -364,6 +441,17 @@ build_create_overrides() {
     cert_body=$(read_file_or_empty "$cli_certificate_body_file")
     cert_pkey=$(read_file_or_empty "$cli_certificate_private_key_file")
     cert_chain=$(read_file_or_empty "$cli_certificate_chain_file")
+
+    ascii_check "--vpc-id" "$cli_vpc_id"
+    ascii_check "--private-subnets" "$cli_private_subnets"
+    ascii_check "--certificate-arn" "$cli_certificate_arn"
+    ascii_check "--dex-admin-email" "$cli_dex_admin_email"
+    ascii_check "--dex-admin-password-hash" "$cli_dex_admin_password_hash"
+    ascii_check "--oidc-superadmin-emails" "$cli_oidc_superadmin_emails"
+    ascii_check "license data file ($cli_license_data_file)" "$license_data"
+    ascii_check "certificate body file ($cli_certificate_body_file)" "$cert_body"
+    ascii_check "certificate private key file ($cli_certificate_private_key_file)" "$cert_pkey"
+    ascii_check "certificate chain file ($cli_certificate_chain_file)" "$cert_chain"
 
     jq -n \
         --arg vpc_id "$cli_vpc_id" \
@@ -421,6 +509,13 @@ main() {
         classify_status "$internal_classify_status" "$internal_classify_reason"
         return 0
     fi
+    if [ -n "$internal_ascii_check_file" ]; then
+        if [ ! -r "$internal_ascii_check_file" ]; then
+            fail 2 "cannot read file: $internal_ascii_check_file"
+        fi
+        ascii_check "$internal_ascii_check_label" "$(cat "$internal_ascii_check_file")"
+        return 0
+    fi
 
     preflight
 
@@ -428,6 +523,12 @@ main() {
         usage >&2
         fail 2 "--stack-name, --region, and --version are required"
     fi
+
+    ascii_check "--stack-name" "$stack_name"
+    ascii_check "--region" "$region"
+    ascii_check "--version" "$version"
+    ascii_check "--template-base-url" "$template_base_url"
+    ascii_check "--deployer-role-arn" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     # REVIEW_IN_PROGRESS and ROLLBACK_COMPLETE both indicate a stack record

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -207,6 +207,10 @@ Optional:
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
+All PARAMS values and FILE_PARAMS file contents must be plain ASCII; smart
+quotes, no-break spaces, and similar pasted characters are rejected with a
+message naming the offending character and its position.
+
 Exit codes:
   0  success or no-op
   1  generic / AWS / change set failure
@@ -223,6 +227,77 @@ fail() {
     shift
     printf '[deploy-stack] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (PARAMS entries
+# composed from the driver's environment variables, FILE_PARAMS file contents)
+# must be plain ASCII: smart quotes, no-break spaces, and other typographic
+# characters -- usually introduced by pasting from a word processor, browser,
+# or chat tool -- ride silently into the CloudFormation parameter JSON and
+# surface much later as inscrutable template or service errors.  Reject them
+# up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -448,6 +523,7 @@ build_upstream_values() {
         done >"$out_file.fileparams" || exit $?
         while IFS="$(printf '\t')" read -r key path; do
             [ -n "$key" ] || continue
+            ascii_check "FILE_PARAMS parameter '$key' (file $path)" "$(cat "$path")"
             merged=$(
                 jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
                     $m + {($key): $val}
@@ -466,6 +542,8 @@ build_upstream_values() {
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
                 fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
+            ascii_check "PARAMS parameter name '$key'" "$key"
+            ascii_check "value for parameter '$key' (from PARAMS / a driver environment variable)" "$val"
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
         merged=$(
@@ -531,6 +609,11 @@ main() {
         usage >&2
         fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
+
+    ascii_check "STACK_NAME" "$stack_name"
+    ascii_check "TEMPLATE_URL" "$template_url"
+    ascii_check "REGION" "$region"
+    ascii_check "DEPLOYER_ROLE_ARN" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     existing_status=$(aws cloudformation describe-stacks \

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -313,6 +313,10 @@ Optional:
   DEPLOYER_ROLE_ARN   Passed via --role-arn to create-change-set.
   NO_EXECUTE          Non-empty: create and describe the change set, then stop.
 
+All PARAMS values and FILE_PARAMS file contents must be plain ASCII; smart
+quotes, no-break spaces, and similar pasted characters are rejected with a
+message naming the offending character and its position.
+
 Exit codes:
   0  success or no-op
   1  generic / AWS / change set failure
@@ -329,6 +333,77 @@ fail() {
     shift
     printf '[deploy-stack] ERROR: %s\n' "$*" >&2
     exit "$code"
+}
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation.  Every operator-supplied value (PARAMS entries
+# composed from the driver's environment variables, FILE_PARAMS file contents)
+# must be plain ASCII: smart quotes, no-break spaces, and other typographic
+# characters -- usually introduced by pasting from a word processor, browser,
+# or chat tool -- ride silently into the CloudFormation parameter JSON and
+# surface much later as inscrutable template or service errors.  Reject them
+# up front, naming the exact character and where it sits.
+# Allowed bytes: printable ASCII 0x20-0x7E plus tab, newline, carriage return.
+# ---------------------------------------------------------------------------
+
+# Print a description of the first disallowed byte in "$1" (one line of text),
+# e.g.:  byte 12: left double curly quote (U+201C) -- use a plain " instead
+ascii_describe_line() {
+    _adl_hex=$(printf '%s' "$1" | od -An -v -tx1 | tr -d ' \n')
+    _adl_pos=1
+    while [ -n "$_adl_hex" ]; do
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            7f) break ;;
+            09|0d|2?|3?|4?|5?|6?|7?) ;;
+            *) break ;;
+        esac
+        _adl_hex=${_adl_hex#??}
+        _adl_pos=$((_adl_pos + 1))
+    done
+    _adl_desc=""
+    case "$_adl_hex" in
+        e28098*) _adl_desc="left single curly quote (U+2018) -- use a plain apostrophe (')" ;;
+        e28099*) _adl_desc="right single curly quote (U+2019) -- use a plain apostrophe (')" ;;
+        e2809c*) _adl_desc='left double curly quote (U+201C) -- use a plain double quote (")' ;;
+        e2809d*) _adl_desc='right double curly quote (U+201D) -- use a plain double quote (")' ;;
+        e28093*) _adl_desc='en dash (U+2013) -- use a plain hyphen (-)' ;;
+        e28094*) _adl_desc='em dash (U+2014) -- use a plain hyphen (-)' ;;
+        e2808b*) _adl_desc='zero-width space (U+200B) -- invisible; delete it' ;;
+        e2808?*) _adl_desc='typographic space or invisible formatting character (U+2000-U+200F) -- use a plain space or delete it' ;;
+        e280a8*|e280a9*) _adl_desc='Unicode line/paragraph separator (U+2028/U+2029) -- use a plain newline' ;;
+        e280af*) _adl_desc='narrow no-break space (U+202F) -- looks like a space but is not; use a plain space' ;;
+        efbbbf*) _adl_desc='UTF-8 byte order mark (U+FEFF) -- invisible; remove it (often at the very start of a file)' ;;
+        c2a0*) _adl_desc='no-break space (U+00A0) -- looks like a space but is not; use a plain space' ;;
+        c2ad*) _adl_desc='soft hyphen (U+00AD) -- invisible; delete it' ;;
+    esac
+    if [ -z "$_adl_desc" ]; then
+        _adl_byte=$(printf '%.2s' "$_adl_hex")
+        case "$_adl_byte" in
+            0?|1?|7f) _adl_desc="control character (byte 0x$_adl_byte)" ;;
+            *) _adl_desc="non-ASCII character (UTF-8 bytes 0x$(printf '%.6s' "$_adl_hex"))" ;;
+        esac
+    fi
+    printf 'byte %d: %s' "$_adl_pos" "$_adl_desc"
+}
+
+# ascii_check LABEL TEXT -- fail (exit 2) when TEXT contains anything other
+# than printable ASCII, tab, newline, or carriage return.  The error names
+# the first offending character and its line/byte position.
+ascii_check() {
+    _ac_label="$1"
+    _ac_text="$2"
+    [ -n "$_ac_text" ] || return 0
+    [ -n "$(printf '%s' "$_ac_text" | LC_ALL=C tr -d '\11\12\15\40-\176')" ] || return 0
+    _ac_lineno=0
+    while IFS= read -r _ac_line; do
+        _ac_lineno=$((_ac_lineno + 1))
+        [ -n "$(printf '%s' "$_ac_line" | LC_ALL=C tr -d '\11\15\40-\176')" ] || continue
+        fail 2 "$_ac_label is not plain ASCII: line $_ac_lineno, $(ascii_describe_line "$_ac_line").  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters."
+    done <<ASCII_CHECK_EOF
+$_ac_text
+ASCII_CHECK_EOF
+    fail 2 "$_ac_label is not plain ASCII (contains a disallowed control or non-ASCII byte)"
 }
 
 # ---------------------------------------------------------------------------
@@ -554,6 +629,7 @@ build_upstream_values() {
         done >"$out_file.fileparams" || exit $?
         while IFS="$(printf '\t')" read -r key path; do
             [ -n "$key" ] || continue
+            ascii_check "FILE_PARAMS parameter '$key' (file $path)" "$(cat "$path")"
             merged=$(
                 jq -nc --argjson m "$merged" --arg key "$key" --rawfile val "$path" '
                     $m + {($key): $val}
@@ -572,6 +648,8 @@ build_upstream_values() {
             if [ "$key" = "$entry" ] || [ -z "$key" ]; then
                 fail 2 "PARAMS expects Key=Value, got: $entry"
             fi
+            ascii_check "PARAMS parameter name '$key'" "$key"
+            ascii_check "value for parameter '$key' (from PARAMS / a driver environment variable)" "$val"
             printf '%s\t%s\n' "$key" "$val"
         done >"$out_file.params"
         merged=$(
@@ -637,6 +715,11 @@ main() {
         usage >&2
         fail 2 "missing required: $(echo "$missing_required" | sed 's/^ //; s/ /, /g')"
     fi
+
+    ascii_check "STACK_NAME" "$stack_name"
+    ascii_check "TEMPLATE_URL" "$template_url"
+    ascii_check "REGION" "$region"
+    ascii_check "DEPLOYER_ROLE_ARN" "$deployer_role_arn"
 
     log "checking whether stack $stack_name exists in $region"
     existing_status=$(aws cloudformation describe-stacks \

--- a/tests/unit/test_deploy_lakerunner.py
+++ b/tests/unit/test_deploy_lakerunner.py
@@ -476,3 +476,46 @@ def test_create_full_install_mix(tmp_path):
     )
     assert out["LicenseData"]["ParameterValue"] == '{"customer":"acme"}'
     assert out["TemplateBaseUrl"]["ParameterValue"].startswith("https://my-mirror.example.com")
+
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation: operator-supplied values and file contents must
+# be plain ASCII; smart quotes / no-break spaces (typically pasted from a word
+# processor or chat tool) are rejected with a message naming the character.
+# Exercised via the --internal-ascii-check <label> <file> hook.
+# ---------------------------------------------------------------------------
+
+
+def _run_ascii_check(label, path):
+    return subprocess.run(
+        ["sh", str(SCRIPT), "--internal-ascii-check", label, str(path)],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_ascii_check_rejects_smart_quotes_with_description(tmp_path):
+    f = tmp_path / "license.json"
+    f.write_text('{\u201ccustomer\u201d: \u201cacme\u201d}', encoding="utf-8")
+    result = _run_ascii_check("license data", f)
+    assert result.returncode == 2, result.stderr
+    assert "license data" in result.stderr
+    assert "U+201C" in result.stderr
+    assert "curly quote" in result.stderr
+
+
+def test_ascii_check_rejects_no_break_space_with_location(tmp_path):
+    f = tmp_path / "users.json"
+    f.write_text('[\n {"email":\u00a0"a@b.c"}\n]\n', encoding="utf-8")
+    result = _run_ascii_check("dex users", f)
+    assert result.returncode == 2, result.stderr
+    assert "U+00A0" in result.stderr
+    assert "no-break space" in result.stderr
+    assert "line 2" in result.stderr
+
+
+def test_ascii_check_accepts_plain_ascii(tmp_path):
+    f = tmp_path / "clean.json"
+    f.write_text('[{"email": "a@b.c", "hash": "$2y$10$abc./DEF"}]\n')
+    result = _run_ascii_check("dex users", f)
+    assert result.returncode == 0, result.stderr

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -447,3 +447,53 @@ def test_params_wins_over_file_params_for_same_key(tmp_path):
     assert merged["CertificateBody"] == "literal-wins", (
         "PARAMS should win over FILE_PARAMS for the same key"
     )
+
+
+# ---------------------------------------------------------------------------
+# ASCII-only input validation: PARAMS values (composed from the drivers'
+# environment variables) and FILE_PARAMS file contents must be plain ASCII;
+# smart quotes / no-break spaces (typically pasted from a word processor or
+# chat tool) are rejected with a message naming the character and its position.
+# ---------------------------------------------------------------------------
+
+
+def test_params_smart_quote_rejected_with_description():
+    result = _build_upstream(
+        {"PARAMS": 'DexExtraUsers=[{\u201cemail\u201d: \u201cx@y.z\u201d}]'}
+    )
+    assert result.returncode == 2, (
+        f"expected exit 2 for a smart quote in a PARAMS value, got "
+        f"{result.returncode}:\n{result.stdout}\n{result.stderr}"
+    )
+    assert "DexExtraUsers" in result.stderr
+    assert "U+201C" in result.stderr
+    assert "curly quote" in result.stderr
+
+
+def test_params_no_break_space_rejected_with_description():
+    result = _build_upstream({"PARAMS": "VpcId=vpc-123\u00a0extra"})
+    assert result.returncode == 2, result.stderr
+    assert "VpcId" in result.stderr
+    assert "U+00A0" in result.stderr
+    assert "no-break space" in result.stderr
+
+
+def test_file_params_non_ascii_content_rejected_with_location(tmp_path):
+    users = tmp_path / "users.json"
+    users.write_text(
+        '[\n {"email": "a@b.c"},\n {"hash": "\u2019bad"}\n]\n', encoding="utf-8"
+    )
+    result = _build_upstream({"FILE_PARAMS": f"DexExtraUsers={users}"})
+    assert result.returncode == 2, result.stderr
+    assert "DexExtraUsers" in result.stderr
+    assert "U+2019" in result.stderr
+    assert "line 3" in result.stderr
+
+
+def test_params_plain_ascii_accepted():
+    result = _build_upstream(
+        {"PARAMS": 'A=plain ascii: punctuation! ($2y$10$hash./val) -- ok'}
+    )
+    assert result.returncode == 0, result.stderr
+    merged = json.loads(result.stdout)
+    assert merged["A"] == 'plain ascii: punctuation! ($2y$10$hash./val) -- ok'


### PR DESCRIPTION
## Summary

Operator-supplied values containing smart quotes, no-break spaces, or other non-ASCII / control characters (typically pasted from a word processor, browser, or chat tool) used to ride silently into the CloudFormation parameter JSON and fail much later with inscrutable template or service errors -- e.g. a DEX users JSON with curly quotes rejected by the stack.

All deploy drivers now validate every operator input up front and fail fast (exit 2) with a message naming the parameter, the offending character, its line/byte position, and the plain-ASCII replacement to use:

```
[deploy-stack] ERROR: FILE_PARAMS parameter 'DexExtraUsers' (file /tmp/users.json) is not plain ASCII: line 3, byte 12: right single curly quote (U+2019) -- use a plain apostrophe (').  Curly quotes, odd spaces, and similar characters usually come from pasting text out of a word processor, browser, or chat tool; retype the value using plain ASCII characters.
```

## Details

- `scripts-src/parts/base.sh` (the engine embedded in all five chained drivers) gains `ascii_check`: allowed bytes are printable ASCII 0x20-0x7E plus tab/newline/CR. It runs on every PARAMS key and value, every FILE_PARAMS file's contents, and STACK_NAME / TEMPLATE_URL / REGION / DEPLOYER_ROLE_ARN -- the choke point all driver env vars and input files flow through, before any change set is created.
- Common offenders get named descriptions (curly quotes U+2018/9/U+201C/D, en/em dash, no-break space U+00A0, narrow NBSP U+202F, zero-width space, BOM, soft hyphen, line/paragraph separators); anything else reports its raw bytes.
- `scripts/deploy-lakerunner.sh` (standalone root-stack driver) gets the same helpers, applied to its flag values and input files (license, cert PEMs), plus an `--internal-ascii-check` test hook.
- Generated drivers regenerated via `make scripts`.
- Tests: engine-level via the existing `--internal-build-upstream` hook (smart quote in PARAMS, NBSP in PARAMS, curly quote on line 3 of a FILE_PARAMS file, plain-ASCII accepted) and deploy-lakerunner.sh via the new hook.
- CHANGELOG entry for v1.1.4.

## Test plan

- `make test` (511 passed)
- shellcheck clean on all drivers and the engine part