### PR TITLE
Lower process-tier CPU autoscale target to 50% (v1.4.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.4.3
+
+- **Process-tier CPU autoscaling target lowered 90% → 50%.** The three process
+  services (process-logs, process-metrics, process-traces) now scale out when
+  average CPU crosses 50% instead of 90%, so they leave the 1-replica floor and
+  scale toward `max_replicas` (10) under sustained ingest load much sooner. At
+  90% a steady-but-not-saturated workload could stall at one replica and fall
+  behind, delaying when data becomes queryable.
+- Upgrade action: deploy v1.4.3; no manual steps.
+
 ## v1.4.2
 
 - **Lakerunner bumped to v1.61.2.** Pod startup now tolerates a database schema

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -67,7 +67,7 @@ services:
     autoscaling:
       min_replicas: 1
       max_replicas: 10
-      cpu_target_percent: 90
+      cpu_target_percent: 50
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
@@ -82,7 +82,7 @@ services:
     autoscaling:
       min_replicas: 1
       max_replicas: 10
-      cpu_target_percent: 90
+      cpu_target_percent: 50
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]
@@ -97,7 +97,7 @@ services:
     autoscaling:
       min_replicas: 1
       max_replicas: 10
-      cpu_target_percent: 90
+      cpu_target_percent: 50
     health_check:
       type: "go"
       command: ["/app/bin/lakerunner", "sysinfo"]

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -246,7 +246,7 @@ def test_process_services_have_cpu_scalable_target(td):
 
 
 def test_process_services_have_cpu_target_tracking_policy(td):
-    """Each process-* service tracks CPU at 90% (mirrors the Kubernetes HPA)."""
+    """Each process-* service tracks CPU at 50%."""
     policies = {
         logical_id: r
         for logical_id, r in td["Resources"].items()
@@ -267,7 +267,7 @@ def test_process_services_have_cpu_target_tracking_policy(td):
             cfg["PredefinedMetricSpecification"]["PredefinedMetricType"]
             == "ECSServiceAverageCPUUtilization"
         )
-        assert cfg["TargetValue"] == 90.0
+        assert cfg["TargetValue"] == 50.0
 
 
 def test_pubsub_sqs_has_no_autoscaling(td):


### PR DESCRIPTION
## What

Lower the ECS process-tier CPU autoscaling target from 90% → 50% for `process-logs`, `process-metrics`, `process-traces` (`cpu_target_percent` in `cardinal-defaults.yaml`).

## Why

At a 90% target, a steady-but-not-saturated ingest workload sits below the threshold and never leaves the 1-replica floor, so it can fall behind and delay when data becomes queryable. 50% lets the services scale toward `max_replicas` (10) under load much sooner.

## Changes

- `cardinal-defaults.yaml`: `cpu_target_percent` 90 → 50 on the three process services
- `tests/templates/test_services_process.py`: expected `TargetValue` 90.0 → 50.0
- `CHANGELOG.md`: v1.4.3 entry

`make build` and `make test` pass locally.