### PR TITLE
bump maestro to v1.62.10 (release v1.2.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.2.1
+
+- **maestro image bumped to `v1.62.10`** (from `v1.62.4`). Default `MaestroImage`
+  bump (digest-pinned multi-arch manifest). On redeploy the Maestro service rolls
+  to the new task definition; no parameter, IAM, or resource changes. Upgrade
+  action: deploy v1.2.1; no manual steps.
+
 ## v1.2.0
 
 - **lakerunner image bumped to `v1.54.0`** (from `v1.51.5`). The single

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -34,7 +34,7 @@ storage_profiles:
 # ---------------------------------------------------------------------------
 images:
   lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.54.0@sha256:493ae39c0204cf1dac1fafd18d5221b8532db03ee9d7e57d2142265425b295b7"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.62.4@sha256:4c7dd3522d12d6210083306f40d556788137fba92930299a5b5f7afcba89962e"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.62.10@sha256:d63a430ff1a7f587c4fa2b8996469cff51ad747be69ea6602005c0ec23c16fed"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -32,7 +32,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
 LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.54.0@sha256:493ae39c0204cf1dac1fafd18d5221b8532db03ee9d7e57d2142265425b295b7"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.62.4@sha256:4c7dd3522d12d6210083306f40d556788137fba92930299a5b5f7afcba89962e"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.62.10@sha256:d63a430ff1a7f587c4fa2b8996469cff51ad747be69ea6602005c0ec23c16fed"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
Bumps the maestro image from v1.62.4 to v1.62.10 (digest pinned), adds the v1.2.1 changelog entry. `make build` re-baked the services driver default. Maestro service rolls on redeploy; no parameter/IAM/resource changes. make build + make test (516 passed) green locally.