### PR TITLE
bump lakerunner to v1.63.1, maestro to v1.68.0; release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.5.1
+
+**Image bump — unblocks v1.5.0 satellite mapping.**
+
+- **Images:** lakerunner `v1.61.2` → `v1.63.1`, maestro `v1.66.5` → `v1.68.0`.
+  These are the qualifying versions referenced by v1.5.0: `pubsub-sqs` reads SQS
+  queues from configdb (not env), and Maestro consumes `MAESTRO_SATELLITE_CONFIG`.
+  v1.5.1 is the first release safe to deploy with satellite mapping.
+- **Upgrade action:** redeploy the services stack to pick up the new image pins
+  (this retriggers DB migrations from the lakerunner image, as always). No
+  parameter changes beyond those already documented for v1.5.0.
+
 ## v1.5.0
 
 **Satellite collector mapping via `SATELLITE_CONFIG` → SSM → Maestro.**

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -19,8 +19,8 @@ api_keys:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.61.2@sha256:ea4a843b55fd93a66bb324b4d5f7a69eae07e1b42c9ef9ee1488b87f2a38a267"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.66.5@sha256:542bb54e5e47e24fe4f65458899438fbe4c159282cd0977370942e97c283cd19"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.63.1@sha256:f611e0474d10ce2de557039daf51e276091b00a4b98014a3989ea1d2d733215b"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.68.0@sha256:aa898efcf49672d1b51043f0128b3cf229fbb8215b5def091f00006d189d281d"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -30,8 +30,8 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.61.2@sha256:ea4a843b55fd93a66bb324b4d5f7a69eae07e1b42c9ef9ee1488b87f2a38a267"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.66.5@sha256:542bb54e5e47e24fe4f65458899438fbe4c159282cd0977370942e97c283cd19"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.63.1@sha256:f611e0474d10ce2de557039daf51e276091b00a4b98014a3989ea1d2d733215b"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.68.0@sha256:aa898efcf49672d1b51043f0128b3cf229fbb8215b5def091f00006d189d281d"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
Image-bump release that unblocks v1.5.0 satellite mapping.

- lakerunner `v1.61.2` -> `v1.63.1`
- maestro `v1.66.5` -> `v1.68.0`

These are the qualifying versions referenced by v1.5.0: `pubsub-sqs` reads SQS queues from configdb (not env), and Maestro consumes `MAESTRO_SATELLITE_CONFIG`. v1.5.1 is the first release safe to deploy with satellite mapping.

CHANGELOG entry added under `## v1.5.1`. `make build` + `make lint` clean.