### PR TITLE
tag every resource with the common set; stack tags from the drivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ v0.0.114.
 
 ## Unreleased
 
+**Consistent resource tagging.** Every Cardinal-created resource now carries
+the same five tags — `Name`, `Project=cardinal`,
+`Application=cardinal-lakerunner`, `Component`, `ManagedBy` — from a single
+helper (`naming.cardinal_tags`). Previously the nested children emitted no
+`Application` tag (so ~40% of an install's resources were invisible to an
+`Application` filter), and each root stack carried its own copy of the tag
+builder.
+
+The deploy drivers now also pass `Project` / `Application` / `ManagedBy` as
+**stack** tags on every change set. CloudFormation propagates those to
+resource types the templates cannot tag directly — ALB listeners and listener
+rules, Cloud Map namespaces and services, the IAM server certificate — which
+previously carried only `aws:cloudformation:*` tags.
+
+Upgrade action: redeploy each stack to apply the tags. Tag-only changes; no
+resource is replaced. Note that stack tags are re-applied from the driver on
+every deploy, so tags added by hand to a Cardinal stack will be dropped.
+
 **New stack: `cardinal-satellite-cwmetrics`.** Streams an account's CloudWatch
 metrics into the satellite's existing raw bucket under `cwmetrics-raw/`, via a
 CloudWatch metric stream and a Firehose delivery stream. It is a producer-only

--- a/scripts-src/parts/base.sh
+++ b/scripts-src/parts/base.sh
@@ -45,6 +45,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -580,12 +588,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/scripts/deploy-lakerunner-infra-base.sh
+++ b/scripts/deploy-lakerunner-infra-base.sh
@@ -231,6 +231,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -766,12 +774,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/scripts/deploy-lakerunner-infra-rds.sh
+++ b/scripts/deploy-lakerunner-infra-rds.sh
@@ -131,6 +131,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -666,12 +674,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -458,6 +458,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -993,12 +1001,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/scripts/deploy-satellite-cwmetrics.sh
+++ b/scripts/deploy-satellite-cwmetrics.sh
@@ -146,6 +146,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -681,12 +689,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/scripts/deploy-satellite-infra-base.sh
+++ b/scripts/deploy-satellite-infra-base.sh
@@ -146,6 +146,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -681,12 +689,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/scripts/deploy-satellite-services.sh
+++ b/scripts/deploy-satellite-services.sh
@@ -252,6 +252,14 @@ set -eu
 
 CHANGE_SET_PREFIX="cardinal-deploy-"
 
+# Stack tags.  CloudFormation propagates these to every resource type that
+# supports tagging, including the ones the generators cannot tag directly
+# (ALB listeners and listener rules, Cloud Map, IAM server certificates), and
+# to nested stacks.  Per-resource Name/Component tags still come from the
+# generators (src/cardinal_cfn/naming.py).  Always passed, on create and
+# update alike: a change set that omits --tags drops the stack's tags.
+STACK_TAGS="Key=Project,Value=cardinal Key=Application,Value=cardinal-lakerunner Key=ManagedBy,Value=cardinal-cfn"
+
 stack_name="${STACK_NAME:-}"
 template_url="${TEMPLATE_URL:-}"
 region="${REGION:-}"
@@ -787,12 +795,15 @@ main() {
 
     change_set_name="${CHANGE_SET_PREFIX}$(date +%s)"
     log "creating change set: $change_set_name (type=$cs_type)"
+    # STACK_TAGS is a word list, not one argument -- splitting is intended.
+    # shellcheck disable=SC2086
     cfntool create-change-set \
         --stack-name "$stack_name" \
         --change-set-name "$change_set_name" \
         --change-set-type "$cs_type" \
         --template-url "$template_url" \
         --parameters "file://$work_dir/parameters.json" \
+        --tags $STACK_TAGS \
         --capabilities CAPABILITY_NAMED_IAM CAPABILITY_AUTO_EXPAND \
         --region "$region" >/dev/null
 

--- a/src/cardinal_cfn/lakerunner_infra_base.py
+++ b/src/cardinal_cfn/lakerunner_infra_base.py
@@ -62,22 +62,15 @@ from troposphere.s3 import (
 )
 from troposphere.secretsmanager import GenerateSecretString, Secret
 
+from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import add_no_echo_parameter, add_parameter_group_metadata
 
 
-PROJECT = "cardinal"
-APPLICATION = "cardinal-lakerunner"
 MANAGED_BY = "cardinal-cfn-infra-base"
 
 
 def _tags(*, component: str) -> Tags:
-    return Tags(
-        Application=APPLICATION,
-        Project=PROJECT,
-        ManagedBy=MANAGED_BY,
-        Component=component,
-        Name=f"cardinal-{component}",
-    )
+    return cardinal_tags(component=component, managed_by=MANAGED_BY)
 
 
 def _retain(resource):

--- a/src/cardinal_cfn/lakerunner_infra_rds.py
+++ b/src/cardinal_cfn/lakerunner_infra_rds.py
@@ -27,21 +27,14 @@ from troposphere.secretsmanager import (
     SecretTargetAttachment,
 )
 
+from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import add_parameter_group_metadata
 
-APPLICATION = "cardinal-lakerunner"
-PROJECT = "cardinal"
 MANAGED_BY = "cardinal-cfn-rds"
 
 
 def _tags(*, component: str) -> Tags:
-    return Tags(
-        Application=APPLICATION,
-        Project=PROJECT,
-        ManagedBy=MANAGED_BY,
-        Component=component,
-        Name=f"cardinal-{component}",
-    )
+    return cardinal_tags(component=component, managed_by=MANAGED_BY)
 
 
 def _delete(resource):

--- a/src/cardinal_cfn/naming.py
+++ b/src/cardinal_cfn/naming.py
@@ -1,13 +1,20 @@
 """Naming and tag conventions for Cardinal resources.
 
-Two helper sets coexist:
+``cardinal_tags()`` is the single source of the common tag set every
+Cardinal-created resource carries:
 
-- ``cardinal_tags(component=, role=)`` -- used by the lakerunner nested
-  children. Carries an ``InstallIdShort`` Sub in the Name tag so per-install
-  resources are visually distinguishable in the AWS console.
-- ``cardinal_tags_v2(component=, managed_by=)`` -- used by the data-setup
-  Lambda's CFN wrapper and by callers that want explicit ``managed_by``
-  attribution (which layer owns the resource).
+    Name         cardinal-<role or component>[-<InstallIdShort>]
+    Project      cardinal
+    Application  cardinal-lakerunner
+    Component    <what the resource is for>
+    ManagedBy    which layer owns it (cardinal-cfn-<layer>)
+
+Nested children pass ``role=`` so their Name tag carries the install id and
+per-install resources stay distinguishable in the console; root stacks pass
+``component=`` alone. The deploy drivers additionally set Project /
+Application / ManagedBy as *stack* tags, which CloudFormation propagates to
+resource types the generators cannot tag directly (ALB listeners and listener
+rules, Cloud Map, IAM server certificates).
 
 ``LakerunnerComponent``, ``log_group_name``, ``name_tag``, ``secret_name``,
 and ``ssm_param_name`` are constants/helpers for the bare ``cardinal-*`` /
@@ -22,32 +29,29 @@ from enum import Enum
 from troposphere import Sub, Tags
 
 
-# ---------------------------------------------------------------------------
-# Legacy (used by src/cardinal_cfn/children/* and src/cardinal_cfn/root.py)
-# ---------------------------------------------------------------------------
-
-CARDINAL_PROJECT_TAG = "cardinal"
-MANAGED_BY_TAG = "cardinal-cfn"
-
-
-def cardinal_tags(*, component: str, role: str) -> Tags:
-    """Legacy tag set. Carries an ``InstallIdShort`` Sub in the Name tag."""
-
-    return Tags(
-        Name=Sub(f"cardinal-{role}-${{InstallIdShort}}"),
-        Project=CARDINAL_PROJECT_TAG,
-        Component=component,
-        ManagedBy=MANAGED_BY_TAG,
-    )
-
-
-# ---------------------------------------------------------------------------
-# New shape (used by src/cardinal_cfn/{prereqs,data_setup}/* and the
-# to-be-written src/cardinal_cfn/{app,lakerunner}/* packages)
-# ---------------------------------------------------------------------------
-
 PROJECT = "cardinal"
 APPLICATION = "cardinal-lakerunner"
+MANAGED_BY_TAG = "cardinal-cfn"
+# Back-compat alias; PROJECT is the name to use.
+CARDINAL_PROJECT_TAG = PROJECT
+
+
+def cardinal_tags(
+    *,
+    component: str,
+    role: str | None = None,
+    managed_by: str = MANAGED_BY_TAG,
+) -> Tags:
+    """The common tag set. ``role`` (children) puts InstallIdShort in Name."""
+
+    name = Sub(f"cardinal-{role}-${{InstallIdShort}}") if role else f"cardinal-{component}"
+    return Tags(
+        Name=name,
+        Project=PROJECT,
+        Application=APPLICATION,
+        Component=component,
+        ManagedBy=managed_by,
+    )
 
 
 class LakerunnerComponent(str, Enum):
@@ -67,23 +71,6 @@ class LakerunnerComponent(str, Enum):
     MAESTRO = "maestro"
     DEX = "dex"
     MIGRATOR = "migrator"
-
-
-def cardinal_tags_v2(*, component: str, managed_by: str, install_version: str | None = None) -> Tags:
-    """New tag set. ``managed_by`` is required; no InstallId."""
-
-    if not managed_by:
-        raise ValueError("managed_by is required")
-
-    items: dict[str, str] = {
-        "Application": APPLICATION,
-        "Component": component,
-        "ManagedBy": managed_by,
-        "Name": f"cardinal-{component}",
-    }
-    if install_version:
-        items["cardinal:install-version"] = install_version
-    return Tags(**items)
 
 
 def name_tag(*, role: str) -> str:

--- a/src/cardinal_cfn/satellite_cwmetrics.py
+++ b/src/cardinal_cfn/satellite_cwmetrics.py
@@ -40,12 +40,11 @@ from troposphere.firehose import (
 from troposphere.iam import Policy, Role
 from troposphere.logs import LogGroup
 
+from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import add_parameter_group_metadata
 from cardinal_cfn.policies import apply_policy
 from cardinal_cfn.satellite_infra_base import INGEST_PREFIXES
 
-APPLICATION = "cardinal-lakerunner"
-PROJECT = "cardinal"
 MANAGED_BY = "cardinal-cfn-satellite"
 
 # Must be one of the raw bucket's notified prefixes or the delivered objects
@@ -68,13 +67,7 @@ _LOG_RETENTION_DAYS = 7
 
 
 def _tags(*, component: str) -> Tags:
-    return Tags(
-        Application=APPLICATION,
-        Project=PROJECT,
-        ManagedBy=MANAGED_BY,
-        Component=component,
-        Name=f"cardinal-{component}",
-    )
+    return cardinal_tags(component=component, managed_by=MANAGED_BY)
 
 
 def build() -> Template:

--- a/src/cardinal_cfn/satellite_infra_base.py
+++ b/src/cardinal_cfn/satellite_infra_base.py
@@ -47,8 +47,8 @@ from troposphere.s3 import (
 )
 from troposphere.sqs import Queue, QueuePolicy, RedrivePolicy
 
-APPLICATION = "cardinal-lakerunner"
-PROJECT = "cardinal"
+from cardinal_cfn.naming import cardinal_tags
+
 MANAGED_BY = "cardinal-cfn-satellite"
 
 # Key prefixes whose objects are ingestible telemetry and therefore notify the
@@ -71,13 +71,7 @@ DLQ_RETENTION_SECONDS = 1209600  # 14 days, for inspection/redrive
 
 
 def _tags(*, component: str) -> Tags:
-    return Tags(
-        Application=APPLICATION,
-        Project=PROJECT,
-        ManagedBy=MANAGED_BY,
-        Component=component,
-        Name=f"cardinal-{component}",
-    )
+    return cardinal_tags(component=component, managed_by=MANAGED_BY)
 
 
 def _delete(resource):

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -73,11 +73,10 @@ from troposphere.logs import LogGroup
 from cardinal_cfn.defaults import load_defaults, load_otel_default_config
 from cardinal_cfn.images import add_image_override
 from cardinal_cfn.install_id import install_id_short
+from cardinal_cfn.naming import cardinal_tags
 from cardinal_cfn.parameters import add_parameter_group_metadata
 from cardinal_cfn.policies import apply_policy
 
-APPLICATION = "cardinal-lakerunner"
-PROJECT = "cardinal"
 MANAGED_BY = "cardinal-cfn-satellite"
 
 _SERVICE_KEY = "otel-grpc"
@@ -86,13 +85,7 @@ _HEALTH_PORT = 13133
 
 
 def _tags(*, component: str) -> Tags:
-    return Tags(
-        Application=APPLICATION,
-        Project=PROJECT,
-        ManagedBy=MANAGED_BY,
-        Component=component,
-        Name=f"cardinal-{component}",
-    )
+    return cardinal_tags(component=component, managed_by=MANAGED_BY)
 
 
 def _ecs_tasks_trust() -> dict:

--- a/tests/unit/test_common_tags.py
+++ b/tests/unit/test_common_tags.py
@@ -1,0 +1,63 @@
+"""Every tagged resource, in every template, carries the common tag set.
+
+The generators are the only thing that tags most resources, so a resource that
+grows a hand-rolled Tags list silently drops out of cost allocation and out of
+`resourcegroupstaggingapi` queries. This walks every template we emit and
+fails on any Tags that is not the full set from naming.cardinal_tags().
+
+Resource types CloudFormation tags from the *stack* tags instead (listeners,
+listener rules, Cloud Map, IAM server certificates) carry no Tags property
+here by design -- see STACK_TAGS in scripts-src/parts/base.sh.
+"""
+
+import importlib
+
+import pytest
+
+COMMON_TAG_KEYS = {"Name", "Project", "Application", "Component", "ManagedBy"}
+
+GENERATORS = [
+    "cardinal_cfn.lakerunner_infra_base",
+    "cardinal_cfn.lakerunner_infra_rds",
+    "cardinal_cfn.lakerunner_services",
+    "cardinal_cfn.satellite_infra_base",
+    "cardinal_cfn.satellite_services",
+    "cardinal_cfn.satellite_cwmetrics",
+    "cardinal_cfn.children.alb",
+    "cardinal_cfn.children.cert",
+    "cardinal_cfn.children.maestro",
+    "cardinal_cfn.children.migration",
+    "cardinal_cfn.children.services_control",
+    "cardinal_cfn.children.services_process",
+    "cardinal_cfn.children.services_query",
+]
+
+
+def _tagged_resources(module_name):
+    """Yield (logical_id, tag_keys) for resources carrying a Tags list."""
+    template = importlib.import_module(module_name).build().to_dict()
+    for logical_id, resource in template.get("Resources", {}).items():
+        tags = resource.get("Properties", {}).get("Tags")
+        if isinstance(tags, list) and tags and isinstance(tags[0], dict) and "Key" in tags[0]:
+            yield logical_id, {tag["Key"] for tag in tags}
+
+
+@pytest.mark.parametrize("module_name", GENERATORS)
+def test_every_tagged_resource_carries_the_common_set(module_name):
+    offenders = {
+        logical_id: sorted(COMMON_TAG_KEYS - keys)
+        for logical_id, keys in _tagged_resources(module_name)
+        if not COMMON_TAG_KEYS <= keys
+    }
+    assert not offenders, f"{module_name} resources missing common tags: {offenders}"
+
+
+# The services root is pure composition -- nested stacks plus the Cloud Map
+# namespace, none of which the generator tags; the stack tags cover them.
+COMPOSITION_ONLY = {"cardinal_cfn.lakerunner_services"}
+
+
+@pytest.mark.parametrize("module_name", sorted(set(GENERATORS) - COMPOSITION_ONLY))
+def test_templates_actually_tag_something(module_name):
+    """Guards the walker itself: a bad shape would make the check vacuous."""
+    assert list(_tagged_resources(module_name)), f"{module_name} tagged nothing"

--- a/tests/unit/test_deploy_stack_lint.py
+++ b/tests/unit/test_deploy_stack_lint.py
@@ -134,6 +134,20 @@ def test_cfntool_wrapper_only_wraps_role_capable_subcommands():
     )
 
 
+def test_change_set_carries_the_common_stack_tags():
+    """Stack tags are how listeners, listener rules, Cloud Map and the IAM
+    server certificate get tagged -- the generators cannot tag those. They must
+    ride every change set: omitting --tags on an update drops the stack's tags."""
+    text = ENGINE.read_text()
+    for key, value in (
+        ("Project", "cardinal"),
+        ("Application", "cardinal-lakerunner"),
+        ("ManagedBy", "cardinal-cfn"),
+    ):
+        assert f"Key={key},Value={value}" in text, f"STACK_TAGS missing {key}"
+    assert "--tags $STACK_TAGS" in text, "create-change-set does not pass --tags"
+
+
 def test_satellite_infra_base_takes_principal_directly():
     """The satellite trust principal arrives as a direct LAKERUNNER_PRINCIPAL env
     var, never mapped from the central lakerunner-infra-base stack -- a satellite

--- a/tests/unit/test_naming.py
+++ b/tests/unit/test_naming.py
@@ -1,17 +1,18 @@
 """Tests for the naming and tag conventions module."""
 
-import pytest
-
 from cardinal_cfn.naming import (
     APPLICATION,
+    MANAGED_BY_TAG,
     PROJECT,
     LakerunnerComponent,
-    cardinal_tags_v2,
+    cardinal_tags,
     log_group_name,
     name_tag,
     secret_name,
     ssm_param_name,
 )
+
+COMMON_TAG_KEYS = {"Name", "Project", "Application", "Component", "ManagedBy"}
 
 
 def _tag_dict(tags) -> dict[str, str]:
@@ -23,31 +24,26 @@ def test_constants():
     assert APPLICATION == "cardinal-lakerunner"
 
 
-def test_tags_carry_required_keys():
-    tags = cardinal_tags_v2(component="task-role", managed_by="cardinal-prereqs-script")
-    keys = set(_tag_dict(tags).keys())
-    assert {"Application", "Component", "ManagedBy", "Name"} <= keys
-
-
-def test_tags_values_match_inputs():
-    tags = _tag_dict(cardinal_tags_v2(component="ingest-bucket", managed_by="cardinal-data-setup-script"))
+def test_tags_carry_the_common_set():
+    tags = _tag_dict(cardinal_tags(component="ingest-bucket", managed_by="cardinal-cfn-satellite"))
+    assert set(tags) == COMMON_TAG_KEYS
+    assert tags["Project"] == PROJECT
     assert tags["Application"] == APPLICATION
     assert tags["Component"] == "ingest-bucket"
-    assert tags["ManagedBy"] == "cardinal-data-setup-script"
+    assert tags["ManagedBy"] == "cardinal-cfn-satellite"
     assert tags["Name"] == "cardinal-ingest-bucket"
 
 
-def test_tags_install_version_optional():
-    tags_without = _tag_dict(cardinal_tags_v2(component="x", managed_by="m"))
-    assert "cardinal:install-version" not in tags_without
-
-    tags_with = _tag_dict(cardinal_tags_v2(component="x", managed_by="m", install_version="v1.2.3"))
-    assert tags_with["cardinal:install-version"] == "v1.2.3"
+def test_managed_by_defaults_to_the_children_value():
+    tags = _tag_dict(cardinal_tags(component="compute"))
+    assert tags["ManagedBy"] == MANAGED_BY_TAG
 
 
-def test_managed_by_required():
-    with pytest.raises(ValueError):
-        cardinal_tags_v2(component="x", managed_by="")
+def test_role_puts_install_id_in_name_and_keeps_the_common_set():
+    tags = _tag_dict(cardinal_tags(component="compute", role="query-api"))
+    assert set(tags) == COMMON_TAG_KEYS
+    assert tags["Name"] == {"Fn::Sub": "cardinal-query-api-${InstallIdShort}"}
+    assert tags["Component"] == "compute"
 
 
 def test_name_tag_emits_plain_string_no_install_id():


### PR DESCRIPTION
One tag helper instead of three, and stack tags for what templates cannot tag.

- `naming.cardinal_tags()` is now the only tag builder: Name, Project, Application, Component, ManagedBy. The five root generators' copy-pasted `_tags()` bodies call it; the unused `cardinal_tags_v2()` is gone.
- Nested children previously emitted no `Application` tag — measured on a live install: 50 resources tagged Project=cardinal, only 29 tagged Application.
- Drivers pass `--tags` on every change set, so ALB listeners/rules, Cloud Map, and the IAM server certificate stop carrying only `aws:cloudformation:*`.
- New `tests/unit/test_common_tags.py` walks every generated template and fails any Tags list missing a key; lint test asserts the change set passes the stack tags.