### PR TITLE
bump lakerunner to v1.61.2; release v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.4.2
+
+- **Lakerunner bumped to v1.61.2.** Pod startup now tolerates a database schema
+  that is *ahead* of the binary: a task whose image is older than the applied
+  migrations starts and waits rather than failing, and migrations remain
+  one-way (forward only). This makes a CloudFormation stack rollback safe across
+  a migration — if an upgrade applies migrations and then fails, the rolled-back
+  (older) tasks no longer crash on the newer schema. Bumping `LakerunnerImage`
+  redeploys the migrator (reruns migrations as a no-op) before the service tier
+  updates, as usual.
+- Upgrade action: deploy v1.4.2; no manual steps.
+
 ## v1.4.1
 
 - **Process workers now set a compaction target file size.** New env vars on the

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -33,7 +33,7 @@ storage_profiles:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.61.1@sha256:9082c81b3c5abbaecec0b388b5cab74dd78703d36b22d95ebbb7e170c9365e6c"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.61.2@sha256:ea4a843b55fd93a66bb324b4d5f7a69eae07e1b42c9ef9ee1488b87f2a38a267"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.66.5@sha256:542bb54e5e47e24fe4f65458899438fbe4c159282cd0977370942e97c283cd19"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.61.1@sha256:9082c81b3c5abbaecec0b388b5cab74dd78703d36b22d95ebbb7e170c9365e6c"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.61.2@sha256:ea4a843b55fd93a66bb324b4d5f7a69eae07e1b42c9ef9ee1488b87f2a38a267"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.66.5@sha256:542bb54e5e47e24fe4f65458899438fbe4c159282cd0977370942e97c283cd19"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"


### PR DESCRIPTION
Bumps lakerunner to v1.61.2 and cuts release v1.4.2. Maestro stays at v1.66.5.

## Why

v1.61.2 makes pod startup tolerate a DB schema that is **ahead** of the binary: an older-image task starts and waits rather than crashing, while migrations stay one-way (forward only). This makes a CloudFormation stack rollback safe across a migration — if an upgrade applies migrations then fails, the rolled-back (older) tasks no longer fail on the newer schema.

## Changes

- `cardinal-defaults.yaml` — lakerunner `v1.61.2@sha256:ea4a843…`
- `scripts/deploy-lakerunner-services.sh` — same pin, regenerated by `make build`
- `CHANGELOG.md` — `## v1.4.2` section

## Verification

- `make build` clean (cfn-lint)
- `make test` — 516 passed