### PR TITLE
ecs: propagate service tags to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.7.1
+
+**ECS tasks now inherit the service's tags.** Every ECS service sets
+`PropagateTags: SERVICE`, so the tasks it launches carry the same five tags.
+Fargate cost allocation bills against *task* tags, not service tags, and
+CloudFormation cannot tag a task directly — so before this the largest
+recurring line item in an install was untagged, and a deployer role that gates
+on resource tags saw untagged tasks.
+
+Upgrade action: redeploy the services and satellite-services stacks. Note that
+ECS applies tags only to tasks it launches *after* the change — verified: the
+stack update alters the service in place and leaves the running tasks alone,
+still untagged. To tag them without waiting for the next image bump, force a
+deployment per service once the stack settles:
+
+```sh
+aws ecs update-service --cluster <cluster> --service <name> --force-new-deployment
+```
+
+Do this inside the same window as any other tag work, since it is the task
+launch — not the stack update — that applies the tags.
+
+Two resource types remain untaggable and are not covered: security-group
+**rules** (`AWS::EC2::SecurityGroupIngress` has no `Tags` property; the
+security groups themselves are tagged) and Application Auto Scaling
+**scalable targets / scaling policies** (likewise no `Tags` property). Both
+are CloudFormation limitations, not omissions.
+
 ## v1.7.0
 
 **Consistent resource tagging.** Every Cardinal-created resource now carries

--- a/src/cardinal_cfn/children/maestro.py
+++ b/src/cardinal_cfn/children/maestro.py
@@ -712,6 +712,9 @@ def build() -> Template:
         Service(
             "MaestroService",
             Cluster=Ref("ClusterArn"),
+            # ECS copies these onto every task it launches; Fargate cost
+            # allocation bills against task tags, not service tags.
+            PropagateTags="SERVICE",
             # Singleton: pure on-demand FARGATE so its one task always places
             # during a rolling deploy; a transient FARGATE_SPOT shortage must
             # never block the task and trip the deploy circuit breaker.

--- a/src/cardinal_cfn/children/services_common.py
+++ b/src/cardinal_cfn/children/services_common.py
@@ -329,6 +329,10 @@ def build_ecs_service(
             ),
         ),
         Tags=cardinal_tags(component="compute", role=service_key),
+        # Fargate cost allocation bills against TASK tags, not service
+        # tags, and CFN cannot tag a task directly -- ECS copies the
+        # service's tags onto every task it launches only when set.
+        PropagateTags="SERVICE",
     )
 
     if target_group_ref is not None:

--- a/src/cardinal_cfn/satellite_services.py
+++ b/src/cardinal_cfn/satellite_services.py
@@ -650,6 +650,9 @@ def build() -> Template:
         Service(
             "CollectorService",
             Cluster=Ref("EcsClusterArn"),
+            # ECS copies these onto every task it launches; Fargate cost
+            # allocation bills against task tags, not service tags.
+            PropagateTags="SERVICE",
             # On-demand FARGATE only. The collector is the deploy-critical
             # ingest path, and ECS rolling deploys + the circuit breaker
             # require every new task to place. FARGATE_SPOT cannot guarantee

--- a/tests/unit/test_common_tags.py
+++ b/tests/unit/test_common_tags.py
@@ -61,3 +61,17 @@ COMPOSITION_ONLY = {"cardinal_cfn.lakerunner_services"}
 def test_templates_actually_tag_something(module_name):
     """Guards the walker itself: a bad shape would make the check vacuous."""
     assert list(_tagged_resources(module_name)), f"{module_name} tagged nothing"
+
+
+@pytest.mark.parametrize("module_name", GENERATORS)
+def test_ecs_services_propagate_tags_to_tasks(module_name):
+    """Fargate cost allocation bills against task tags. CFN cannot tag a task,
+    so a service without PropagateTags launches untagged billable resources."""
+    template = importlib.import_module(module_name).build().to_dict()
+    offenders = [
+        logical_id
+        for logical_id, resource in template.get("Resources", {}).items()
+        if resource["Type"] == "AWS::ECS::Service"
+        and resource.get("Properties", {}).get("PropagateTags") != "SERVICE"
+    ]
+    assert not offenders, f"{module_name} ECS services not propagating tags: {offenders}"


### PR DESCRIPTION
Fargate cost allocation bills against task tags, and CloudFormation cannot tag a task. Every ECS service now sets `PropagateTags: SERVICE`, so tasks inherit the service's five tags.

Verified on the us-east-2 install: after the stack update the service reports `propagateTags=SERVICE` but the *running* task stayed untagged — ECS only tags tasks it launches after the change. A forced deployment produced a task carrying all five tags. The changelog documents the force-new-deployment step rather than implying the stack update does it.

Remaining untaggable (CFN limitations, documented): security-group rules and Application Auto Scaling scalable targets/policies.