### PR TITLE
bump lakerunner to v1.60.0, maestro to v1.66.0; release v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.3.0
+
+- **lakerunner image bumped to `v1.60.0`** (from `v1.57.1`). The single
+  `LakerunnerImage` drives every lakerunner task and the DB migrator, so the
+  update redeploys `MigratorService` (reruns the idempotent migrator) before the
+  service tiers roll. As of this release the `process-{logs,metrics,traces}`
+  workers no longer use DuckDB in-process — the heavy lifting moved to the `lkrn
+  pack` subprocess. This stack never set the old DuckDB tuning env vars
+  (`LAKERUNNER_DUCKDB_MEMORY_LIMIT`, `LAKERUNNER_DUCKDB_TEMP_DIRECTORY`,
+  `MALLOC_ARENA_MAX`) and relies on binary defaults, so there is no parameter,
+  env, or resource change. No IAM changes.
+- **maestro image bumped to `v1.66.0`** (from `v1.62.10`). Default `MaestroImage`
+  bump (digest-pinned multi-arch manifest); the Maestro service rolls to the new
+  task definition on redeploy. No parameter, IAM, or resource changes.
+- Upgrade action: deploy v1.3.0; no manual steps.
+
 ## v1.2.2
 
 - **lakerunner image bumped to `v1.57.1`** (from `v1.54.0`). The single

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,8 +33,8 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.57.1@sha256:d09563114a804b62880b592787e184226ed50a3ae134f26f6fb3a49f694cb98b"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.62.10@sha256:d63a430ff1a7f587c4fa2b8996469cff51ad747be69ea6602005c0ec23c16fed"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.60.0@sha256:fa3b991d2ba4d83f2ff15b784547e4e323f8428f0bf176d485de55050c04b1be"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.66.0@sha256:6951531fb3e0594b4ed90c9a0e4696a9fa824cedb051669882f7d6d100f3630e"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,8 +31,8 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.57.1@sha256:d09563114a804b62880b592787e184226ed50a3ae134f26f6fb3a49f694cb98b"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.62.10@sha256:d63a430ff1a7f587c4fa2b8996469cff51ad747be69ea6602005c0ec23c16fed"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.60.0@sha256:fa3b991d2ba4d83f2ff15b784547e4e323f8428f0bf176d485de55050c04b1be"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.66.0@sha256:6951531fb3e0594b4ed90c9a0e4696a9fa824cedb051669882f7d6d100f3630e"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
## Summary

| Image | From | To |
|---|---|---|
| lakerunner | v1.57.1 | v1.60.0 |
| maestro | v1.62.10 | v1.66.0 |

Both digest-pinned. Driver image suffixes in `deploy-lakerunner-services.sh` regenerated from `cardinal-defaults.yaml` by `make build`.

## DuckDB envar cleanup

No change required. lakerunner v1.60.0 moves `process-{logs,metrics,traces}` off in-process DuckDB to the `lkrn pack` subprocess. This stack never set the DuckDB tuning env vars (`LAKERUNNER_DUCKDB_MEMORY_LIMIT`, `LAKERUNNER_DUCKDB_TEMP_DIRECTORY`, `MALLOC_ARENA_MAX`) — process-* run with `environment: {}` and rely on binary defaults — so there is nothing to remove or add.

## Verification

- `make build` — cfn-lint clean
- `make test` — 516 passed

Upgrade action: deploy v1.3.0; no manual steps.