### PR TITLE
bump images: lakerunner v1.81.0, maestro v1.94.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ install up to date, read every entry from the version you are on up to your
 target version and apply the noted upgrade actions. Earliest recorded version is
 v0.0.114.
 
+## v1.7.5
+
+**Image bumps.** Default `LakerunnerImage` v1.79.2 → v1.81.0 and
+`MaestroImage` v1.93.3 → v1.94.1 (both digest-pinned).
+
+Worth flagging on the lakerunner bump: DuckDB and direct parquet segment
+reading are gone (cardinalhq/lakerunner#1296, #1301, #1303) and the
+lkrn-native query engine is now the only query path (#1298). Query workers no
+longer carry the DuckDB runtime; no stack-side parameter or sizing change is
+required, but it is a large change under the query tier. Also included:
+structured-log filter execution in LogQL (#1297) and several alerting fixes —
+fingerprint incident lifecycle (#1300), exception rules firing on any step
+at/above `min_count` rather than every step (#1302), and notifier fallback for
+rules with no bound webhook actions (#1295).
+
+Upgrade action: redeploy the services stack. The `LakerunnerImage` change
+reruns the migrator before the service tiers update, as designed.
+
 ## v1.7.4
 
 **Image bumps.** Default `LakerunnerImage` v1.79.1 → v1.79.2 and

--- a/cardinal-defaults.yaml
+++ b/cardinal-defaults.yaml
@@ -19,8 +19,8 @@ api_keys:
 # so the two cannot drift; any change to LakerunnerImage retriggers migrations.
 # ---------------------------------------------------------------------------
 images:
-  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.79.2@sha256:dbad1019ab062f503dcccc1514098157bea5720db30e339d5f0de8b915ba84a8"
-  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.93.3@sha256:f26695a43e38d70fd36b7349fd5bac24970b14a3185b688eecec4b56320f3728"
+  lakerunner: "public.ecr.aws/cardinalhq.io/lakerunner:v1.81.0@sha256:ec07934e1fcd7e900bb308a9713660742d377e4da047ea7e95affb12f6707018"
+  maestro:    "public.ecr.aws/cardinalhq.io/maestro:v1.94.1@sha256:f28b1de681f26e23d174fa65b3a55152cd5c067db1215f89bf0ce9fbd2278edc"
   otel:       "public.ecr.aws/cardinalhq.io/cardinalhq-otel-collector:v1.10.0@sha256:ad9d6459d2d231a4ea0b709347587e4c3dc43eb82e169e915305d9ddae73540c"
   dex:        "public.ecr.aws/cardinalhq.io/dex-customization:v0.5.0@sha256:3fd7766b7a089948bfbe504ea4b23671b2257e2fed0247ac638c9902aca4aebd"
   db_init:    "public.ecr.aws/docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"

--- a/scripts/deploy-lakerunner-services.sh
+++ b/scripts/deploy-lakerunner-services.sh
@@ -31,8 +31,8 @@ DEFAULT_IMAGE_REGISTRY="public.ecr.aws"
 # (official postgres psql client) is baked too -- this stack is always on
 # public.ecr.aws -- so a redeploy always carries the pinned default;
 # DB_INIT_IMAGE remains a full-URI escape hatch.
-LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.79.2@sha256:dbad1019ab062f503dcccc1514098157bea5720db30e339d5f0de8b915ba84a8"
-MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.93.3@sha256:f26695a43e38d70fd36b7349fd5bac24970b14a3185b688eecec4b56320f3728"
+LAKERUNNER_IMAGE_SUFFIX="cardinalhq.io/lakerunner:v1.81.0@sha256:ec07934e1fcd7e900bb308a9713660742d377e4da047ea7e95affb12f6707018"
+MAESTRO_IMAGE_SUFFIX="cardinalhq.io/maestro:v1.94.1@sha256:f28b1de681f26e23d174fa65b3a55152cd5c067db1215f89bf0ce9fbd2278edc"
 DEX_IMAGE_SUFFIX="cardinalhq.io/dex-customization:v0.5.0@sha256:3fd7766b7a089948bfbe504ea4b23671b2257e2fed0247ac638c9902aca4aebd"
 DB_INIT_IMAGE_SUFFIX="docker/library/postgres:18-alpine@sha256:96d56f7f57c6aacd1fcb908bc83b345ec5f83231ee486dd66a1baadce274db88"
 


### PR DESCRIPTION
Defaults bumped to lakerunner v1.81.0 and maestro v1.94.1 (digest-pinned). Changelog entry added for v1.7.5.