### PR TITLE
bump lakerunner to v1.54.0 (release v1.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.2.0
+
+- **lakerunner image bumped to `v1.54.0`** (from `v1.51.5`). The single
+  `LakerunnerImage` drives every lakerunner task and the DB migrator, so the
+  update redeploys `MigratorService` (reruns the idempotent migrator) before the
+  service tiers roll. No parameter or IAM changes. Upgrade action: deploy v1.2.0;
+  no manual steps.
+
 ## v1.1.9
 
 - **process-{logs,metrics,traces} now autoscale on CPU via native ECS

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,7 +33,7 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.51.5@sha256:80f1dcb8f3a06463402fa110c42d6b2149c77faffcf8748093ce95e1dde9a460"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.54.0@sha256:493ae39c0204cf1dac1fafd18d5221b8532db03ee9d7e57d2142265425b295b7"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.62.4@sha256:4c7dd3522d12d6210083306f40d556788137fba92930299a5b5f7afcba89962e"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.51.5@sha256:80f1dcb8f3a06463402fa110c42d6b2149c77faffcf8748093ce95e1dde9a460"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.54.0@sha256:493ae39c0204cf1dac1fafd18d5221b8532db03ee9d7e57d2142265425b295b7"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.62.4@sha256:4c7dd3522d12d6210083306f40d556788137fba92930299a5b5f7afcba89962e"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"


### PR DESCRIPTION
Bumps the lakerunner image from v1.51.5 to v1.54.0 (digest pinned) and adds the v1.2.0 changelog entry. `make build` re-baked the services driver's pinned default to match. Single LakerunnerImage drives all tasks + the migrator, so the update reruns migrations before the service tiers roll. No parameter/IAM changes.

make build + make test (516 passed) green locally.