### PR TITLE
maestro: create pg extensions in db-init, allow keyless mcp-gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,22 @@ otel-collector `v1.8.0` → `v1.10.0`.
 Upgrade action: redeploy the root stack. The lakerunner bump retriggers the DB
 migrator (reruns once, idempotent) before the service tiers update.
 
+**Maestro task changes required by maestro v1.87.8.** Two settings the new
+image needs, both applied automatically by the stack:
+
+- `db-init` now creates the `vector`, `pgcrypto` and `citext` extensions in the
+  `maestro` database. mcp-gateway's startup preflight requires them to exist;
+  its migrations no longer create them, so without this the maestro service
+  never starts and the deployment circuit breaker fails the stack.
+- The bundled mcp-gateway runs with `MCP_ALLOW_NO_AUTH=true`. It now fails
+  closed on a missing API key; its port has no target group and no
+  security-group ingress, so it is reachable only over loopback within the
+  maestro task.
+
+Upgrade action: none beyond redeploying — the extensions are created on the
+next maestro task start. The DB master credentials already have the privileges
+required (RDS `rds_superuser`).
+
 ## v1.6.6
 
 **Image bump:** lakerunner `v1.69.1` → `v1.75.0`, maestro `v1.74.0` → `v1.87.3`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,16 @@ Upgrade action: none beyond redeploying — the extensions are created on the
 next maestro task start. The DB master credentials already have the privileges
 required (RDS `rds_superuser`).
 
+**Self-telemetry now reaches the install's own collector.** The service tiers
+receive the collector endpoint in `LAKERUNNER_SELF_TELEMETRY_ENDPOINT` instead
+of `OTEL_EXPORTER_OTLP_ENDPOINT`. A license that carries its own telemetry
+endpoint overrides the latter, so on such a license the install's collector
+previously received nothing. With the self var, a licensed install ships to
+both (license endpoint primary, collector secondary) and an install whose
+license carries no endpoint ships to the collector alone — no duplication in
+either case. Upgrade action: redeploy the services stack; no parameter
+changes.
+
 ## v1.6.6
 
 **Image bump:** lakerunner `v1.69.1` → `v1.75.0`, maestro `v1.74.0` → `v1.87.3`,

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -401,15 +401,22 @@ def build() -> Template:
         Image=db_init_image_ref,
         Essential=False,
         EntryPoint=["sh", "-c"],
-        # Create the maestro database; mcp-gateway can't create the database it
-        # connects to. Everything else (schema, ownership, the pgvector /
-        # pgcrypto / citext extensions) is handled by mcp-gateway's migrations,
-        # which run as the DB superuser. The "|| true" tolerates re-runs.
+        # Create the maestro database and its extensions; mcp-gateway can't
+        # create the database it connects to, and since maestro v1.87.8 its
+        # startup preflight requires vector/pgcrypto/citext to already exist
+        # ("provisioned by the operator, not by migrations"). Schema and
+        # ownership are still mcp-gateway's migrations. The "|| true" tolerates
+        # re-runs of CREATE DATABASE; the extension step must succeed.
         Command=[
             (
                 "PGPASSWORD=$LRDB_PASSWORD psql -h $LRDB_HOST -p $LRDB_PORT "
                 "-U $LRDB_USER -d postgres -v ON_ERROR_STOP=1 "
-                "-c \"CREATE DATABASE maestro\" || true"
+                "-c \"CREATE DATABASE maestro\" || true; "
+                "PGPASSWORD=$LRDB_PASSWORD psql -h $LRDB_HOST -p $LRDB_PORT "
+                "-U $LRDB_USER -d maestro -v ON_ERROR_STOP=1 "
+                "-c \"CREATE EXTENSION IF NOT EXISTS vector\" "
+                "-c \"CREATE EXTENSION IF NOT EXISTS pgcrypto\" "
+                "-c \"CREATE EXTENSION IF NOT EXISTS citext\""
             )
         ],
         Environment=[
@@ -460,6 +467,12 @@ def build() -> Template:
         PortMappings=[PortMapping(ContainerPort=mcp_gateway_port, Protocol="tcp")],
         Environment=db_env + [
             Environment(Name="MCP_PORT", Value=str(mcp_gateway_port)),
+            # The gateway fails closed on a missing API key since maestro
+            # v1.87.8. Its port has no target group and no SG ingress, so it
+            # is reachable only over loopback inside this task -- the same
+            # pod-local sidecar topology conductor's own deployment uses,
+            # which sets this flag too.
+            Environment(Name="MCP_ALLOW_NO_AUTH", Value="true"),
             Environment(
                 Name="MCP_MIGRATE_RECOVER_FROM_DIRTY",
                 Value=Ref("McpMigrateRecoverFromDirty"),

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -40,10 +40,18 @@ def lakerunner_otel_env(*, service_key: str) -> list:
     """OTel env vars wired to the in-cluster otel-collector.
 
     Mirrors the helm chart pattern: OTEL_SERVICE_NAME=lakerunner-<component>,
-    ENABLE_OTLP_TELEMETRY toggles the actual exporter, OTEL_EXPORTER_OTLP_ENDPOINT
-    points at the collector's Cloud Map DNS name, and OTEL_RESOURCE_ATTRIBUTES
-    carries ecs.cluster.name. All four env vars are unconditionally set; the
-    ENABLE_OTLP_TELEMETRY flag is what actually starts/stops exporting.
+    ENABLE_OTLP_TELEMETRY toggles the actual exporter,
+    LAKERUNNER_SELF_TELEMETRY_ENDPOINT points at the install's collector, and
+    OTEL_RESOURCE_ATTRIBUTES carries ecs.cluster.name. All four env vars are
+    unconditionally set; the ENABLE_OTLP_TELEMETRY flag is what actually
+    starts/stops exporting.
+
+    The endpoint is the self-telemetry var, not OTEL_EXPORTER_OTLP_ENDPOINT:
+    a license that carries its own telemetry endpoint overrides the latter and
+    ships nowhere else, whereas the self endpoint is a second destination
+    alongside the license one (and the sole destination when the license
+    carries none). Lakerunner sets OTEL_EXPORTER_OTLP_ENDPOINT itself from the
+    endpoint it resolves, so the stack must not also set it.
 
     Expects the calling stack to declare these parameters:
       - SelfTelemetryEndpoint (String): the OTLP gRPC URL, or "" when disabled.
@@ -52,7 +60,7 @@ def lakerunner_otel_env(*, service_key: str) -> list:
     """
     return [
         Environment(Name="OTEL_SERVICE_NAME", Value=f"lakerunner-{service_key}"),
-        Environment(Name="OTEL_EXPORTER_OTLP_ENDPOINT", Value=Ref("SelfTelemetryEndpoint")),
+        Environment(Name="LAKERUNNER_SELF_TELEMETRY_ENDPOINT", Value=Ref("SelfTelemetryEndpoint")),
         Environment(Name="ENABLE_OTLP_TELEMETRY", Value=Ref("SelfTelemetryEnabled")),
         Environment(
             Name="OTEL_RESOURCE_ATTRIBUTES",

--- a/tests/templates/test_maestro.py
+++ b/tests/templates/test_maestro.py
@@ -110,6 +110,33 @@ def test_db_init_is_not_essential(td):
     assert db_init["Essential"] is False
 
 
+def test_db_init_creates_maestro_extensions(td):
+    # mcp-gateway's startup preflight (maestro v1.87.8+) requires these to
+    # already exist in the maestro database; nothing else creates them.
+    task_def = next(
+        r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
+    )
+    db_init = next(
+        c for c in task_def["Properties"]["ContainerDefinitions"] if c["Name"] == "db-init"
+    )
+    command = " ".join(db_init["Command"])
+    assert "-d maestro" in command
+    for ext in ("vector", "pgcrypto", "citext"):
+        assert f"CREATE EXTENSION IF NOT EXISTS {ext}" in command
+
+
+def test_mcp_gateway_runs_without_api_key(td):
+    # The gateway fails closed on a missing key; its port is loopback-only.
+    task_def = next(
+        r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"
+    )
+    gateway = next(
+        c for c in task_def["Properties"]["ContainerDefinitions"] if c["Name"] == "mcp-gateway"
+    )
+    env = {e["Name"]: e["Value"] for e in gateway["Environment"]}
+    assert env["MCP_ALLOW_NO_AUTH"] == "true"
+
+
 def test_maestro_and_dex_are_essential(td):
     task_def = next(
         r for r in td["Resources"].values() if r["Type"] == "AWS::ECS::TaskDefinition"

--- a/tests/unit/test_services_common.py
+++ b/tests/unit/test_services_common.py
@@ -7,6 +7,17 @@ import pytest
 from cardinal_cfn.children import services_common
 
 
+def test_otel_env_uses_self_telemetry_endpoint_var():
+    """The collector endpoint must ride LAKERUNNER_SELF_TELEMETRY_ENDPOINT: a
+    license carrying its own endpoint overrides OTEL_EXPORTER_OTLP_ENDPOINT, so
+    setting that one instead means the install's collector gets nothing."""
+    env = services_common.lakerunner_otel_env(service_key="query-api")
+    rendered = json.loads(json.dumps(env, default=lambda o: o.to_dict()))
+    by_name = {e["Name"]: e["Value"] for e in rendered}
+    assert by_name["LAKERUNNER_SELF_TELEMETRY_ENDPOINT"] == {"Ref": "SelfTelemetryEndpoint"}
+    assert "OTEL_EXPORTER_OTLP_ENDPOINT" not in by_name
+
+
 def test_build_log_group_uses_cardinal_naming_contract():
     lg = services_common.build_log_group(service_key="query-api")
     rendered = json.loads(json.dumps(lg, default=lambda o: o.to_dict()))


### PR DESCRIPTION
maestro v1.87.8 fails to start without these:

- mcp-gateway preflight requires vector/pgcrypto/citext to already exist; migrations no longer create them. db-init now does.
- mcp-gateway fails closed on a missing API key; it is loopback-only in this task, so MCP_ALLOW_NO_AUTH=true (same as conductor's own sidecar deployment).

Verified on a full us-east-2 deploy: without these the Maestro service trips the ECS circuit breaker and rolls back the stack; with them the stack creates clean and the Maestro UI logs in.