### PR TITLE
bump lakerunner v1.69.1; release v1.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.6.5
+
+**Image bump:** lakerunner `v1.69.0` → `v1.69.1`. Upgrade action: redeploy the
+root stack. The lakerunner bump retriggers the DB migrator (reruns once,
+idempotent) before the service tiers update.
+
 ## v1.6.4
 
 **Image bump:** lakerunner `v1.68.0` → `v1.69.0`, maestro `v1.73.1` → `v1.74.0`.

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -19,7 +19,7 @@ api_keys:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.69.0@sha256:e027b4b2fbb9728b23dec81e8757f30ae715863c37f41e0277e7ab4dd03aeb0e"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.69.1@sha256:67bfae2ddbf5936a28d6f1abf6ca2c98ec4879ab2c0594606e34dbd8739c77ad"
   maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.74.0@sha256:34f02e4178221a54e9741e344e8f4480d500e389b0d09d08216bd2ce29db7f79"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.8.0@sha256:9906eea2b38f1614047ada60ce7887704652484bb5b01a7f8a1d932277e1f151"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.69.0@sha256:e027b4b2fbb9728b23dec81e8757f30ae715863c37f41e0277e7ab4dd03aeb0e"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.69.1@sha256:67bfae2ddbf5936a28d6f1abf6ca2c98ec4879ab2c0594606e34dbd8739c77ad"
 MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.74.0@sha256:34f02e4178221a54e9741e344e8f4480d500e389b0d09d08216bd2ce29db7f79"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.4.0@sha256:c85811b3a82b1574063971ce79126886607fbc82a1f9d777587fc4895ce18b7b"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"


### PR DESCRIPTION
Image bump: lakerunner `v1.69.0` → `v1.69.1`. maestro/dex/otel unchanged.

Updates pins in `cardinal-defaults.yaml` and `scripts/deploy-lakerunner-services.sh` (synced via `make build`), plus the `v1.6.5` CHANGELOG entry.

Upgrade action: redeploy the root stack. The lakerunner bump retriggers the DB migrator (reruns once, idempotent) before the service tiers update.

`make test` — 516 passed; cfn-lint clean.