### PR TITLE
process workers: 2M compact target; metrics mem to 4G (v1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.4.1
+
+- **Process workers now set a compaction target file size.** New env vars on the
+  three process services: `LAKERUNNER_PROCESSING_LOGS_COMPACT_TARGET_FILE_SIZE`,
+  `LAKERUNNER_PROCESSING_METRICS_COMPACT_TARGET_FILE_SIZE`, and
+  `LAKERUNNER_PROCESSING_TRACES_COMPACT_TARGET_FILE_SIZE`, each set to `2097152`
+  (2 MiB). Changes compaction output sizing only; no parameter, IAM, or resource
+  changes.
+- **`process-metrics` memory bumped to 4096 MiB** (from 2048), matching
+  `process-logs`. The task definition rolls to the larger size on redeploy;
+  ensure the cluster has Fargate capacity for the increase.
+- Upgrade action: deploy v1.4.1; no manual steps.
+
 ## v1.4.0
 
 - **lakerunner image bumped to `v1.61.1`** (from `v1.60.0`). The single

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -71,13 +71,14 @@ services:
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
-    environment: {}
+    environment:
+      LAKERUNNER_PROCESSING_LOGS_COMPACT_TARGET_FILE_SIZE: "2097152"
 
   lakerunner-process-metrics:
     signal_type: metrics
     command: ["/app/bin/lakerunner", "process-metrics"]
     cpu: 1024
-    memory_mib: 2048
+    memory_mib: 4096
     autoscaling:
       min_replicas: 1
       max_replicas: 10
@@ -85,7 +86,8 @@ services:
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
-    environment: {}
+    environment:
+      LAKERUNNER_PROCESSING_METRICS_COMPACT_TARGET_FILE_SIZE: "2097152"
 
   lakerunner-process-traces:
     signal_type: traces
@@ -99,7 +101,8 @@ services:
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
-    environment: {}
+    environment:
+      LAKERUNNER_PROCESSING_TRACES_COMPACT_TARGET_FILE_SIZE: "2097152"
 
   lakerunner-sweeper:
     signal_type: common


### PR DESCRIPTION
Patch release v1.4.1.

## Changes

- Set `LAKERUNNER_PROCESSING_{LOGS,METRICS,TRACES}_COMPACT_TARGET_FILE_SIZE` to `2097152` (2 MiB) on the three process services.
- Bump `process-metrics` memory from 2048 to 4096 MiB (matches `process-logs`).

## Upgrade action

Deploy v1.4.1; no manual steps. `process-metrics` task definition rolls to the larger memory size on redeploy — ensure Fargate capacity for the increase.

See CHANGELOG.md for the operator-facing entry.