### PR TITLE
bump lakerunner to v1.57.1; release v1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.2.2
+
+- **lakerunner image bumped to `v1.57.1`** (from `v1.54.0`). The single
+  `LakerunnerImage` drives every lakerunner task and the DB migrator, so the
+  update redeploys `MigratorService` (reruns the idempotent migrator) before the
+  service tiers roll. No parameter or IAM changes. Upgrade action: deploy v1.2.2;
+  no manual steps.
+
 ## v1.2.1
 
 - **maestro image bumped to `v1.62.10`** (from `v1.62.4`). Default `MaestroImage`

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,7 +33,7 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.54.0@sha256:493ae39c0204cf1dac1fafd18d5221b8532db03ee9d7e57d2142265425b295b7"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.57.1@sha256:d09563114a804b62880b592787e184226ed50a3ae134f26f6fb3a49f694cb98b"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.62.10@sha256:d63a430ff1a7f587c4fa2b8996469cff51ad747be69ea6602005c0ec23c16fed"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.54.0@sha256:493ae39c0204cf1dac1fafd18d5221b8532db03ee9d7e57d2142265425b295b7"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.57.1@sha256:d09563114a804b62880b592787e184226ed50a3ae134f26f6fb3a49f694cb98b"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.62.10@sha256:d63a430ff1a7f587c4fa2b8996469cff51ad747be69ea6602005c0ec23c16fed"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"


### PR DESCRIPTION
Bumps the lakerunner image to `v1.57.1` (from `v1.54.0`, digest-pinned multi-arch manifest) and cuts release v1.2.2.

- `cardinal-defaults.yaml`, `scripts/deploy-lakerunner-services.sh`: image suffix updated
- `CHANGELOG.md`: v1.2.2 entry

The single `LakerunnerImage` drives every lakerunner task and the DB migrator, so the update redeploys MigratorService (reruns the idempotent migrator) before the service tiers roll. No parameter or IAM changes.

`make build` (cfn-lint clean) and `make test` (516 passed) green.