### PR TITLE
bump lakerunner to v1.67.1; release v1.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.6.2
+
+**Image bump:** lakerunner `v1.67.0` → `v1.67.1`. Upgrade action: redeploy the
+root stack. The lakerunner bump retriggers the DB migrator (reruns once,
+idempotent) before the service tiers update.
+
 ## v1.6.1
 
 **Image bump:** lakerunner `v1.65.0` → `v1.67.0`, maestro `v1.71.0` → `v1.72.1`.

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -19,7 +19,7 @@ api_keys:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.67.0@sha256:fbc91d75b4be77a808bc2e296d15ad8d081dea9656ef3b4eab17c90ba105dfa5"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.67.1@sha256:81bab9db5bd71c484a23b1e7bb93e6831f54454bbf1e5fb03255620cd4a2e4c0"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.72.1@sha256:7561d6281483bffbe2b41d42679165a191056e4cb4555261bebd7f8abddfdda3"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.67.0@sha256:fbc91d75b4be77a808bc2e296d15ad8d081dea9656ef3b4eab17c90ba105dfa5"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.67.1@sha256:81bab9db5bd71c484a23b1e7bb93e6831f54454bbf1e5fb03255620cd4a2e4c0"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.72.1@sha256:7561d6281483bffbe2b41d42679165a191056e4cb4555261bebd7f8abddfdda3"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"


### PR DESCRIPTION
## Summary

- Bump `LakerunnerImage` default `v1.67.0` → `v1.67.1` (digest-pinned) in `cardinal-defaults.yaml`.
- Regenerate `scripts/deploy-lakerunner-services.sh` image suffix to match.
- Add `CHANGELOG.md` entry for `v1.6.2`.

## Upgrade action

Redeploy the root stack. The lakerunner bump retriggers the DB migrator (reruns once, idempotent) before the service tiers update.

## Verification

- `make build` (cfn-lint clean, idempotent re-run leaves tree clean)
- `make test` — 516 passed