### PR TITLE
services-process: set LAKERUNNER_LOG_TRACKED_FIELDS on process-logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.1.6
+
+- **process-logs now sets `LAKERUNNER_LOG_TRACKED_FIELDS`.** The process-logs
+  task hardcodes the tracked-field set
+  `service_name,environment_type,installation,proc_name,partition_id` — the log
+  fields whose distinct values are rolled up into the fast tag-value lookup
+  table at ingest, overriding lakerunner's compiled-in default
+  (`k8s_cluster_name,k8s_namespace_name,service_name`). Requires a lakerunner
+  image that honors this env var. No new parameters; on redeploy the
+  process-logs task definition revises and the service rolls. Temporary until
+  tracked fields get a Maestro UI; per-org admin-API config still overrides it.
+
 ## v1.1.5
 
 - **Image bumps: lakerunner `v1.41.6` -> `v1.51.1`, maestro `v1.53.1` ->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ v0.0.114.
 
 ## v1.1.6
 
+- **Image bump: lakerunner `v1.51.1` -> `v1.51.3`.** Default `LakerunnerImage`
+  bump (digest-pinned multi-arch manifest); this is the version that honors
+  `LAKERUNNER_LOG_TRACKED_FIELDS` (below). On redeploy the DB migrator reruns
+  (idempotent) before the service-tier stacks update. No new parameters or
+  resource replacements; upgrade action is none if you use the defaults. If you
+  pin `LakerunnerImage` via a parameter, set it to the new version explicitly.
 - **process-logs now sets `LAKERUNNER_LOG_TRACKED_FIELDS`.** The process-logs
   task hardcodes the tracked-field set
   `service_name,environment_type,installation,proc_name,partition_id` — the log

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,7 +33,7 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.51.1@sha256:4035270bcab86b14492c442ef6f9cf6bd2a76cd3e577bdd01d8aea89f84fcc82"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.51.3@sha256:973513c22a88b534eb5ba122f2c4028b3bd0704716dbb0a28ddcf0cf8b799232"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.60.3@sha256:c974dfaa6becfac0b4b9a87f1997d78f9db5519d527ebea0cd1383efa9f05e49"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.51.1@sha256:4035270bcab86b14492c442ef6f9cf6bd2a76cd3e577bdd01d8aea89f84fcc82"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.51.3@sha256:973513c22a88b534eb5ba122f2c4028b3bd0704716dbb0a28ddcf0cf8b799232"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.60.3@sha256:c974dfaa6becfac0b4b9a87f1997d78f9db5519d527ebea0cd1383efa9f05e49"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -406,6 +406,17 @@ def build() -> Template:
             "memory_mib": Ref("ProcessLogsMemory"),
             "desired_count": _min_replicas(logs_cfg),
             "output_name": "ProcessLogsServiceName",
+            # Temporary hack until tracked fields get a Maestro UI: override the
+            # default set of log fields rolled up into the log_field_values fast
+            # tag-value lookup table at ingest. process-logs is the only task
+            # that reads this (the lone GetLogTrackedFields caller is the
+            # log-ingest worklane). Per-org admin-API config still wins.
+            "extra_env": [
+                Environment(
+                    Name="LAKERUNNER_LOG_TRACKED_FIELDS",
+                    Value="service_name,environment_type,installation,proc_name,partition_id",
+                ),
+            ],
         },
         {
             "service_key": "process-metrics",

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -400,6 +400,30 @@ def test_process_services_have_no_autoregister_env(td):
 
 
 # ---------------------------------------------------------------------------
+# log tracked-fields override (temporary, until a Maestro UI exists)
+# ---------------------------------------------------------------------------
+
+
+def test_process_logs_sets_tracked_fields_env(td):
+    """process-logs carries the explicit tracked-fields override consumed by
+    the log-ingest worklane (the lone GetLogTrackedFields caller)."""
+    env = _env(td, "ProcessLogsTaskDef")
+    assert env.get("LAKERUNNER_LOG_TRACKED_FIELDS") == (
+        "service_name,environment_type,installation,proc_name,partition_id"
+    ), env.get("LAKERUNNER_LOG_TRACKED_FIELDS")
+
+
+def test_other_process_services_have_no_tracked_fields_env(td):
+    """Only process-logs reads tracked fields; metrics/traces/pubsub must not
+    carry the override."""
+    for task_def_id in ("ProcessMetricsTaskDef", "ProcessTracesTaskDef", "PubsubSqsTaskDef"):
+        env = _env(td, task_def_id)
+        assert "LAKERUNNER_LOG_TRACKED_FIELDS" not in env, (
+            f"{task_def_id} unexpectedly has LAKERUNNER_LOG_TRACKED_FIELDS"
+        )
+
+
+# ---------------------------------------------------------------------------
 # B → C boundary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Sets `LAKERUNNER_LOG_TRACKED_FIELDS=service_name,environment_type,installation,proc_name,partition_id` on the **process-logs** ECS task.

These are the log fields whose distinct values lakerunner rolls up into the `log_field_values` fast tag-value lookup table at ingest. The new env var overrides lakerunner's compiled-in default (`k8s_cluster_name,k8s_namespace_name,service_name`).

## Why on process-logs only

The only caller of `GetLogTrackedFields` in lakerunner is the log-ingest worklane, which runs in the process-logs worker. process-metrics, process-traces, and pubsub-sqs never resolve tracked fields, and the query side just reads the rollup table. So the override belongs on process-logs alone.

## Requires

The lakerunner-side env var: cardinalhq/lakerunner#939. Until an image that honors `LAKERUNNER_LOG_TRACKED_FIELDS` is the default `LakerunnerImage`, this env var is inert (harmless).

## Temporary

This is a deliberate hardcoded hack until tracked fields get a proper Maestro UI. Per-org config set through the admin API still takes precedence over this default.

## Tests / docs

- `test_services_process.py`: asserts process-logs carries the exact override and that metrics/traces/pubsub do not.
- `CHANGELOG.md`: v1.1.6 entry (operator-facing; on redeploy the process-logs task definition revises and the service rolls; no new parameters).
- `make check` green (513 passed); `make build` + cfn-lint clean.