### PR TITLE
Bump process-logs memory to 4G; lakerunner v1.51.5, maestro v1.62.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.1.7
+
+- **process-logs memory default `2048` -> `4096` MiB.** `ProcessLogsMemory`
+  default doubled (still 1 vCPU; 4096 MiB is a valid Fargate combo). On redeploy
+  the process-logs task definition revises and the service rolls; each
+  process-logs task now reserves 4 GiB. If you pin `ProcessLogsMemory` via a
+  parameter, it is unchanged. Note the autoscaler ceiling is unchanged
+  (`ProcessLogsReplicas`, default 10), so peak reservation rises accordingly.
+- **Image bumps: lakerunner `v1.51.3` -> `v1.51.5`, maestro `v1.60.3` ->
+  `v1.62.4`.** Default `LakerunnerImage` and `MaestroImage` bumps (digest-pinned
+  multi-arch manifests). On redeploy the DB migrator reruns (idempotent) before
+  the service-tier stacks update. No new parameters or resource replacements;
+  upgrade action is none if you use the defaults. If you pin the images via
+  parameters, set them to the new versions explicitly.
+
 ## v1.1.6
 
 - **Image bump: lakerunner `v1.51.1` -> `v1.51.3`.** Default `LakerunnerImage`

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.51.3@sha256:973513c22a88b534eb5ba122f2c4028b3bd0704716dbb0a28ddcf0cf8b799232"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.60.3@sha256:c974dfaa6becfac0b4b9a87f1997d78f9db5519d527ebea0cd1383efa9f05e49"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.51.5@sha256:80f1dcb8f3a06463402fa110c42d6b2149c77faffcf8748093ce95e1dde9a460"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.62.4@sha256:4c7dd3522d12d6210083306f40d556788137fba92930299a5b5f7afcba89962e"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
@@ -63,7 +63,7 @@ services:
     signal_type: logs
     command: ["/app/bin/lakerunner", "process-logs"]
     cpu: 1024
-    memory_mib: 2048
+    memory_mib: 4096
     autoscaling:
       min_replicas: 1
       max_replicas: 10

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,8 +31,8 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.51.3@sha256:973513c22a88b534eb5ba122f2c4028b3bd0704716dbb0a28ddcf0cf8b799232"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.60.3@sha256:c974dfaa6becfac0b4b9a87f1997d78f9db5519d527ebea0cd1383efa9f05e49"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.51.5@sha256:80f1dcb8f3a06463402fa110c42d6b2149c77faffcf8748093ce95e1dde9a460"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.62.4@sha256:4c7dd3522d12d6210083306f40d556788137fba92930299a5b5f7afcba89962e"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
Targeted for the **v1.1.7** release (held — bundling with one further change before tagging; no release/redeploy from this PR).

## Changes

- **process-logs memory `2048` -> `4096` MiB.** `ProcessLogsMemory` default doubled in `cardinal-defaults.yaml` (CPU unchanged at 1024; 4096 MiB is a valid Fargate combo at 1 vCPU). Each process-logs ingest task now reserves 4 GiB.
- **lakerunner `v1.51.3` -> `v1.51.5`** (digest-pinned multi-arch manifest).
- **maestro `v1.60.3` -> `v1.62.4`** (digest-pinned multi-arch manifest).

Drivers regenerated via `make scripts` (image suffixes flow from `cardinal-defaults.yaml`). Changelog `v1.1.7` section added.

## Verification

- `make build` + cfn-lint clean; `make check` green (513 passed).
- Generated `services-process.yaml`: `ProcessLogsMemory` default `4096`, `LakerunnerImage` default `v1.51.5`.
- Generated `maestro.yaml`: `MaestroImage` default `v1.62.4`.
- Generated `scripts/deploy-lakerunner-services.sh`: new lakerunner + maestro image suffixes.

## Operator impact (for the changelog when released)

On redeploy: process-logs task def revises and rolls (now 4 GiB/task; autoscaler ceiling `ProcessLogsReplicas`=10 unchanged, so peak reservation rises). Image bumps rerun the idempotent DB migrator before the service tier updates. No new parameters, no resource replacements.