### PR TITLE
images: bump lakerunner to v1.79.1 and maestro to v1.93.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.7.3
+
+**Image bumps.** Default `LakerunnerImage` v1.79.0 → v1.79.1 and
+`MaestroImage` v1.93.0 → v1.93.1 (both digest-pinned).
+
+Upgrade action: redeploy the services stack. The `LakerunnerImage` change
+reruns the migrator before the service tiers update, as designed.
+
 ## v1.7.2
 
 **Image bumps.** Default `LakerunnerImage` v1.76.2 → v1.79.0 and

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -19,8 +19,8 @@ api_keys:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.79.0@sha256:d015bfb9361a5fdbbb381313a1ad16adc2ad469dbfa3a8377b19a11f53a977a0"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.93.0@sha256:3d40deb6a23aaa39a18bb038c599425eb9bb12a4447e61de127357564327893b"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.79.1@sha256:ccd3deeb2929d61202736cbe793be1fd00c8c99aed167bf12313a80528ebe6c4"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.93.1@sha256:4e16870c125c0096c2a3c3d92a0f5934b46e031dccff74cf09bcea87794f3138"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.10.0@sha256:ad9d6459d2d231a4ea0b709347587e4c3dc43eb82e169e915305d9ddae73540c"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.5.0@sha256:3fd7766b7a089948bfbe504ea4b23671b2257e2fed0247ac638c9902aca4aebd"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,8 +31,8 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.79.0@sha256:d015bfb9361a5fdbbb381313a1ad16adc2ad469dbfa3a8377b19a11f53a977a0"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.93.0@sha256:3d40deb6a23aaa39a18bb038c599425eb9bb12a4447e61de127357564327893b"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.79.1@sha256:ccd3deeb2929d61202736cbe793be1fd00c8c99aed167bf12313a80528ebe6c4"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.93.1@sha256:4e16870c125c0096c2a3c3d92a0f5934b46e031dccff74cf09bcea87794f3138"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.5.0@sha256:3fd7766b7a089948bfbe504ea4b23671b2257e2fed0247ac638c9902aca4aebd"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
Digest-pinned image bumps plus the v1.7.3 changelog entry.