### PR TITLE
Disable Spot by default for lakerunner (lakerunner_capacity knob, v1.4.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.4.4
+
+- **Spot is now disabled by default for the lakerunner side.** New build-time
+  knob `lakerunner_capacity` in `cardinal-defaults.yaml`, default `ondemand`:
+  the four autoscaled workers (process-logs, process-metrics, process-traces,
+  query-worker) now run pure on-demand FARGATE instead of the previous Base=1
+  on-demand + FARGATE_SPOT scale-out. This removes exposure to FARGATE_SPOT
+  capacity shortages on the lakerunner tier. Set `lakerunner_capacity: fallback`
+  to opt back into Spot scale-out. Deploy-critical singletons and the collector
+  were already on-demand and are unaffected.
+- Upgrade action: deploy v1.4.4. Expect a higher steady-state Fargate bill on the
+  process and query-worker tiers (on-demand vs spot); set `lakerunner_capacity:
+  fallback` before building if you want the prior Spot behavior.
+
 ## v1.4.3
 
 - **Process-tier CPU autoscaling target lowered 90% → 50%.** The three process

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -43,6 +43,16 @@ images:
   aws_cli:    "public.ecr.aws/aws-cli/aws-cli:2.34.63@sha256:c95ab0642137f55a12b95b6956dd03cefdbd73e760e0e7b870afc9b47f9c8150"
 
 # ---------------------------------------------------------------------------
+# Capacity for the autoscaled lakerunner scale-out workers (process-logs,
+# process-metrics, process-traces, query-worker). One build-time knob:
+#   "ondemand" - pure on-demand FARGATE; disables Spot on the lakerunner side (default).
+#   "fallback" - Base=1 on-demand FARGATE + FARGATE_SPOT scale-out.
+# Deploy-critical singletons (query-api, control, maestro, pubsub-sqs,
+# migrator) and the collector are always on-demand and ignore this knob.
+# ---------------------------------------------------------------------------
+lakerunner_capacity: ondemand
+
+# ---------------------------------------------------------------------------
 # Lakerunner microservices. Each entry's tier (query / process / control) is
 # determined by which services-*.yaml child stack owns it; this file does not
 # encode the tier mapping (the generators do).

--- a/src/cardinal_cfn/children/services_process.py
+++ b/src/cardinal_cfn/children/services_process.py
@@ -57,6 +57,7 @@ def build() -> Template:
     )
 
     defaults = load_defaults()
+    lakerunner_capacity = defaults.get("lakerunner_capacity", "ondemand")
     pubsub_cfg = defaults["services"]["lakerunner-pubsub-sqs"]
     logs_cfg = defaults["services"]["lakerunner-process-logs"]
     metrics_cfg = defaults["services"]["lakerunner-process-metrics"]
@@ -484,12 +485,13 @@ def build() -> Template:
             base_env=base_env,
             base_secrets=base_secrets,
             extra_env=spec.get("extra_env"),
-            # Autoscaled workers (process-{logs,metrics,traces}) default to
-            # "fallback": Base=1 on-demand guarantees the first NEW task of a
-            # rolling upgrade places even in a transient FARGATE_SPOT shortage,
-            # while scale-out replicas ride cheap spot. pubsub-sqs overrides this
-            # to "ondemand" (it's a deploy-critical singleton, not autoscaled).
-            capacity=spec.get("capacity", "fallback"),
+            # Autoscaled workers (process-{logs,metrics,traces}) take the
+            # build-time "lakerunner_capacity" knob (default "fallback": Base=1
+            # on-demand guarantees the first NEW task of a rolling upgrade places
+            # even in a transient FARGATE_SPOT shortage, while scale-out replicas
+            # ride cheap spot; "ondemand" disables spot). pubsub-sqs overrides
+            # this to "ondemand" (deploy-critical singleton, not autoscaled).
+            capacity=spec.get("capacity", lakerunner_capacity),
         )
         t.add_output(Output(spec["output_name"], Value=GetAtt(ecs_service, "Name")))
 

--- a/src/cardinal_cfn/children/services_query.py
+++ b/src/cardinal_cfn/children/services_query.py
@@ -296,10 +296,12 @@ def build() -> Template:
             subnets_csv_param="PrivateSubnetsCsv",
             security_group_id_param="TaskSecurityGroupId",
             container_name="query-worker",
-            # Base=1 guarantees the first NEW task of a rolling upgrade lands on
-            # on-demand even in a transient FARGATE_SPOT shortage; the remaining
-            # scale-out replicas stay spot-weighted (~85-90% spot).
-            capacity="fallback",
+            # Build-time "lakerunner_capacity" knob (default "fallback": Base=1
+            # guarantees the first NEW task of a rolling upgrade lands on
+            # on-demand even in a transient FARGATE_SPOT shortage, while the
+            # remaining scale-out replicas stay spot-weighted ~85-90% spot;
+            # "ondemand" disables spot on the lakerunner side).
+            capacity=defaults.get("lakerunner_capacity", "ondemand"),
         )
     )
 

--- a/tests/templates/test_services_process.py
+++ b/tests/templates/test_services_process.py
@@ -529,17 +529,6 @@ def _assert_on_demand(items):
     assert all("Base" not in i for i in items)
 
 
-def _assert_fallback(items):
-    # Autoscaled worker: Base=1 on-demand first replica + weighted spot scale-out.
-    by_provider = {i["CapacityProvider"]: i for i in items}
-    assert by_provider["FARGATE"]["Base"] == 1
-    assert "FARGATE_SPOT" in by_provider
-    assert by_provider["FARGATE_SPOT"]["Weight"] == 4
-    assert "Base" not in by_provider["FARGATE_SPOT"]
-    bases = [i.get("Base", 0) for i in items]
-    assert sum(1 for b in bases if b) == 1
-
-
 def test_pubsub_sqs_is_pure_on_demand(td):
     # pubsub-sqs is a non-autoscaled, deploy-critical singleton: pure on-demand
     # FARGATE so a rolling deploy always places. No FARGATE_SPOT.
@@ -547,10 +536,10 @@ def test_pubsub_sqs_is_pure_on_demand(td):
     _assert_on_demand(_service_items(td, "PubsubSqsService"))
 
 
-def test_process_workers_have_ondemand_base_with_spot_scaleout(td):
-    # process-* autoscale (to 10): Base=1 guarantees the first NEW task of a
-    # rolling upgrade lands on on-demand even in a transient FARGATE_SPOT
-    # shortage; scale-out replicas stay spot-weighted.
+def test_process_workers_are_pure_on_demand_by_default(td):
+    # The shipped default (lakerunner_capacity: ondemand) disables Spot on the
+    # lakerunner side, so process-* run pure on-demand FARGATE. The "fallback"
+    # (spot scale-out) strategy is covered in test_services_common.py.
     for suffix in ("ProcessLogsService", "ProcessMetricsService", "ProcessTracesService"):
-        assert _service_strategy(td, suffix) == {"FARGATE_SPOT", "FARGATE"}, suffix
-        _assert_fallback(_service_items(td, suffix))
+        assert _service_strategy(td, suffix) == {"FARGATE"}, suffix
+        _assert_on_demand(_service_items(td, suffix))

--- a/tests/templates/test_services_query.py
+++ b/tests/templates/test_services_query.py
@@ -385,12 +385,11 @@ def test_query_api_is_pure_on_demand(td):
     assert all("Base" not in i for i in items)
 
 
-def test_query_worker_has_ondemand_base_with_spot_scaleout(td):
-    # query-worker autoscales (to 8): Base=1 guarantees the first NEW task of a
-    # rolling upgrade lands on on-demand even in a transient FARGATE_SPOT
-    # shortage; scale-out replicas stay spot-weighted.
-    assert _service_strategy(td, "QueryWorkerService") == {"FARGATE_SPOT", "FARGATE"}
-    by_provider = {i["CapacityProvider"]: i for i in _service_items(td, "QueryWorkerService")}
-    assert by_provider["FARGATE"]["Base"] == 1
-    assert by_provider["FARGATE_SPOT"]["Weight"] == 4
-    assert "Base" not in by_provider["FARGATE_SPOT"]
+def test_query_worker_is_pure_on_demand_by_default(td):
+    # The shipped default (lakerunner_capacity: ondemand) disables Spot on the
+    # lakerunner side, so query-worker runs pure on-demand FARGATE. The
+    # "fallback" (spot scale-out) strategy is covered in test_services_common.py.
+    assert _service_strategy(td, "QueryWorkerService") == {"FARGATE"}
+    items = _service_items(td, "QueryWorkerService")
+    assert items == [{"CapacityProvider": "FARGATE", "Weight": 1}]
+    assert all("Base" not in i for i in items)


### PR DESCRIPTION
## What

Adds a build-time `lakerunner_capacity` knob (`cardinal-defaults.yaml`) and flips the **default to `ondemand`**, disabling FARGATE_SPOT on the lakerunner side.

- `ondemand` (new default): process-{logs,metrics,traces} + query-worker run pure on-demand FARGATE.
- `fallback`: prior behavior (Base=1 on-demand + FARGATE_SPOT scale-out).

Deploy-critical singletons (query-api, control, maestro, pubsub-sqs, migrator) and the collector were already on-demand and are unaffected.

## Why

Protects the lakerunner tier from FARGATE_SPOT capacity shortages. `fallback` remains a one-line opt-in for cost-sensitive installs.

## Changes

- `cardinal-defaults.yaml`: `lakerunner_capacity: ondemand` (+ docs)
- `services_process.py`, `services_query.py`: workers read the knob
- template tests updated to assert on-demand default; `fallback` strategy stays covered by `test_services_common.py`
- `CHANGELOG.md`: v1.4.4

`make build` and `make test` pass; no `FARGATE_SPOT` in generated lakerunner templates.