### PR TITLE
services driver: PROCESS_{LOGS,METRICS,TRACES}_MEMORY env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.1.8
+
+- **`deploy-lakerunner-services.sh` gains `PROCESS_LOGS_MEMORY` /
+  `PROCESS_METRICS_MEMORY` / `PROCESS_TRACES_MEMORY`.** Optional env vars that
+  set the Fargate task memory (MiB) for the process-{logs,metrics,traces}
+  services. Each must be a valid Fargate CPU/memory combo (at 1 vCPU:
+  2048-8192). Passed to the stack only when set, so an existing install's value
+  carries forward on update unless you override it -- note this means a bumped
+  template default (e.g. the v1.1.7 process-logs 4096) does NOT reach an existing
+  install through a plain upgrade; set the matching env var on the services
+  driver to apply a new size in place. No upgrade action if you are happy with
+  your current sizing.
+
 ## v1.1.7
 
 - **process-logs memory default `2048` -> `4096` MiB.** `ProcessLogsMemory`

--- a/scripts-src/parts/deploy-lakerunner-services.sh
+++ b/scripts-src/parts/deploy-lakerunner-services.sh
@@ -118,6 +118,17 @@ Optional (template defaults preserved when unset):
                               output).  Maestro/Dex OIDC issuer and redirect
                               URLs are derived from it, so the certificate must
                               match it.  Unset: the raw ALB DNS name is used.
+  PROCESS_LOGS_MEMORY         Fargate task memory (MiB) for process-logs
+                              (template default 4096).  Must be a valid Fargate
+                              CPU/memory combo (at 1 vCPU: 2048-8192).  Unset
+                              keeps the stack's current value on update (template
+                              default on create) -- set it to apply a new size.
+  PROCESS_METRICS_MEMORY      Fargate task memory (MiB) for process-metrics
+                              (template default 2048).  Same combo rules; unset
+                              keeps the current value.
+  PROCESS_TRACES_MEMORY       Fargate task memory (MiB) for process-traces
+                              (template default 2048).  Same combo rules; unset
+                              keeps the current value.
   DB_INIT_IMAGE               Full image URI override for the db-init image
                               (official postgres psql client). Bypasses
                               IMAGE_REGISTRY. Default: the baked, pinned suffix
@@ -257,6 +268,18 @@ ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 PublicDnsName=$PUBLIC_DNS_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
+
+# Process-tier Fargate memory (MiB). Passed only when explicitly set, so an
+# existing install's value carries forward on update unless the operator
+# overrides it (like the images above, a bumped template default is otherwise
+# never picked up on update -- but unlike the images we do NOT force these, to
+# avoid clobbering an operator's deliberate sizing).
+[ -n "${PROCESS_LOGS_MEMORY:-}" ] && params="$params
+ProcessLogsMemory=$PROCESS_LOGS_MEMORY"
+[ -n "${PROCESS_METRICS_MEMORY:-}" ] && params="$params
+ProcessMetricsMemory=$PROCESS_METRICS_MEMORY"
+[ -n "${PROCESS_TRACES_MEMORY:-}" ] && params="$params
+ProcessTracesMemory=$PROCESS_TRACES_MEMORY"
 
 # Public-ECR images: composed from IMAGE_REGISTRY + the baked, locked suffixes,
 # always passed as literal params so a redeploy carries the pinned defaults

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -119,6 +119,17 @@ Optional (template defaults preserved when unset):
                               output).  Maestro/Dex OIDC issuer and redirect
                               URLs are derived from it, so the certificate must
                               match it.  Unset: the raw ALB DNS name is used.
+  PROCESS_LOGS_MEMORY         Fargate task memory (MiB) for process-logs
+                              (template default 4096).  Must be a valid Fargate
+                              CPU/memory combo (at 1 vCPU: 2048-8192).  Unset
+                              keeps the stack's current value on update (template
+                              default on create) -- set it to apply a new size.
+  PROCESS_METRICS_MEMORY      Fargate task memory (MiB) for process-metrics
+                              (template default 2048).  Same combo rules; unset
+                              keeps the current value.
+  PROCESS_TRACES_MEMORY       Fargate task memory (MiB) for process-traces
+                              (template default 2048).  Same combo rules; unset
+                              keeps the current value.
   DB_INIT_IMAGE               Full image URI override for the db-init image
                               (official postgres psql client). Bypasses
                               IMAGE_REGISTRY. Default: the baked, pinned suffix
@@ -258,6 +269,18 @@ ServiceNamespaceName=$SERVICE_NAMESPACE_NAME"
 PublicDnsName=$PUBLIC_DNS_NAME"
 [ -n "$self_telemetry_endpoint" ] && params="$params
 SelfTelemetryEndpoint=$self_telemetry_endpoint"
+
+# Process-tier Fargate memory (MiB). Passed only when explicitly set, so an
+# existing install's value carries forward on update unless the operator
+# overrides it (like the images above, a bumped template default is otherwise
+# never picked up on update -- but unlike the images we do NOT force these, to
+# avoid clobbering an operator's deliberate sizing).
+[ -n "${PROCESS_LOGS_MEMORY:-}" ] && params="$params
+ProcessLogsMemory=$PROCESS_LOGS_MEMORY"
+[ -n "${PROCESS_METRICS_MEMORY:-}" ] && params="$params
+ProcessMetricsMemory=$PROCESS_METRICS_MEMORY"
+[ -n "${PROCESS_TRACES_MEMORY:-}" ] && params="$params
+ProcessTracesMemory=$PROCESS_TRACES_MEMORY"
 
 # Public-ECR images: composed from IMAGE_REGISTRY + the baked, locked suffixes,
 # always passed as literal params so a redeploy carries the pinned defaults


### PR DESCRIPTION
Targeted for **v1.1.8**.

## Why

In-place upgrades carry forward existing stack parameter values (`UsePreviousValue`); only params the driver passes explicitly (the images) refresh to new defaults. So when v1.1.7 bumped the `ProcessLogsMemory` default 2048 -> 4096, an existing install upgraded via `deploy-lakerunner-services.sh` stays at 2048 — there was no lever to apply a new process-tier memory size in place.

## What

Adds three optional env vars to `deploy-lakerunner-services.sh`:

- `PROCESS_LOGS_MEMORY`
- `PROCESS_METRICS_MEMORY`
- `PROCESS_TRACES_MEMORY`

Each sets the Fargate task memory (MiB) for the matching process service. They're forwarded to the stack **only when set**, mirroring the existing optional-param pattern (`PUBLIC_SUBNETS`, `ALB_SCHEME`, …). Unset → the stack's current value carries forward on update (template default on create), so we don't clobber an operator's deliberate sizing. Set → the new size applies in place.

This is deliberately *not* forced like the image params: memory is operator-tuned, so a default bump should be opt-in on existing installs, not silent.

## Usage

```sh
STACK_NAME=cardinal-lakerunner-services ... PROCESS_LOGS_MEMORY=4096 \
  scripts/deploy-lakerunner-services.sh
```

Must be a valid Fargate CPU/memory combo (at 1 vCPU: 2048–8192).

## Verification

- `scripts-src/parts/deploy-lakerunner-services.sh` edited (source); `scripts/` regenerated via `make scripts`.
- Generated driver carries the new usage docs + the three `[ -n "${PROCESS_*_MEMORY:-}" ] && params=…` lines.
- `make check` green (513 passed); shellcheck (driver lint tests) clean.
- Changelog `v1.1.8` section added, with the explicit note that a bumped default needs the env var to reach existing installs.